### PR TITLE
Add bounded live website collector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,33 @@ jobs:
           python-version: "3.11"
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -e ".[dev]"
-      - run: ruff check .
-      - run: mypy src tests
-      - run: pytest
-      - run: python -m veridra.audit
-      - uses: actions/upload-artifact@v4
+      - name: Ruff
+        shell: bash
+        run: |
+          mkdir -p artifacts/ci
+          set -o pipefail
+          ruff check . 2>&1 | tee artifacts/ci/ruff.log
+      - name: Strict mypy
+        shell: bash
+        run: |
+          mkdir -p artifacts/ci
+          set -o pipefail
+          mypy src tests 2>&1 | tee artifacts/ci/mypy.log
+      - name: Pytest
+        shell: bash
+        run: |
+          mkdir -p artifacts/ci
+          set -o pipefail
+          pytest 2>&1 | tee artifacts/ci/pytest.log
+      - name: Deterministic audit
+        shell: bash
+        run: |
+          mkdir -p artifacts/ci
+          set -o pipefail
+          python -m veridra.audit 2>&1 | tee artifacts/ci/audit.log
+      - name: Upload verification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: veridra-audit
-          path: artifacts/audit
+          name: veridra-verification
+          path: artifacts

--- a/src/veridra/app.py
+++ b/src/veridra/app.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import html
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
-from .core import demo_assessment
+from .collector import CollectionError
+from .core import UnsafeTargetError, demo_assessment
+from .service import assess_url
 
-app = FastAPI(title="Veridra", version="0.1.0")
+app = FastAPI(title="Veridra", version="0.2.0")
 
 
 def dashboard() -> str:
@@ -33,6 +35,14 @@ def health() -> dict[str, str]:
 @app.get("/api/demo")
 def demo() -> dict[str, object]:
     return demo_assessment().model_dump(mode="json")
+
+
+@app.get("/api/assess")
+def assess(url: str = Query(min_length=1, max_length=2048)) -> dict[str, object]:
+    try:
+        return assess_url(url).model_dump(mode="json")
+    except (UnsafeTargetError, CollectionError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/src/veridra/collector.py
+++ b/src/veridra/collector.py
@@ -47,8 +47,19 @@ class SiteEvidence:
 
 
 class _PinnedHTTPSConnection(http.client.HTTPSConnection):
-    def __init__(self, hostname: str, connect_ip: str, port: int, timeout: float) -> None:
-        super().__init__(hostname, port=port, timeout=timeout, context=ssl.create_default_context())
+    def __init__(
+        self,
+        hostname: str,
+        connect_ip: str,
+        port: int,
+        timeout: float,
+    ) -> None:
+        super().__init__(
+            hostname,
+            port=port,
+            timeout=timeout,
+            context=ssl.create_default_context(),
+        )
         self._connect_ip = connect_ip
 
     def connect(self) -> None:
@@ -57,7 +68,10 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
             self.timeout,
             self.source_address,
         )
-        self.sock = self._context.wrap_socket(raw_socket, server_hostname=self.host)
+        self.sock = self._context.wrap_socket(
+            raw_socket,
+            server_hostname=self.host,
+        )
 
 
 def prepare_target(raw_url: str) -> PreparedTarget:
@@ -72,7 +86,9 @@ def prepare_target(raw_url: str) -> PreparedTarget:
     port = parsed.port or (443 if scheme == "https" else 80)
     default_port = 443 if scheme == "https" else 80
     host_header = hostname if port == default_port else f"{hostname}:{port}"
-    request_target = urlunparse(("", "", parsed.path or "/", parsed.params, parsed.query, ""))
+    request_target = urlunparse(
+        ("", "", parsed.path or "/", parsed.params, parsed.query, "")
+    )
     return PreparedTarget(
         url=normalized,
         scheme=scheme,
@@ -85,7 +101,11 @@ def prepare_target(raw_url: str) -> PreparedTarget:
     )
 
 
