### PR TITLE
Add live assessment workflow and printable report

### DIFF
--- a/src/veridra/app.py
+++ b/src/veridra/app.py
@@ -1,30 +1,43 @@
 from __future__ import annotations
 
 import html
+from urllib.parse import urlencode
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
 from .collector import CollectionError
-from .core import UnsafeTargetError, demo_assessment
+from .core import Assessment, UnsafeTargetError, demo_assessment
+from .reports import render_report
 from .service import assess_url
 
-app = FastAPI(title="Veridra", version="0.2.0")
+app = FastAPI(title="Veridra", version="0.3.0")
 
 
-def dashboard() -> str:
-    assessment = demo_assessment()
+def dashboard(
+    assessment: Assessment,
+    *,
+    submitted_url: str = "",
+    error: str | None = None,
+    demo_mode: bool = False,
+) -> str:
     cards = "".join(
-        f"<article><span>{key.title()}</span><strong>{value}</strong></article>"
+        f"<article><span>{html.escape(key.title())}</span><strong>{value}</strong></article>"
         for key, value in assessment.summary.items()
     )
     rows = "".join(
-        f"<tr><td><span class='pill {item.status}'>{item.status}</span></td><td>{html.escape(item.area)}</td><td><strong>{html.escape(item.title)}</strong></td><td>{html.escape(item.summary)}</td><td>{html.escape(item.recommendation or 'No action required.')}</td></tr>"
+        f"<tr><td><span class='pill {item.status}'>{html.escape(item.status.value)}</span></td><td>{html.escape(item.area)}</td><td><strong>{html.escape(item.title)}</strong></td><td>{html.escape(item.summary)}</td><td>{html.escape(item.recommendation or 'No action required.')}</td></tr>"
         for item in assessment.findings
     )
