### PR TITLE
Add assessment metadata and area summaries

### DIFF
--- a/src/veridra/core.py
+++ b/src/veridra/core.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import ipaddress
 import socket
-from collections import Counter
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
 from enum import StrEnum
 from html.parser import HTMLParser
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, HttpUrl, TypeAdapter
@@ -35,23 +36,73 @@ class Finding(BaseModel):
 
 
 class Assessment(BaseModel):
-    schema_version: str = "1.1"
+    schema_version: str = "1.2"
     target: HttpUrl
+    mode: Literal["demo", "live"]
+    generated_at: datetime
+    elapsed_ms: int
     findings: list[Finding]
     summary: dict[str, int]
+    area_summary: dict[str, dict[str, int]]
 
     @classmethod
-    def build(cls, target: str, findings: list[Finding]) -> Assessment:
-        counts = Counter(item.status.value for item in findings)
+    def build(
+        cls,
+        target: str,
+        findings: list[Finding],
+        *,
+        mode: Literal["demo", "live"] = "live",
+        generated_at: datetime | None = None,
+        elapsed_ms: int = 0,
+    ) -> Assessment:
+        status_priority = {
+            Status.attention: 0,
+            Status.unavailable: 1,
+            Status.passed: 2,
+        }
+        severity_priority = {
+            "critical": 0,
+            "high": 1,
+            "medium": 2,
+            "low": 3,
+            "info": 4,
+        }
+        ordered = sorted(
+            findings,
+            key=lambda item: (
+                status_priority[item.status],
+                severity_priority.get(item.severity.lower(), 5),
+                item.area.lower(),
+                item.title.lower(),
+            ),
+        )
+        counts = Counter(item.status.value for item in ordered)
+        area_counts: defaultdict[str, Counter[str]] = defaultdict(Counter)
+        for item in ordered:
+            area_counts[item.area][item.status.value] += 1
+            area_counts[item.area]["total"] += 1
+        area_summary = {
+            area: {
+                "passed": values.get("passed", 0),
+                "attention": values.get("attention", 0),
+                "unavailable": values.get("unavailable", 0),
+                "total": values.get("total", 0),
+            }
+            for area, values in sorted(area_counts.items())
+        }
         return cls(
             target=TypeAdapter(HttpUrl).validate_python(target),
-            findings=findings,
+            mode=mode,
+            generated_at=generated_at or datetime.now(timezone.utc),
+            elapsed_ms=max(0, elapsed_ms),
+            findings=ordered,
             summary={
                 "passed": counts.get("passed", 0),
                 "attention": counts.get("attention", 0),
                 "unavailable": counts.get("unavailable", 0),
-                "total": len(findings),
+                "total": len(ordered),
             },
+            area_summary=area_summary,
         )
 
 
@@ -173,4 +224,8 @@ def analyze_document(html: str, headers: dict[str, str], robots: str = "") -> li
 
 def demo_assessment() -> Assessment:
     html = "<html><head><title>Demo</title><meta name='viewport' content='width=device-width'></head><body><h1>Demo</h1></body></html>"
-    return Assessment.build("https://demo.veridra.local", analyze_document(html, {"x-content-type-options": "nosniff"}))
+    return Assessment.build(
+        "https://demo.veridra.local",
+        analyze_document(html, {"x-content-type-options": "nosniff"}),
+        mode="demo",
+    )

--- a/src/veridra/core.py
+++ b/src/veridra/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ipaddress
 import socket
 from collections import Counter, defaultdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import StrEnum
 from html.parser import HTMLParser
 from typing import Any, Literal
@@ -93,7 +93,7 @@ class Assessment(BaseModel):
         return cls(
             target=TypeAdapter(HttpUrl).validate_python(target),
             mode=mode,
-            generated_at=generated_at or datetime.now(timezone.utc),
+            generated_at=generated_at or datetime.now(UTC),
             elapsed_ms=max(0, elapsed_ms),
             findings=ordered,
             summary={

--- a/src/veridra/reports.py
+++ b/src/veridra/reports.py
@@ -29,6 +29,16 @@ def _finding_row(item: Finding) -> str:
     )
 
 
+def _area_row(area: str, values: dict[str, int]) -> str:
+    return (
+        f"<tr><td>{html.escape(area)}</td>"
+        f"<td>{values['passed']}</td>"
+        f"<td>{values['attention']}</td>"
+        f"<td>{values['unavailable']}</td>"
+        f"<td>{values['total']}</td></tr>"
+    )
+
+
 def render_report(assessment: Assessment) -> str:
     target = html.escape(str(assessment.target))
     summary_cards = "".join(
@@ -38,8 +48,14 @@ def render_report(assessment: Assessment) -> str:
         )
         for key, value in assessment.summary.items()
     )