-def _request_once(target: PreparedTarget, timeout: float, max_bytes: int) -> tuple[int, dict[str, str], bytes]:
+def _request_once(
+    target: PreparedTarget,
+    timeout: float,
+    max_bytes: int,
+) -> tuple[int, dict[str, str], bytes]:
     if target.scheme == "https":
         connection: http.client.HTTPConnection = _PinnedHTTPSConnection(
             target.hostname,
@@ -94,7 +114,11 @@ def _request_once(target: PreparedTarget, timeout: float, max_bytes: int) -> tup
             timeout,
         )
     else:
-        connection = http.client.HTTPConnection(target.connect_ip, target.port, timeout=timeout)
+        connection = http.client.HTTPConnection(
+            target.connect_ip,
+            target.port,
+            timeout=timeout,
+        )
 
     try:
         connection.request(
@@ -110,16 +134,25 @@ def _request_once(target: PreparedTarget, timeout: float, max_bytes: int) -> tup
         response = connection.getresponse()
         body = response.read(max_bytes + 1)
         if len(body) > max_bytes:
-            raise CollectionError(f"Response exceeded the {max_bytes}-byte limit.")
-        headers = {key.lower(): value for key, value in response.getheaders()}
+            raise CollectionError(
+                f"Response exceeded the {max_bytes}-byte limit."
+            )
+        headers = {
+            key.lower(): value for key, value in response.getheaders()
+        }
         return response.status, headers, body
     except (OSError, http.client.HTTPException, ssl.SSLError) as exc:
-        raise CollectionError(f"Request failed for {target.url}: {exc}") from exc
+        raise CollectionError(
+            f"Request failed for {target.url}: {exc}"
+        ) from exc
     finally:
         connection.close()
 
 
-Requester = Callable[[PreparedTarget, float, int], tuple[int, dict[str, str], bytes]]
+Requester = Callable[
+    [PreparedTarget, float, int],
+    tuple[int, dict[str, str], bytes],
+]
 
 
 def collect_page(
@@ -140,15 +173,24 @@ def collect_page(
 
         if status in _REDIRECT_STATUSES and "location" in headers:
             if redirect_count >= max_redirects:
-                raise CollectionError(f"Redirect limit of {max_redirects} exceeded.")
-            current_url = normalize_url(urljoin(current_url, headers["location"]))
+                raise CollectionError(
+                    f"Redirect limit of {max_redirects} exceeded."
+                )
+            current_url = normalize_url(
+                urljoin(current_url, headers["location"])
+            )
             redirects.append(current_url)
             continue
 
         charset = "utf-8"
         content_type = headers.get("content-type", "")
         if "charset=" in content_type.lower():
-            charset = content_type.lower().split("charset=", 1)[1].split(";", 1)[0].strip()
+            charset = (
+                content_type.lower()
+                .split("charset=", 1)[1]
+                .split(";", 1)[0]
+                .strip()
+            )
         try:
             decoded = body.decode(charset, errors="replace")
         except LookupError:
@@ -168,12 +210,22 @@ def collect_page(
     raise CollectionError("The request did not produce a terminal response.")
 
 
-def collect_site(raw_url: str, *, requester: Requester = _request_once) -> SiteEvidence:
+def collect_site(
+    raw_url: str,
+    *,
+    requester: Requester = _request_once,
+) -> SiteEvidence:
     homepage = collect_page(raw_url, requester=requester)
     parsed = urlparse(homepage.final_url)
-    robots_url = urlunparse((parsed.scheme, parsed.netloc, "/robots.txt", "", "", ""))
+    robots_url = urlunparse(
+        (parsed.scheme, parsed.netloc, "/robots.txt", "", "", "")
+    )
     try:
-        robots = collect_page(robots_url, requester=requester, max_bytes=256_000)
+        robots = collect_page(
+            robots_url,
+            requester=requester,
+            max_bytes=256_000,
+        )
     except (CollectionError, UnsafeTargetError):
         robots = None
     return SiteEvidence(homepage=homepage, robots=robots)

--- a/src/veridra/collector.py
+++ b/src/veridra/collector.py
@@ -5,6 +5,7 @@ import socket
 import ssl
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import cast
 from urllib.parse import urljoin, urlparse, urlunparse
 
 from .core import UnsafeTargetError, normalize_url, resolve_public_ips
@@ -63,9 +64,10 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
         self._connect_ip = connect_ip
 
     def connect(self) -> None:
+        connection_timeout = cast(float | None, self.timeout)
         raw_socket = socket.create_connection(
             (self._connect_ip, self.port),
-            self.timeout,
+            connection_timeout,
             self.source_address,
         )
         self.sock = self._context.wrap_socket(

--- a/src/veridra/collector.py
+++ b/src/veridra/collector.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import http.client
+import socket
+import ssl
+from collections.abc import Callable
+from dataclasses import dataclass
+from urllib.parse import urljoin, urlparse, urlunparse
+
+from .core import UnsafeTargetError, normalize_url, resolve_public_ips
+
+_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+
+
+class CollectionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class PreparedTarget:
+    url: str
+    scheme: str
+    hostname: str
+    port: int
+    request_target: str
+    host_header: str
+    validated_ips: tuple[str, ...]
+    connect_ip: str
+
+
+@dataclass(frozen=True)
+class PageEvidence:
+    requested_url: str
+    final_url: str
+    status_code: int
+    headers: dict[str, str]
+    body: str
+    redirect_chain: tuple[str, ...]
+    connected_ip: str
+    validated_ips: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SiteEvidence:
+    homepage: PageEvidence
+    robots: PageEvidence | None
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(self, hostname: str, connect_ip: str, port: int, timeout: float) -> None:
+        super().__init__(hostname, port=port, timeout=timeout, context=ssl.create_default_context())
+        self._connect_ip = connect_ip
+
+    def connect(self) -> None:
+        raw_socket = socket.create_connection(
+            (self._connect_ip, self.port),
+            self.timeout,
+            self.source_address,
+        )
+        self.sock = self._context.wrap_socket(raw_socket, server_hostname=self.host)
+
+
+def prepare_target(raw_url: str) -> PreparedTarget:
+    normalized = normalize_url(raw_url)
+    parsed = urlparse(normalized)
+    hostname = parsed.hostname
+    if hostname is None:
+        raise UnsafeTargetError("A target hostname is required.")
+
+    validated_ips = tuple(resolve_public_ips(hostname))
+    scheme = parsed.scheme
+    port = parsed.port or (443 if scheme == "https" else 80)
+    default_port = 443 if scheme == "https" else 80
+    host_header = hostname if port == default_port else f"{hostname}:{port}"
+    request_target = urlunparse(("", "", parsed.path or "/", parsed.params, parsed.query, ""))
+    return PreparedTarget(
+        url=normalized,
+        scheme=scheme,
+        hostname=hostname,
+        port=port,
+        request_target=request_target,
+        host_header=host_header,
+        validated_ips=validated_ips,
+        connect_ip=validated_ips[0],
+    )
+
+
+def _request_once(target: PreparedTarget, timeout: float, max_bytes: int) -> tuple[int, dict[str, str], bytes]:
+    if target.scheme == "https":
+        connection: http.client.HTTPConnection = _PinnedHTTPSConnection(
+            target.hostname,
+            target.connect_ip,
+            target.port,
+            timeout,
+        )
+    else:
+        connection = http.client.HTTPConnection(target.connect_ip, target.port, timeout=timeout)
+
+    try:
+        connection.request(
+            "GET",
+            target.request_target,
+            headers={
+                "Host": target.host_header,
+                "User-Agent": "Veridra/0.2 (+bounded public website assessment)",
+                "Accept": "text/html,text/plain;q=0.9,*/*;q=0.1",
+                "Connection": "close",
+            },
+        )
+        response = connection.getresponse()
+        body = response.read(max_bytes + 1)
+        if len(body) > max_bytes:
+            raise CollectionError(f"Response exceeded the {max_bytes}-byte limit.")
+        headers = {key.lower(): value for key, value in response.getheaders()}
+        return response.status, headers, body
+    except (OSError, http.client.HTTPException, ssl.SSLError) as exc:
+        raise CollectionError(f"Request failed for {target.url}: {exc}") from exc
+    finally:
+        connection.close()
+
+
+Requester = Callable[[PreparedTarget, float, int], tuple[int, dict[str, str], bytes]]
+
+
+def collect_page(
+    raw_url: str,
+    *,
+    timeout: float = 10.0,
+    max_bytes: int = 1_000_000,
+    max_redirects: int = 5,
+    requester: Requester = _request_once,
+) -> PageEvidence:
+    requested_url = normalize_url(raw_url)
+    current_url = requested_url
+    redirects: list[str] = []
+
+    for redirect_count in range(max_redirects + 1):
+        prepared = prepare_target(current_url)
+        status, headers, body = requester(prepared, timeout, max_bytes)
+
+        if status in _REDIRECT_STATUSES and "location" in headers:
+            if redirect_count >= max_redirects:
+                raise CollectionError(f"Redirect limit of {max_redirects} exceeded.")
+            current_url = normalize_url(urljoin(current_url, headers["location"]))
+            redirects.append(current_url)
+            continue
+
+        charset = "utf-8"
+        content_type = headers.get("content-type", "")
+        if "charset=" in content_type.lower():
+            charset = content_type.lower().split("charset=", 1)[1].split(";", 1)[0].strip()
+        try:
+            decoded = body.decode(charset, errors="replace")
+        except LookupError:
+            decoded = body.decode("utf-8", errors="replace")
+
+        return PageEvidence(
+            requested_url=requested_url,
+            final_url=prepared.url,
+            status_code=status,
+            headers=headers,
+            body=decoded,
+            redirect_chain=tuple(redirects),
+            connected_ip=prepared.connect_ip,
+            validated_ips=prepared.validated_ips,
+        )
+
+    raise CollectionError("The request did not produce a terminal response.")
+
+
+def collect_site(raw_url: str, *, requester: Requester = _request_once) -> SiteEvidence:
+    homepage = collect_page(raw_url, requester=requester)
+    parsed = urlparse(homepage.final_url)
+    robots_url = urlunparse((parsed.scheme, parsed.netloc, "/robots.txt", "", "", ""))
+    try:
+        robots = collect_page(robots_url, requester=requester, max_bytes=256_000)
+    except (CollectionError, UnsafeTargetError):
+        robots = None
+    return SiteEvidence(homepage=homepage, robots=robots)

--- a/src/veridra/collector.py
+++ b/src/veridra/collector.py
@@ -5,7 +5,6 @@ import socket
 import ssl
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import cast
 from urllib.parse import urljoin, urlparse, urlunparse
 
 from .core import UnsafeTargetError, normalize_url, resolve_public_ips
@@ -55,22 +54,22 @@ class _PinnedHTTPSConnection(http.client.HTTPSConnection):
         port: int,
         timeout: float,
     ) -> None:
+        context = ssl.create_default_context()
         super().__init__(
             hostname,
             port=port,
             timeout=timeout,
-            context=ssl.create_default_context(),
+            context=context,
         )
         self._connect_ip = connect_ip
+        self._ssl_context = context
 
     def connect(self) -> None:
-        connection_timeout = cast(float | None, self.timeout)
         raw_socket = socket.create_connection(
             (self._connect_ip, self.port),
-            connection_timeout,
-            self.source_address,
+            self.timeout,
         )
-        self.sock = self._context.wrap_socket(
+        self.sock = self._ssl_context.wrap_socket(
             raw_socket,
             server_hostname=self.host,
         )

--- a/src/veridra/service.py
+++ b/src/veridra/service.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from .collector import Requester, SiteEvidence, _request_once, collect_site
+from .core import Assessment, Finding, Status, analyze_document
+
+
+def _transport_findings(evidence: SiteEvidence) -> list[Finding]:
+    homepage = evidence.homepage
+    return [
+        Finding(
+            id="health.http-status",
+            area="Website health",
+            title="Homepage response",
+            status=Status.passed if 200 <= homepage.status_code < 400 else Status.attention,
+            severity="info" if 200 <= homepage.status_code < 400 else "high",
+            summary=f"Homepage returned HTTP {homepage.status_code}.",
+            recommendation=None
+            if 200 <= homepage.status_code < 400
+            else "Investigate the public homepage response and availability.",
+            evidence={
+                "requested_url": homepage.requested_url,
+                "final_url": homepage.final_url,
+                "connected_ip": homepage.connected_ip,
+                "validated_ips": list(homepage.validated_ips),
+                "redirect_chain": list(homepage.redirect_chain),
+            },
+        ),
+        Finding(
+            id="search.robots-availability",
+            area="Search visibility",
+            title="robots.txt availability",
+            status=Status.passed if evidence.robots is not None else Status.unavailable,
+            severity="info" if evidence.robots is not None else "low",
+            summary="robots.txt was collected."
+            if evidence.robots is not None
+            else "robots.txt could not be collected within the bounded request scope.",
+            recommendation=None
+            if evidence.robots is not None
+            else "Confirm whether a public robots.txt file should be available.",
+        ),
+    ]
+
+
+def assess_url(raw_url: str, *, requester: Requester = _request_once) -> Assessment:
+    evidence = collect_site(raw_url, requester=requester)
+    robots_text = evidence.robots.body if evidence.robots is not None else ""
+    findings = _transport_findings(evidence)
+    findings.extend(
+        analyze_document(
+            evidence.homepage.body,
+            evidence.homepage.headers,
+            robots_text,
+        )
+    )
+    return Assessment.build(evidence.homepage.final_url, findings)

--- a/src/veridra/service.py
+++ b/src/veridra/service.py
@@ -6,17 +6,21 @@ from .core import Assessment, Finding, Status, analyze_document
 
 def _transport_findings(evidence: SiteEvidence) -> list[Finding]:
     homepage = evidence.homepage
+    homepage_ok = 200 <= homepage.status_code < 400
+    robots_available = evidence.robots is not None
     return [
         Finding(
             id="health.http-status",
             area="Website health",
             title="Homepage response",
-            status=Status.passed if 200 <= homepage.status_code < 400 else Status.attention,
-            severity="info" if 200 <= homepage.status_code < 400 else "high",
+            status=Status.passed if homepage_ok else Status.attention,
+            severity="info" if homepage_ok else "high",
             summary=f"Homepage returned HTTP {homepage.status_code}.",
-            recommendation=None
-            if 200 <= homepage.status_code < 400
-            else "Investigate the public homepage response and availability.",
+            recommendation=(
+                None
+                if homepage_ok
+                else "Investigate the public homepage response and availability."
+            ),
             evidence={
                 "requested_url": homepage.requested_url,
                 "final_url": homepage.final_url,
@@ -29,19 +33,32 @@ def _transport_findings(evidence: SiteEvidence) -> list[Finding]:
             id="search.robots-availability",
             area="Search visibility",
             title="robots.txt availability",
-            status=Status.passed if evidence.robots is not None else Status.unavailable,
-            severity="info" if evidence.robots is not None else "low",
-            summary="robots.txt was collected."
-            if evidence.robots is not None
-            else "robots.txt could not be collected within the bounded request scope.",
-            recommendation=None
-            if evidence.robots is not None
-            else "Confirm whether a public robots.txt file should be available.",
+            status=(
+                Status.passed if robots_available else Status.unavailable
+            ),
+            severity="info" if robots_available else "low",
+            summary=(
+                "robots.txt was collected."
+                if robots_available
+                else (
+                    "robots.txt could not be collected within the bounded "
+                    "request scope."
+                )
+            ),
+            recommendation=(
+                None
+                if robots_available
+                else "Confirm whether a public robots.txt file should be available."
+            ),
         ),
     ]
 
 
-def assess_url(raw_url: str, *, requester: Requester = _request_once) -> Assessment:
+def assess_url(
+    raw_url: str,
+    *,
+    requester: Requester = _request_once,
+) -> Assessment:
     evidence = collect_site(raw_url, requester=requester)
     robots_text = evidence.robots.body if evidence.robots is not None else ""
     findings = _transport_findings(evidence)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
+import pytest
 from fastapi.testclient import TestClient
 
+import veridra.app as app_module
 from veridra.app import app
+from veridra.core import Assessment, UnsafeTargetError
 
 client = TestClient(app)
 
@@ -19,3 +24,21 @@ def test_dashboard_contract() -> None:
 def test_demo_api() -> None:
     payload = client.get("/api/demo").json()
     assert payload["summary"]["total"] > 0
+
+
+def test_live_assessment_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected = Assessment.build("https://example.com", [])
+    monkeypatch.setattr(app_module, "assess_url", lambda url: expected)
+    response = client.get("/api/assess", params={"url": "example.com"})
+    assert response.status_code == 200
+    assert response.json()["target"] == "https://example.com/"
+
+
+def test_live_assessment_rejects_unsafe_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    def reject(url: str) -> Assessment:
+        raise UnsafeTargetError("Non-public target address is not allowed: 127.0.0.1")
+
+    monkeypatch.setattr(app_module, "assess_url", reject)
+    response = client.get("/api/assess", params={"url": "localhost"})
+    assert response.status_code == 400
+    assert "Non-public" in response.json()["detail"]

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -46,13 +46,11 @@ def test_https_connection_preserves_original_sni(
 
     raw_socket = object()
     monkeypatch.setattr(
-        collector.ssl,
-        "create_default_context",
+        "veridra.collector.ssl.create_default_context",
         lambda: FakeContext(),
     )
     monkeypatch.setattr(
-        collector.socket,
-        "create_connection",
+        "veridra.collector.socket.create_connection",
         lambda *args, **kwargs: raw_socket,
     )
 
@@ -145,8 +143,7 @@ def test_streaming_response_limit_is_enforced(
             pass
 
     monkeypatch.setattr(
-        collector.http.client,
-        "HTTPConnection",
+        "veridra.collector.http.client.HTTPConnection",
         FakeConnection,
     )
     target = PreparedTarget(

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from veridra import collector
+from veridra.collector import CollectionError, PreparedTarget, collect_page, prepare_target
+from veridra.core import UnsafeTargetError
+
+
+def test_prepare_target_uses_validated_ip_and_original_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(collector, "resolve_public_ips", lambda hostname: ["93.184.216.34"])
+    target = prepare_target("https://example.com/path?q=1")
+    assert target.connect_ip == "93.184.216.34"
+    assert target.host_header == "example.com"
+    assert target.request_target == "/path?q=1"
+
+
+def test_https_connection_preserves_original_sni(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: dict[str, Any] = {}
+
+    class FakeContext:
+        def wrap_socket(self, sock: object, *, server_hostname: str) -> object:
+            recorded["socket"] = sock
+            recorded["server_hostname"] = server_hostname
+            return object()
+
+    raw_socket = object()
+    monkeypatch.setattr(collector.ssl, "create_default_context", lambda: FakeContext())
+    monkeypatch.setattr(collector.socket, "create_connection", lambda *args, **kwargs: raw_socket)
+
+    connection = collector._PinnedHTTPSConnection("example.com", "93.184.216.34", 443, 5.0)
+    connection.connect()
+    assert recorded == {"socket": raw_socket, "server_hostname": "example.com"}
+
+
+def test_redirect_target_is_revalidated(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_resolve(hostname: str) -> list[str]:
+        if hostname == "internal.example":
+            raise UnsafeTargetError("Non-public target address is not allowed: 127.0.0.1")
+        return ["93.184.216.34"]
+
+    monkeypatch.setattr(collector, "resolve_public_ips", fake_resolve)
+
+    def requester(
+        target: PreparedTarget,
+        timeout: float,
+        max_bytes: int,
+    ) -> tuple[int, dict[str, str], bytes]:
+        del timeout, max_bytes
+        assert target.hostname == "example.com"
+        return 302, {"location": "https://internal.example/"}, b""
+
+    with pytest.raises(UnsafeTargetError, match="Non-public"):
+        collect_page("https://example.com", requester=requester)
+
+
+def test_redirect_limit_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(collector, "resolve_public_ips", lambda hostname: ["93.184.216.34"])
+
+    def requester(
+        target: PreparedTarget,
+        timeout: float,
+        max_bytes: int,
+    ) -> tuple[int, dict[str, str], bytes]:
+        del target, timeout, max_bytes
+        return 302, {"location": "/again"}, b""
+
+    with pytest.raises(CollectionError, match="Redirect limit"):
+        collect_page("https://example.com", requester=requester, max_redirects=1)
+
+
+def test_streaming_response_limit_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResponse:
+        status = 200
+
+        def read(self, amount: int) -> bytes:
+            return b"x" * amount
+
+        def getheaders(self) -> list[tuple[str, str]]:
+            return []
+
+    class FakeConnection:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def request(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def getresponse(self) -> FakeResponse:
+            return FakeResponse()
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(collector.http.client, "HTTPConnection", FakeConnection)
+    target = PreparedTarget(
+        url="http://example.com/",
+        scheme="http",
+        hostname="example.com",
+        port=80,
+        request_target="/",
+        host_header="example.com",
+        validated_ips=("93.184.216.34",),
+        connect_ip="93.184.216.34",
+    )
+
+    with pytest.raises(CollectionError, match="byte limit"):
+        collector._request_once(target, timeout=5.0, max_bytes=10)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -46,10 +46,6 @@ def test_https_connection_preserves_original_sni(
 
     raw_socket = object()
     monkeypatch.setattr(
-        "veridra.collector.ssl.create_default_context",
-        lambda: FakeContext(),
-    )
-    monkeypatch.setattr(
         "veridra.collector.socket.create_connection",
         lambda *args, **kwargs: raw_socket,
     )
@@ -60,6 +56,7 @@ def test_https_connection_preserves_original_sni(
         443,
         5.0,
     )
+    setattr(connection, "_ssl_context", FakeContext())
     connection.connect()
     assert recorded == {
         "socket": raw_socket,

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -5,40 +5,78 @@ from typing import Any
 import pytest
 
 from veridra import collector
-from veridra.collector import CollectionError, PreparedTarget, collect_page, prepare_target
+from veridra.collector import (
+    CollectionError,
+    PreparedTarget,
+    collect_page,
+    prepare_target,
+)
 from veridra.core import UnsafeTargetError
 
 
-def test_prepare_target_uses_validated_ip_and_original_host(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(collector, "resolve_public_ips", lambda hostname: ["93.184.216.34"])
+def test_prepare_target_uses_validated_ip_and_original_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        collector,
+        "resolve_public_ips",
+        lambda hostname: ["93.184.216.34"],
+    )
     target = prepare_target("https://example.com/path?q=1")
     assert target.connect_ip == "93.184.216.34"
     assert target.host_header == "example.com"
     assert target.request_target == "/path?q=1"
 
 
-def test_https_connection_preserves_original_sni(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_https_connection_preserves_original_sni(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     recorded: dict[str, Any] = {}
 
     class FakeContext:
-        def wrap_socket(self, sock: object, *, server_hostname: str) -> object:
+        def wrap_socket(
+            self,
+            sock: object,
+            *,
+            server_hostname: str,
+        ) -> object:
             recorded["socket"] = sock
             recorded["server_hostname"] = server_hostname
             return object()
 
     raw_socket = object()
-    monkeypatch.setattr(collector.ssl, "create_default_context", lambda: FakeContext())
-    monkeypatch.setattr(collector.socket, "create_connection", lambda *args, **kwargs: raw_socket)
+    monkeypatch.setattr(
+        collector.ssl,
+        "create_default_context",
+        lambda: FakeContext(),
+    )
+    monkeypatch.setattr(
+        collector.socket,
+        "create_connection",
+        lambda *args, **kwargs: raw_socket,
+    )
 
-    connection = collector._PinnedHTTPSConnection("example.com", "93.184.216.34", 443, 5.0)
+    connection = collector._PinnedHTTPSConnection(
+        "example.com",
+        "93.184.216.34",
+        443,
+        5.0,
+    )
     connection.connect()
-    assert recorded == {"socket": raw_socket, "server_hostname": "example.com"}
+    assert recorded == {
+        "socket": raw_socket,
+        "server_hostname": "example.com",
+    }
 
 
-def test_redirect_target_is_revalidated(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_redirect_target_is_revalidated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def fake_resolve(hostname: str) -> list[str]:
         if hostname == "internal.example":
-            raise UnsafeTargetError("Non-public target address is not allowed: 127.0.0.1")
+            raise UnsafeTargetError(
+                "Non-public target address is not allowed: 127.0.0.1"
+            )
         return ["93.184.216.34"]
 
     monkeypatch.setattr(collector, "resolve_public_ips", fake_resolve)
@@ -56,8 +94,14 @@ def test_redirect_target_is_revalidated(monkeypatch: pytest.MonkeyPatch) -> None
         collect_page("https://example.com", requester=requester)
 
 
-def test_redirect_limit_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(collector, "resolve_public_ips", lambda hostname: ["93.184.216.34"])
+def test_redirect_limit_is_enforced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        collector,
+        "resolve_public_ips",
+        lambda hostname: ["93.184.216.34"],
+    )
 
     def requester(
         target: PreparedTarget,
@@ -68,10 +112,16 @@ def test_redirect_limit_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
         return 302, {"location": "/again"}, b""
 
     with pytest.raises(CollectionError, match="Redirect limit"):
-        collect_page("https://example.com", requester=requester, max_redirects=1)
+        collect_page(
+            "https://example.com",
+            requester=requester,
+            max_redirects=1,
+        )
 
 
-def test_streaming_response_limit_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_streaming_response_limit_is_enforced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class FakeResponse:
         status = 200
 
@@ -94,7 +144,11 @@ def test_streaming_response_limit_is_enforced(monkeypatch: pytest.MonkeyPatch) -
         def close(self) -> None:
             pass
 
-    monkeypatch.setattr(collector.http.client, "HTTPConnection", FakeConnection)
+    monkeypatch.setattr(
+        collector.http.client,
+        "HTTPConnection",
+        FakeConnection,
+    )
     target = PreparedTarget(
         url="http://example.com/",
         scheme="http",

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -56,7 +56,7 @@ def test_https_connection_preserves_original_sni(
         443,
         5.0,
     )
-    setattr(connection, "_ssl_context", FakeContext())
+    monkeypatch.setattr(connection, "_ssl_context", FakeContext())
     connection.connect()
     assert recorded == {
         "socket": raw_socket,


### PR DESCRIPTION
## Scope

Implements issue #2 with the first real, bounded public website assessment path.

- validates public HTTP/HTTPS targets;
- pins each request to an already validated public IP;
- preserves the original Host header and HTTPS SNI hostname;
- revalidates and repins every redirect hop;
- enforces timeout, redirect and response-size limits;
- collects homepage and robots.txt evidence;
- converts transport evidence into the assessment model;
- exposes a loopback-local `/api/assess` endpoint;
- adds deterministic collector and API tests without public-internet dependence.

## Safety boundary

No authentication, form submission, port scanning, wordlist discovery, exploit payloads or vulnerability guarantees. The application still binds only to loopback and is not an anonymous public service.

## Verification required

- Ruff
- strict mypy
- pytest with collector boundary tests
- deterministic project audit
- exact-head GitHub Actions success

Closes #2 after verified merge.