+    escaped_url = html.escape(submitted_url, quote=True)
+    error_panel = (
+        f"<div class='error' role='alert'>{html.escape(error)}</div>" if error else ""
+    )
+    report_query = urlencode({"demo": "true"}) if demo_mode else urlencode({"url": submitted_url})
+    report_link = f"/report?{report_query}"
     return f"""<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>Veridra</title><style>
-*{{box-sizing:border-box}}body{{margin:0;font:14px Arial,sans-serif;background:#f7f8fa;color:#17191c}}aside{{position:fixed;inset:0 auto 0 0;width:230px;background:#f1f3f6;padding:28px 18px;border-right:1px solid #e0e3e8}}aside h1{{margin:0 0 36px;font-size:24px}}nav a{{display:block;padding:12px;border-radius:8px;color:#333;text-decoration:none;margin:4px 0}}nav a.active{{background:#dde1e6;font-weight:700}}main{{margin-left:230px;padding:42px;max-width:1600px}}header{{display:flex;justify-content:space-between;align-items:start;border-bottom:1px solid #e2e5e9;padding-bottom:24px}}h2{{font-size:28px;margin:0}}.muted{{color:#6c737d}}.cards{{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin:24px 0}}article{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:18px}}article span{{display:block;color:#6c737d;text-transform:uppercase;font-size:12px}}article strong{{display:block;font-size:28px;margin-top:10px}}section{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:20px}}table{{width:100%;border-collapse:collapse}}th,td{{text-align:left;padding:13px;border-bottom:1px solid #e8eaed;vertical-align:top}}th{{font-size:11px;text-transform:uppercase;color:#69717b}}.pill{{display:inline-block;padding:4px 8px;border-radius:999px;border:1px solid}}.passed{{color:#16794a;background:#f0faf5}}.attention{{color:#946200;background:#fff9e8}}@media(max-width:800px){{aside{{position:static;width:auto}}main{{margin:0;padding:20px}}.cards{{grid-template-columns:repeat(2,1fr)}}table{{display:block;overflow:auto}}}}
-</style></head><body><aside><h1>Veridra</h1><nav><a class='active'>Overview</a><a>Website health</a><a>Search visibility</a><a>AI discoverability</a><a>Trust signals</a><a>Security posture</a><a>Reports</a></nav></aside><main><header><div><h2>Website assessment</h2><p class='muted'>Visibility, trust and public security evidence.</p></div><button>Run assessment</button></header><div class='cards'>{cards}</div><section><h3>Evidence-backed findings</h3><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th></tr></thead><tbody>{rows}</tbody></table><p class='muted'>Scope: bounded public checks only. This is not a penetration test.</p></section></main></body></html>"""
+*{{box-sizing:border-box}}body{{margin:0;font:14px Arial,sans-serif;background:#f7f8fa;color:#17191c}}aside{{position:fixed;inset:0 auto 0 0;width:230px;background:#f1f3f6;padding:28px 18px;border-right:1px solid #e0e3e8}}aside h1{{margin:0 0 36px;font-size:24px}}nav a{{display:block;padding:12px;border-radius:8px;color:#333;text-decoration:none;margin:4px 0}}nav a.active{{background:#dde1e6;font-weight:700}}main{{margin-left:230px;padding:42px;max-width:1600px}}header{{display:flex;justify-content:space-between;gap:24px;align-items:start;border-bottom:1px solid #e2e5e9;padding-bottom:24px}}h2{{font-size:28px;margin:0}}.muted{{color:#6c737d}}form{{display:flex;gap:8px;min-width:min(520px,100%)}}input{{flex:1;min-width:220px;padding:11px;border:1px solid #cfd4da;border-radius:7px}}button,.button{{border:0;border-radius:7px;background:#22272d;color:white;padding:11px 16px;text-decoration:none;cursor:pointer}}.actions{{display:flex;gap:8px;align-items:center}}.cards{{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin:24px 0}}article{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:18px}}article span{{display:block;color:#6c737d;text-transform:uppercase;font-size:12px}}article strong{{display:block;font-size:28px;margin-top:10px}}section{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:20px}}table{{width:100%;border-collapse:collapse}}th,td{{text-align:left;padding:13px;border-bottom:1px solid #e8eaed;vertical-align:top}}th{{font-size:11px;text-transform:uppercase;color:#69717b}}.pill{{display:inline-block;padding:4px 8px;border-radius:999px;border:1px solid}}.passed{{color:#16794a;background:#f0faf5}}.attention{{color:#946200;background:#fff9e8}}.unavailable{{color:#5f6873;background:#f3f4f6}}.error{{margin-top:18px;padding:13px;border-left:3px solid #b42318;background:#fff1f0;color:#7a271a}}@media(max-width:1000px){{header{{display:block}}form{{margin-top:18px}}}}@media(max-width:800px){{aside{{position:static;width:auto}}main{{margin:0;padding:20px}}.cards{{grid-template-columns:repeat(2,1fr)}}table{{display:block;overflow:auto}}form{{display:block}}input{{width:100%;margin-bottom:8px}}}}
+</style></head><body><aside><h1>Veridra</h1><nav><a class='active'>Overview</a><a>Website health</a><a>Search visibility</a><a>AI discoverability</a><a>Trust signals</a><a>Security posture</a><a href='{html.escape(report_link, quote=True)}'>Reports</a></nav></aside><main><header><div><h2>Website assessment</h2><p class='muted'>Visibility, trust and public security evidence.</p></div><div><form method='get' action='/'><label class='muted' for='url'>Public website</label><input id='url' name='url' type='text' maxlength='2048' placeholder='example.com' value='{escaped_url}' required><div class='actions'><button type='submit'>Run assessment</button><a class='button' href='{html.escape(report_link, quote=True)}'>Open report</a></div></form></div></header>{error_panel}<div class='cards'>{cards}</div><section><h3>Evidence-backed findings</h3><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th></tr></thead><tbody>{rows}</tbody></table><p class='muted'>Scope: bounded public checks only. This is not a penetration test.</p></section></main></body></html>"""
 
 
 @app.get("/health")
@@ -45,9 +58,37 @@ def assess(url: str = Query(min_length=1, max_length=2048)) -> dict[str, object]
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+@app.get("/report", response_class=HTMLResponse)
+def report(
+    url: str | None = Query(default=None, min_length=1, max_length=2048),
+    demo: bool = False,
+) -> str:
+    if demo:
+        return render_report(demo_assessment())
+    if url is None:
+        raise HTTPException(status_code=400, detail="A target URL is required.")
+    try:
+        return render_report(assess_url(url))
+    except (UnsafeTargetError, CollectionError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
 @app.get("/", response_class=HTMLResponse)
-def index() -> str:
-    return dashboard()
+def index(
+    url: str | None = Query(default=None, min_length=1, max_length=2048),
+) -> str:
+    if url is None:
+        return dashboard(demo_assessment(), demo_mode=True)
+    try:
+        assessment = assess_url(url)
+        return dashboard(assessment, submitted_url=url)
+    except (UnsafeTargetError, CollectionError) as exc:
+        return dashboard(
+            demo_assessment(),
+            submitted_url=url,
+            error=str(exc),
+            demo_mode=True,
+        )
 
 
 def main() -> None:

--- a/src/veridra/audit.py
+++ b/src/veridra/audit.py
@@ -5,18 +5,40 @@ from pathlib import Path
 
 from .app import dashboard
 from .core import demo_assessment
+from .reports import render_report
 
 
 def run_audit(root: Path, output: Path) -> dict[str, object]:
     output.mkdir(parents=True, exist_ok=True)
+    demo = demo_assessment()
+    dashboard_html = dashboard(demo, demo_mode=True)
+    report_html = render_report(demo)
     checks = {
-        "required_files": all((root / path).exists() for path in ["pyproject.toml", "README.md", "src/veridra/app.py", "tests"]),
-        "responsive_ui": "meta name='viewport'" in dashboard(),
-        "scope_notice": "not a penetration test" in dashboard(),
-        "demo_evidence": demo_assessment().summary["total"] > 0,
+        "required_files": all(
+            (root / path).exists()
+            for path in [
+                "pyproject.toml",
+                "README.md",
+                "src/veridra/app.py",
+                "src/veridra/reports.py",
+                "tests",
+            ]
+        ),
+        "responsive_ui": "meta name='viewport'" in dashboard_html,
+        "scope_notice": "not a penetration test" in dashboard_html,
+        "assessment_form": "name='url'" in dashboard_html,
+        "printable_report": "window.print()" in report_html,
+        "report_scope_notice": "not a penetration test" in report_html,
+        "demo_evidence": demo.summary["total"] > 0,
     }
-    report: dict[str, object] = {"passed": all(checks.values()), "checks": checks}
-    (output / "audit-report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    report: dict[str, object] = {
+        "passed": all(checks.values()),
+        "checks": checks,
+    }
+    (output / "audit-report.json").write_text(
+        json.dumps(report, indent=2),
+        encoding="utf-8",
+    )
     return report
 
 

--- a/src/veridra/reports.py
+++ b/src/veridra/reports.py
@@ -15,26 +15,24 @@ _SCOPE = (
 def render_report(assessment: Assessment) -> str:
     target = html.escape(str(assessment.target))
     summary_cards = "".join(
-        "<article><span>{label}</span><strong>{value}</strong></article>".format(
-            label=html.escape(key.title()),
-            value=value,
+        (
+            f"<article><span>{html.escape(key.title())}</span>"
+            f"<strong>{value}</strong></article>"
         )
         for key, value in assessment.summary.items()
     )
     rows = "".join(
-        "<tr><td>{status}</td><td>{area}</td><td>{title}</td>"
-        "<td>{summary}</td><td>{recommendation}</td><td><pre>{evidence}</pre></td></tr>".format(
-            status=html.escape(item.status.value),
-            area=html.escape(item.area),
-            title=html.escape(item.title),
-            summary=html.escape(item.summary),
-            recommendation=html.escape(item.recommendation or "No action required."),
-            evidence=html.escape(
-                json.dumps(item.evidence, indent=2, sort_keys=True, ensure_ascii=False)
-            ),
+        (
+            f"<tr><td>{html.escape(item.status.value)}</td>"
+            f"<td>{html.escape(item.area)}</td>"
+            f"<td>{html.escape(item.title)}</td>"
+            f"<td>{html.escape(item.summary)}</td>"
+            f"<td>{html.escape(item.recommendation or 'No action required.')}</td>"
+            f"<td><pre>{html.escape(json.dumps(item.evidence, indent=2, sort_keys=True, ensure_ascii=False))}</pre></td></tr>"
         )
         for item in assessment.findings
     )
+    scope = html.escape(_SCOPE)
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -42,16 +40,100 @@ def render_report(assessment: Assessment) -> str:
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Veridra assessment report</title>
 <style>
-*{{box-sizing:border-box}}body{{margin:0;background:#eef1f4;color:#17191c;font:14px Arial,sans-serif}}main{{max-width:1300px;margin:32px auto;background:white;padding:40px;border:1px solid #dfe3e8}}header{{display:flex;justify-content:space-between;gap:24px;border-bottom:1px solid #dfe3e8;padding-bottom:22px}}h1{{margin:0 0 8px;font-size:30px}}.target{{word-break:break-all;color:#555}}.cards{{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin:24px 0}}article{{border:1px solid #dfe3e8;padding:16px}}article span{{display:block;text-transform:uppercase;font-size:11px;color:#68707a}}article strong{{display:block;font-size:26px;margin-top:8px}}table{{width:100%;border-collapse:collapse}}th,td{{text-align:left;vertical-align:top;padding:10px;border-bottom:1px solid #e5e7ea}}th{{font-size:11px;text-transform:uppercase;color:#68707a}}pre{{white-space:pre-wrap;word-break:break-word;font-size:11px;margin:0}}.scope{{margin-top:26px;padding:14px;background:#f6f7f9;border-left:3px solid #707780}}@media(max-width:800px){{main{{margin:0;padding:20px}}.cards{{grid-template-columns:repeat(2,1fr)}}table{{display:block;overflow:auto}}}}@media print{{body{{background:white}}main{{border:0;margin:0;max-width:none;padding:0}}button{{display:none}}}}
+* {{ box-sizing: border-box; }}
+body {{
+  margin: 0;
+  background: #eef1f4;
+  color: #17191c;
+  font: 14px Arial, sans-serif;
+}}
+main {{
+  max-width: 1300px;
+  margin: 32px auto;
+  background: white;
+  padding: 40px;
+  border: 1px solid #dfe3e8;
+}}
+header {{
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  border-bottom: 1px solid #dfe3e8;
+  padding-bottom: 22px;
+}}
+h1 {{ margin: 0 0 8px; font-size: 30px; }}
+.target {{ word-break: break-all; color: #555; }}
+.cards {{
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin: 24px 0;
+}}
+article {{ border: 1px solid #dfe3e8; padding: 16px; }}
+article span {{
+  display: block;
+  text-transform: uppercase;
+  font-size: 11px;
+  color: #68707a;
+}}
+article strong {{ display: block; font-size: 26px; margin-top: 8px; }}
+table {{ width: 100%; border-collapse: collapse; }}
+th, td {{
+  text-align: left;
+  vertical-align: top;
+  padding: 10px;
+  border-bottom: 1px solid #e5e7ea;
+}}
+th {{ font-size: 11px; text-transform: uppercase; color: #68707a; }}
+pre {{
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 11px;
+  margin: 0;
+}}
+.scope {{
+  margin-top: 26px;
+  padding: 14px;
+  background: #f6f7f9;
+  border-left: 3px solid #707780;
+}}
+@media (max-width: 800px) {{
+  main {{ margin: 0; padding: 20px; }}
+  .cards {{ grid-template-columns: repeat(2, 1fr); }}
+  table {{ display: block; overflow: auto; }}
+}}
+@media print {{
+  body {{ background: white; }}
+  main {{ border: 0; margin: 0; max-width: none; padding: 0; }}
+  button {{ display: none; }}
+}}
 </style>
 </head>
 <body>
 <main>
-<header><div><h1>Veridra assessment report</h1><div class="target">{target}</div></div><button onclick="window.print()">Print report</button></header>
+<header>
+  <div>
+    <h1>Veridra assessment report</h1>
+    <div class="target">{target}</div>
+  </div>
+  <button onclick="window.print()">Print report</button>
+</header>
 <div class="cards">{summary_cards}</div>
 <h2>Evidence-backed findings</h2>
-<table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th><th>Evidence</th></tr></thead><tbody>{rows}</tbody></table>
-<p class="scope">{html.escape(_SCOPE)}</p>
+<table>
+  <thead>
+    <tr>
+      <th>Status</th>
+      <th>Area</th>
+      <th>Finding</th>
+      <th>Observation</th>
+      <th>Recommended action</th>
+      <th>Evidence</th>
+    </tr>
+  </thead>
+  <tbody>{rows}</tbody>
+</table>
+<p class="scope">{scope}</p>
 </main>
 </body>
 </html>"""

--- a/src/veridra/reports.py
+++ b/src/veridra/reports.py
@@ -3,13 +3,30 @@ from __future__ import annotations
 import html
 import json
 
-from .core import Assessment
+from .core import Assessment, Finding
 
 _SCOPE = (
     "Scope: bounded public checks only. This is not a penetration test and "
     "does not inspect authenticated functionality, source code, server "
     "configuration, or private infrastructure."
 )
+
+
+def _finding_row(item: Finding) -> str:
+    evidence_json = json.dumps(
+        item.evidence,
+        indent=2,
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return (
+        f"<tr><td>{html.escape(item.status.value)}</td>"
+        f"<td>{html.escape(item.area)}</td>"
+        f"<td>{html.escape(item.title)}</td>"
+        f"<td>{html.escape(item.summary)}</td>"
+        f"<td>{html.escape(item.recommendation or 'No action required.')}</td>"
+        f"<td><pre>{html.escape(evidence_json)}</pre></td></tr>"
+    )
 
 
 def render_report(assessment: Assessment) -> str:
@@ -21,17 +38,7 @@ def render_report(assessment: Assessment) -> str:
         )
         for key, value in assessment.summary.items()
     )
-    rows = "".join(
-        (
-            f"<tr><td>{html.escape(item.status.value)}</td>"
-            f"<td>{html.escape(item.area)}</td>"
-            f"<td>{html.escape(item.title)}</td>"
-            f"<td>{html.escape(item.summary)}</td>"
-            f"<td>{html.escape(item.recommendation or 'No action required.')}</td>"
-            f"<td><pre>{html.escape(json.dumps(item.evidence, indent=2, sort_keys=True, ensure_ascii=False))}</pre></td></tr>"
-        )
-        for item in assessment.findings
-    )
+    rows = "".join(_finding_row(item) for item in assessment.findings)
     scope = html.escape(_SCOPE)
     return f"""<!doctype html>
 <html lang="en">

--- a/src/veridra/reports.py
+++ b/src/veridra/reports.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import html
+import json
+
+from .core import Assessment
+
+_SCOPE = (
+    "Scope: bounded public checks only. This is not a penetration test and "
+    "does not inspect authenticated functionality, source code, server "
+    "configuration, or private infrastructure."
+)
+
+
+def render_report(assessment: Assessment) -> str:
+    target = html.escape(str(assessment.target))
+    summary_cards = "".join(
+        "<article><span>{label}</span><strong>{value}</strong></article>".format(
+            label=html.escape(key.title()),
+            value=value,
+        )
+        for key, value in assessment.summary.items()
+    )
+    rows = "".join(
+        "<tr><td>{status}</td><td>{area}</td><td>{title}</td>"
+        "<td>{summary}</td><td>{recommendation}</td><td><pre>{evidence}</pre></td></tr>".format(
+            status=html.escape(item.status.value),
+            area=html.escape(item.area),
+            title=html.escape(item.title),
+            summary=html.escape(item.summary),
+            recommendation=html.escape(item.recommendation or "No action required."),
+            evidence=html.escape(
+                json.dumps(item.evidence, indent=2, sort_keys=True, ensure_ascii=False)
+            ),
+        )
+        for item in assessment.findings
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Veridra assessment report</title>
+<style>
+*{{box-sizing:border-box}}body{{margin:0;background:#eef1f4;color:#17191c;font:14px Arial,sans-serif}}main{{max-width:1300px;margin:32px auto;background:white;padding:40px;border:1px solid #dfe3e8}}header{{display:flex;justify-content:space-between;gap:24px;border-bottom:1px solid #dfe3e8;padding-bottom:22px}}h1{{margin:0 0 8px;font-size:30px}}.target{{word-break:break-all;color:#555}}.cards{{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin:24px 0}}article{{border:1px solid #dfe3e8;padding:16px}}article span{{display:block;text-transform:uppercase;font-size:11px;color:#68707a}}article strong{{display:block;font-size:26px;margin-top:8px}}table{{width:100%;border-collapse:collapse}}th,td{{text-align:left;vertical-align:top;padding:10px;border-bottom:1px solid #e5e7ea}}th{{font-size:11px;text-transform:uppercase;color:#68707a}}pre{{white-space:pre-wrap;word-break:break-word;font-size:11px;margin:0}}.scope{{margin-top:26px;padding:14px;background:#f6f7f9;border-left:3px solid #707780}}@media(max-width:800px){{main{{margin:0;padding:20px}}.cards{{grid-template-columns:repeat(2,1fr)}}table{{display:block;overflow:auto}}}}@media print{{body{{background:white}}main{{border:0;margin:0;max-width:none;padding:0}}button{{display:none}}}}
+</style>
+</head>
+<body>
+<main>
+<header><div><h1>Veridra assessment report</h1><div class="target">{target}</div></div><button onclick="window.print()">Print report</button></header>
+<div class="cards">{summary_cards}</div>
+<h2>Evidence-backed findings</h2>
+<table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th><th>Evidence</th></tr></thead><tbody>{rows}</tbody></table>
+<p class="scope">{html.escape(_SCOPE)}</p>
+</main>
+</body>
+</html>"""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,6 +19,8 @@ def test_dashboard_contract() -> None:
     assert response.status_code == 200
     assert "AI discoverability" in response.text
     assert "not a penetration test" in response.text
+    assert "name='url'" in response.text
+    assert "/report?demo=true" in response.text
 
 
 def test_demo_api() -> None:
@@ -34,11 +36,51 @@ def test_live_assessment_api(monkeypatch: pytest.MonkeyPatch) -> None:
     assert response.json()["target"] == "https://example.com/"
 
 
-def test_live_assessment_rejects_unsafe_target(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_live_assessment_rejects_unsafe_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     def reject(url: str) -> Assessment:
-        raise UnsafeTargetError("Non-public target address is not allowed: 127.0.0.1")
+        raise UnsafeTargetError(
+            "Non-public target address is not allowed: 127.0.0.1"
+        )
 
     monkeypatch.setattr(app_module, "assess_url", reject)
     response = client.get("/api/assess", params={"url": "localhost"})
     assert response.status_code == 400
     assert "Non-public" in response.json()["detail"]
+
+
+def test_live_dashboard_uses_assessment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = Assessment.build("https://example.com", [])
+    monkeypatch.setattr(app_module, "assess_url", lambda url: expected)
+    response = client.get("/", params={"url": "example.com"})
+    assert response.status_code == 200
+    assert "value='example.com'" in response.text
+    assert "/report?url=example.com" in response.text
+
+
+def test_dashboard_displays_safe_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def reject(url: str) -> Assessment:
+        raise UnsafeTargetError("Rejected <script>alert(1)</script>")
+
+    monkeypatch.setattr(app_module, "assess_url", reject)
+    response = client.get("/", params={"url": "localhost"})
+    assert response.status_code == 200
+    assert "<script>alert(1)</script>" not in response.text
+    assert "Rejected &lt;script&gt;alert(1)&lt;/script&gt;" in response.text
+
+
+def test_demo_report_route() -> None:
+    response = client.get("/report", params={"demo": "true"})
+    assert response.status_code == 200
+    assert "Veridra assessment report" in response.text
+    assert "This is not a penetration test" in response.text
+
+
+def test_report_requires_target() -> None:
+    response = client.get("/report")
+    assert response.status_code == 400

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from veridra.core import Assessment, Finding, Status
+from veridra.reports import render_report
+
+
+def test_report_escapes_target_derived_content() -> None:
+    assessment = Assessment.build(
+        "https://example.com",
+        [
+            Finding(
+                id="test.escape",
+                area="Website health",
+                title="Unsafe <script>alert(1)</script>",
+                status=Status.attention,
+                severity="medium",
+                summary="Observed <b>markup</b>.",
+                recommendation="Use > safe output.",
+                evidence={"value": "<img src=x onerror=alert(1)>"},
+            )
+        ],
+    )
+
+    report = render_report(assessment)
+
+    assert "<script>alert(1)</script>" not in report
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in report
+    assert "&lt;img src=x onerror=alert(1)&gt;" in report
+
+
+def test_report_contains_scope_and_print_action() -> None:
+    report = render_report(Assessment.build("https://example.com", []))
+    assert "This is not a penetration test" in report
+    assert "window.print()" in report
+    assert "Evidence-backed findings" in report


### PR DESCRIPTION
## Scope

Implements issue #4:

- dashboard URL input for bounded live assessments;
- safe rendering of live or demo results;
- printable HTML report with summary, findings, evidence and recommendations;
- escaped target-derived content;
- report and dashboard route tests;
- loopback-only application behavior remains unchanged.

## Excluded

No accounts, billing, public deployment, email delivery, PDF engine, LLM API calls, backlink provider, or active vulnerability scanning.

## Required proof

- Ruff
- strict mypy
- pytest
- deterministic audit
- exact-head GitHub Actions success

Closes #4 after verified merge.