+    area_rows = "".join(
+        _area_row(area, values)
+        for area, values in assessment.area_summary.items()
+    )
     rows = "".join(_finding_row(item) for item in assessment.findings)
     scope = html.escape(_SCOPE)
+    generated = html.escape(assessment.generated_at.isoformat())
+    mode = html.escape(assessment.mode.title())
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -48,62 +64,21 @@ def render_report(assessment: Assessment) -> str:
 <title>Veridra assessment report</title>
 <style>
 * {{ box-sizing: border-box; }}
-body {{
-  margin: 0;
-  background: #eef1f4;
-  color: #17191c;
-  font: 14px Arial, sans-serif;
-}}
-main {{
-  max-width: 1300px;
-  margin: 32px auto;
-  background: white;
-  padding: 40px;
-  border: 1px solid #dfe3e8;
-}}
-header {{
-  display: flex;
-  justify-content: space-between;
-  gap: 24px;
-  border-bottom: 1px solid #dfe3e8;
-  padding-bottom: 22px;
-}}
+body {{ margin: 0; background: #eef1f4; color: #17191c; font: 14px Arial, sans-serif; }}
+main {{ max-width: 1300px; margin: 32px auto; background: white; padding: 40px; border: 1px solid #dfe3e8; }}
+header {{ display: flex; justify-content: space-between; gap: 24px; border-bottom: 1px solid #dfe3e8; padding-bottom: 22px; }}
 h1 {{ margin: 0 0 8px; font-size: 30px; }}
 .target {{ word-break: break-all; color: #555; }}
-.cards {{
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 12px;
-  margin: 24px 0;
-}}
+.meta {{ margin: 14px 0 0; display: flex; flex-wrap: wrap; gap: 18px; color: #555; }}
+.cards {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 24px 0; }}
 article {{ border: 1px solid #dfe3e8; padding: 16px; }}
-article span {{
-  display: block;
-  text-transform: uppercase;
-  font-size: 11px;
-  color: #68707a;
-}}
+article span {{ display: block; text-transform: uppercase; font-size: 11px; color: #68707a; }}
 article strong {{ display: block; font-size: 26px; margin-top: 8px; }}
-table {{ width: 100%; border-collapse: collapse; }}
-th, td {{
-  text-align: left;
-  vertical-align: top;
-  padding: 10px;
-  border-bottom: 1px solid #e5e7ea;
-}}
+table {{ width: 100%; border-collapse: collapse; margin-bottom: 28px; }}
+th, td {{ text-align: left; vertical-align: top; padding: 10px; border-bottom: 1px solid #e5e7ea; }}
 th {{ font-size: 11px; text-transform: uppercase; color: #68707a; }}
-pre {{
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-size: 11px;
-  margin: 0;
-}}
-.scope {{
-  margin-top: 26px;
-  padding: 14px;
-  background: #f6f7f9;
-  border-left: 3px solid #707780;
-}}
+pre {{ white-space: pre-wrap; word-break: break-word; font-size: 11px; margin: 0; }}
+.scope {{ margin-top: 26px; padding: 14px; background: #f6f7f9; border-left: 3px solid #707780; }}
 @media (max-width: 800px) {{
   main {{ margin: 0; padding: 20px; }}
   .cards {{ grid-template-columns: repeat(2, 1fr); }}
@@ -122,21 +97,25 @@ pre {{
   <div>
     <h1>Veridra assessment report</h1>
     <div class="target">{target}</div>
+    <div class="meta">
+      <span><strong>Mode:</strong> {mode}</span>
+      <span><strong>Generated:</strong> {generated}</span>
+      <span><strong>Elapsed:</strong> {assessment.elapsed_ms} ms</span>
+      <span><strong>Schema:</strong> {html.escape(assessment.schema_version)}</span>
+    </div>
   </div>
   <button onclick="window.print()">Print report</button>
 </header>
 <div class="cards">{summary_cards}</div>
+<h2>Assessment areas</h2>
+<table>
+  <thead><tr><th>Area</th><th>Passed</th><th>Attention</th><th>Unavailable</th><th>Total</th></tr></thead>
+  <tbody>{area_rows}</tbody>
+</table>
 <h2>Evidence-backed findings</h2>
 <table>
   <thead>
-    <tr>
-      <th>Status</th>
-      <th>Area</th>
-      <th>Finding</th>
-      <th>Observation</th>
-      <th>Recommended action</th>
-      <th>Evidence</th>
-    </tr>
+    <tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th><th>Evidence</th></tr>
   </thead>
   <tbody>{rows}</tbody>
 </table>

--- a/src/veridra/reports.py
+++ b/src/veridra/reports.py
@@ -64,21 +64,69 @@ def render_report(assessment: Assessment) -> str:
 <title>Veridra assessment report</title>
 <style>
 * {{ box-sizing: border-box; }}
-body {{ margin: 0; background: #eef1f4; color: #17191c; font: 14px Arial, sans-serif; }}
-main {{ max-width: 1300px; margin: 32px auto; background: white; padding: 40px; border: 1px solid #dfe3e8; }}
-header {{ display: flex; justify-content: space-between; gap: 24px; border-bottom: 1px solid #dfe3e8; padding-bottom: 22px; }}
+body {{
+  margin: 0;
+  background: #eef1f4;
+  color: #17191c;
+  font: 14px Arial, sans-serif;
+}}
+main {{
+  max-width: 1300px;
+  margin: 32px auto;
+  background: white;
+  padding: 40px;
+  border: 1px solid #dfe3e8;
+}}
+header {{
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  border-bottom: 1px solid #dfe3e8;
+  padding-bottom: 22px;
+}}
 h1 {{ margin: 0 0 8px; font-size: 30px; }}
 .target {{ word-break: break-all; color: #555; }}
-.meta {{ margin: 14px 0 0; display: flex; flex-wrap: wrap; gap: 18px; color: #555; }}
-.cards {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 24px 0; }}
+.meta {{
+  margin: 14px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  color: #555;
+}}
+.cards {{
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin: 24px 0;
+}}
 article {{ border: 1px solid #dfe3e8; padding: 16px; }}
-article span {{ display: block; text-transform: uppercase; font-size: 11px; color: #68707a; }}
+article span {{
+  display: block;
+  text-transform: uppercase;
+  font-size: 11px;
+  color: #68707a;
+}}
 article strong {{ display: block; font-size: 26px; margin-top: 8px; }}
 table {{ width: 100%; border-collapse: collapse; margin-bottom: 28px; }}
-th, td {{ text-align: left; vertical-align: top; padding: 10px; border-bottom: 1px solid #e5e7ea; }}
+th, td {{
+  text-align: left;
+  vertical-align: top;
+  padding: 10px;
+  border-bottom: 1px solid #e5e7ea;
+}}
 th {{ font-size: 11px; text-transform: uppercase; color: #68707a; }}
-pre {{ white-space: pre-wrap; word-break: break-word; font-size: 11px; margin: 0; }}
-.scope {{ margin-top: 26px; padding: 14px; background: #f6f7f9; border-left: 3px solid #707780; }}
+pre {{
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 11px;
+  margin: 0;
+}}
+.scope {{
+  margin-top: 26px;
+  padding: 14px;
+  background: #f6f7f9;
+  border-left: 3px solid #707780;
+}}
 @media (max-width: 800px) {{
   main {{ margin: 0; padding: 20px; }}
   .cards {{ grid-template-columns: repeat(2, 1fr); }}
@@ -109,13 +157,28 @@ pre {{ white-space: pre-wrap; word-break: break-word; font-size: 11px; margin: 0
 <div class="cards">{summary_cards}</div>
 <h2>Assessment areas</h2>
 <table>
-  <thead><tr><th>Area</th><th>Passed</th><th>Attention</th><th>Unavailable</th><th>Total</th></tr></thead>
+  <thead>
+    <tr>
+      <th>Area</th>
+      <th>Passed</th>
+      <th>Attention</th>
+      <th>Unavailable</th>
+      <th>Total</th>
+    </tr>
+  </thead>
   <tbody>{area_rows}</tbody>
 </table>
 <h2>Evidence-backed findings</h2>
 <table>
   <thead>
-    <tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th><th>Evidence</th></tr>
+    <tr>
+      <th>Status</th>
+      <th>Area</th>
+      <th>Finding</th>
+      <th>Observation</th>
+      <th>Recommended action</th>
+      <th>Evidence</th>
+    </tr>
   </thead>
   <tbody>{rows}</tbody>
 </table>

--- a/src/veridra/service.py
+++ b/src/veridra/service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from time import perf_counter
+
 from .collector import Requester, SiteEvidence, _request_once, collect_site
 from .core import Assessment, Finding, Status, analyze_document
 
@@ -59,6 +61,7 @@ def assess_url(
     *,
     requester: Requester = _request_once,
 ) -> Assessment:
+    started = perf_counter()
     evidence = collect_site(raw_url, requester=requester)
     robots_text = evidence.robots.body if evidence.robots is not None else ""
     findings = _transport_findings(evidence)
@@ -69,4 +72,10 @@ def assess_url(
             robots_text,
         )
     )
-    return Assessment.build(evidence.homepage.final_url, findings)
+    elapsed_ms = round((perf_counter() - started) * 1000)
+    return Assessment.build(
+        evidence.homepage.final_url,
+        findings,
+        mode="live",
+        elapsed_ms=elapsed_ms,
+    )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timezone
+
 import pytest
 
 from veridra.core import (
+    Assessment,
+    Finding,
     Status,
     UnsafeTargetError,
     analyze_document,
@@ -67,6 +71,64 @@ def test_crawler_groups_are_evaluated_independently() -> None:
     assert findings["ai.googlebot"].status == Status.attention
 
 
+def test_assessment_metadata_area_summary_and_ordering() -> None:
+    generated_at = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+    findings = [
+        Finding(
+            id="passed",
+            area="Website health",
+            title="Passed item",
+            status=Status.passed,
+            severity="info",
+            summary="Passed.",
+        ),
+        Finding(
+            id="unavailable",
+            area="Search visibility",
+            title="Unavailable item",
+            status=Status.unavailable,
+            severity="low",
+            summary="Unavailable.",
+        ),
+        Finding(
+            id="attention",
+            area="Website health",
+            title="Attention item",
+            status=Status.attention,
+            severity="high",
+            summary="Attention.",
+        ),
+    ]
+
+    assessment = Assessment.build(
+        "https://example.com",
+        findings,
+        mode="live",
+        generated_at=generated_at,
+        elapsed_ms=125,
+    )
+
+    assert assessment.schema_version == "1.2"
+    assert assessment.mode == "live"
+    assert assessment.generated_at == generated_at
+    assert assessment.elapsed_ms == 125
+    assert [item.id for item in assessment.findings] == [
+        "attention",
+        "unavailable",
+        "passed",
+    ]
+    assert assessment.area_summary["Website health"] == {
+        "passed": 1,
+        "attention": 1,
+        "unavailable": 0,
+        "total": 2,
+    }
+
+
 def test_demo_summary() -> None:
     assessment = demo_assessment()
+    assert assessment.mode == "demo"
     assert assessment.summary["total"] == len(assessment.findings)
+    assert sum(values["total"] for values in assessment.area_summary.values()) == len(
+        assessment.findings
+    )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -72,7 +72,7 @@ def test_crawler_groups_are_evaluated_independently() -> None:
 
 
 def test_assessment_metadata_area_summary_and_ordering() -> None:
-    generated_at = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+    generated_at = datetime(2026, 7, 20, 12, 0, tzinfo=UTC)
     findings = [
         Finding(
             id="passed",

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from veridra.core import Assessment, Finding, Status
 from veridra.reports import render_report
 
@@ -28,8 +30,30 @@ def test_report_escapes_target_derived_content() -> None:
     assert "&lt;img src=x onerror=alert(1)&gt;" in report
 
 
-def test_report_contains_scope_and_print_action() -> None:
-    report = render_report(Assessment.build("https://example.com", []))
+def test_report_contains_scope_metadata_and_area_summary() -> None:
+    generated = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+    assessment = Assessment.build(
+        "https://example.com",
+        [
+            Finding(
+                id="test.attention",
+                area="Website health",
+                title="Attention",
+                status=Status.attention,
+                severity="medium",
+                summary="Needs attention.",
+            )
+        ],
+        mode="live",
+        generated_at=generated,
+        elapsed_ms=125,
+    )
+    report = render_report(assessment)
+
     assert "This is not a penetration test" in report
     assert "window.print()" in report
     assert "Evidence-backed findings" in report
+    assert "Assessment areas" in report
+    assert "2026-07-20T12:00:00+00:00" in report
+    assert "125 ms" in report
+    assert "Website health" in report

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from veridra.core import Assessment, Finding, Status
 from veridra.reports import render_report
@@ -31,7 +31,7 @@ def test_report_escapes_target_derived_content() -> None:
 
 
 def test_report_contains_scope_metadata_and_area_summary() -> None:
-    generated = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+    generated = datetime(2026, 7, 20, 12, 0, tzinfo=UTC)
     assessment = Assessment.build(
         "https://example.com",
         [


### PR DESCRIPTION
## Scope

Implements issue #8:

- records demo/live mode, generation timestamp, elapsed milliseconds, and schema version;
- adds deterministic per-area status summaries;
- orders findings by attention priority, severity, area, and title;
- keeps the existing top-level status summary for API compatibility;
- displays metadata and area summaries in printable reports;
- adds deterministic model and report tests.

## Explicit exclusions

No opaque overall score, persistence database, historical comparison, accounts, billing, public deployment, or external providers.

## Required proof

- Ruff
- strict mypy
- pytest
- deterministic audit
- exact-head GitHub Actions success

Closes #8 after verified merge.