### PR TITLE
Add deterministic evidence package export

### DIFF
--- a/src/veridra/app.py
+++ b/src/veridra/app.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import html
 from urllib.parse import urlencode
 
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Response
 from fastapi.responses import HTMLResponse
 
 from .collector import CollectionError
 from .core import Assessment, UnsafeTargetError, demo_assessment
+from .exports import build_evidence_package
 from .reports import render_report
 from .service import assess_url
 
-app = FastAPI(title="Veridra", version="0.3.0")
+app = FastAPI(title="Veridra", version="0.4.0")
 
 
 def dashboard(
@@ -33,11 +34,23 @@ def dashboard(
     error_panel = (
         f"<div class='error' role='alert'>{html.escape(error)}</div>" if error else ""
     )
-    report_query = urlencode({"demo": "true"}) if demo_mode else urlencode({"url": submitted_url})
-    report_link = f"/report?{report_query}"
+    query = urlencode({"demo": "true"}) if demo_mode else urlencode({"url": submitted_url})
+    report_link = f"/report?{query}"
+    export_link = f"/export?{query}"
     return f"""<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>Veridra</title><style>
-*{{box-sizing:border-box}}body{{margin:0;font:14px Arial,sans-serif;background:#f7f8fa;color:#17191c}}aside{{position:fixed;inset:0 auto 0 0;width:230px;background:#f1f3f6;padding:28px 18px;border-right:1px solid #e0e3e8}}aside h1{{margin:0 0 36px;font-size:24px}}nav a{{display:block;padding:12px;border-radius:8px;color:#333;text-decoration:none;margin:4px 0}}nav a.active{{background:#dde1e6;font-weight:700}}main{{margin-left:230px;padding:42px;max-width:1600px}}header{{display:flex;justify-content:space-between;gap:24px;align-items:start;border-bottom:1px solid #e2e5e9;padding-bottom:24px}}h2{{font-size:28px;margin:0}}.muted{{color:#6c737d}}form{{display:flex;gap:8px;min-width:min(520px,100%)}}input{{flex:1;min-width:220px;padding:11px;border:1px solid #cfd4da;border-radius:7px}}button,.button{{border:0;border-radius:7px;background:#22272d;color:white;padding:11px 16px;text-decoration:none;cursor:pointer}}.actions{{display:flex;gap:8px;align-items:center}}.cards{{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin:24px 0}}article{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:18px}}article span{{display:block;color:#6c737d;text-transform:uppercase;font-size:12px}}article strong{{display:block;font-size:28px;margin-top:10px}}section{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:20px}}table{{width:100%;border-collapse:collapse}}th,td{{text-align:left;padding:13px;border-bottom:1px solid #e8eaed;vertical-align:top}}th{{font-size:11px;text-transform:uppercase;color:#69717b}}.pill{{display:inline-block;padding:4px 8px;border-radius:999px;border:1px solid}}.passed{{color:#16794a;background:#f0faf5}}.attention{{color:#946200;background:#fff9e8}}.unavailable{{color:#5f6873;background:#f3f4f6}}.error{{margin-top:18px;padding:13px;border-left:3px solid #b42318;background:#fff1f0;color:#7a271a}}@media(max-width:1000px){{header{{display:block}}form{{margin-top:18px}}}}@media(max-width:800px){{aside{{position:static;width:auto}}main{{margin:0;padding:20px}}.cards{{grid-template-columns:repeat(2,1fr)}}table{{display:block;overflow:auto}}form{{display:block}}input{{width:100%;margin-bottom:8px}}}}
-</style></head><body><aside><h1>Veridra</h1><nav><a class='active'>Overview</a><a>Website health</a><a>Search visibility</a><a>AI discoverability</a><a>Trust signals</a><a>Security posture</a><a href='{html.escape(report_link, quote=True)}'>Reports</a></nav></aside><main><header><div><h2>Website assessment</h2><p class='muted'>Visibility, trust and public security evidence.</p></div><div><form method='get' action='/'><label class='muted' for='url'>Public website</label><input id='url' name='url' type='text' maxlength='2048' placeholder='example.com' value='{escaped_url}' required><div class='actions'><button type='submit'>Run assessment</button><a class='button' href='{html.escape(report_link, quote=True)}'>Open report</a></div></form></div></header>{error_panel}<div class='cards'>{cards}</div><section><h3>Evidence-backed findings</h3><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th></tr></thead><tbody>{rows}</tbody></table><p class='muted'>Scope: bounded public checks only. This is not a penetration test.</p></section></main></body></html>"""
+*{{box-sizing:border-box}}body{{margin:0;font:14px Arial,sans-serif;background:#f7f8fa;color:#17191c}}aside{{position:fixed;inset:0 auto 0 0;width:230px;background:#f1f3f6;padding:28px 18px;border-right:1px solid #e0e3e8}}aside h1{{margin:0 0 36px;font-size:24px}}nav a{{display:block;padding:12px;border-radius:8px;color:#333;text-decoration:none;margin:4px 0}}nav a.active{{background:#dde1e6;font-weight:700}}main{{margin-left:230px;padding:42px;max-width:1600px}}header{{display:flex;justify-content:space-between;gap:24px;align-items:start;border-bottom:1px solid #e2e5e9;padding-bottom:24px}}h2{{font-size:28px;margin:0}}.muted{{color:#6c737d}}form{{display:flex;gap:8px;min-width:min(620px,100%)}}input{{flex:1;min-width:220px;padding:11px;border:1px solid #cfd4da;border-radius:7px}}button,.button{{border:0;border-radius:7px;background:#22272d;color:white;padding:11px 16px;text-decoration:none;cursor:pointer}}.button.secondary{{background:#59616b}}.actions{{display:flex;gap:8px;align-items:center;flex-wrap:wrap}}.cards{{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin:24px 0}}article{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:18px}}article span{{display:block;color:#6c737d;text-transform:uppercase;font-size:12px}}article strong{{display:block;font-size:28px;margin-top:10px}}section{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:20px}}table{{width:100%;border-collapse:collapse}}th,td{{text-align:left;padding:13px;border-bottom:1px solid #e8eaed;vertical-align:top}}th{{font-size:11px;text-transform:uppercase;color:#69717b}}.pill{{display:inline-block;padding:4px 8px;border-radius:999px;border:1px solid}}.passed{{color:#16794a;background:#f0faf5}}.attention{{color:#946200;background:#fff9e8}}.unavailable{{color:#5f6873;background:#f3f4f6}}.error{{margin-top:18px;padding:13px;border-left:3px solid #b42318;background:#fff1f0;color:#7a271a}}@media(max-width:1000px){{header{{display:block}}form{{margin-top:18px}}}}@media(max-width:800px){{aside{{position:static;width:auto}}main{{margin:0;padding:20px}}.cards{{grid-template-columns:repeat(2,1fr)}}table{{display:block;overflow:auto}}form{{display:block}}input{{width:100%;margin-bottom:8px}}}}
+</style></head><body><aside><h1>Veridra</h1><nav><a class='active'>Overview</a><a>Website health</a><a>Search visibility</a><a>AI discoverability</a><a>Trust signals</a><a>Security posture</a><a href='{html.escape(report_link, quote=True)}'>Reports</a></nav></aside><main><header><div><h2>Website assessment</h2><p class='muted'>Visibility, trust and public security evidence.</p></div><div><form method='get' action='/'><label class='muted' for='url'>Public website</label><input id='url' name='url' type='text' maxlength='2048' placeholder='example.com' value='{escaped_url}' required><div class='actions'><button type='submit'>Run assessment</button><a class='button' href='{html.escape(report_link, quote=True)}'>Open report</a><a class='button secondary' href='{html.escape(export_link, quote=True)}'>Export evidence</a></div></form></div></header>{error_panel}<div class='cards'>{cards}</div><section><h3>Evidence-backed findings</h3><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th></tr></thead><tbody>{rows}</tbody></table><p class='muted'>Scope: bounded public checks only. This is not a penetration test.</p></section></main></body></html>"""
+
+
+def _resolve_assessment(url: str | None, demo: bool) -> Assessment:
+    if demo:
+        return demo_assessment()
+    if url is None:
+        raise HTTPException(status_code=400, detail="A target URL is required.")
+    try:
+        return assess_url(url)
+    except (UnsafeTargetError, CollectionError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.get("/health")
@@ -63,14 +76,23 @@ def report(
     url: str | None = Query(default=None, min_length=1, max_length=2048),
     demo: bool = False,
 ) -> str:
-    if demo:
-        return render_report(demo_assessment())
-    if url is None:
-        raise HTTPException(status_code=400, detail="A target URL is required.")
-    try:
-        return render_report(assess_url(url))
-    except (UnsafeTargetError, CollectionError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return render_report(_resolve_assessment(url, demo))
+
+
+@app.get("/export")
+def export(
+    url: str | None = Query(default=None, min_length=1, max_length=2048),
+    demo: bool = False,
+) -> Response:
+    package = build_evidence_package(_resolve_assessment(url, demo))
+    return Response(
+        content=package.content,
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{package.filename}"',
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/src/veridra/audit.py
+++ b/src/veridra/audit.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+import zipfile
+from io import BytesIO
 from pathlib import Path
 
 from .app import dashboard
 from .core import demo_assessment
+from .exports import build_evidence_package
 from .reports import render_report
 
 
@@ -13,6 +16,9 @@ def run_audit(root: Path, output: Path) -> dict[str, object]:
     demo = demo_assessment()
     dashboard_html = dashboard(demo, demo_mode=True)
     report_html = render_report(demo)
+    package = build_evidence_package(demo)
+    with zipfile.ZipFile(BytesIO(package.content)) as archive:
+        package_files = set(archive.namelist())
     checks = {
         "required_files": all(
             (root / path).exists()
@@ -20,6 +26,7 @@ def run_audit(root: Path, output: Path) -> dict[str, object]:
                 "pyproject.toml",
                 "README.md",
                 "src/veridra/app.py",
+                "src/veridra/exports.py",
                 "src/veridra/reports.py",
                 "tests",
             ]
@@ -29,6 +36,11 @@ def run_audit(root: Path, output: Path) -> dict[str, object]:
         "assessment_form": "name='url'" in dashboard_html,
         "printable_report": "window.print()" in report_html,
         "report_scope_notice": "not a penetration test" in report_html,
+        "evidence_export_link": "/export?demo=true" in dashboard_html,
+        "evidence_package": package_files
+        == {"assessment.json", "report.html", "manifest.sha256"},
+        "evidence_manifest": set(package.manifest)
+        == {"assessment.json", "report.html"},
         "demo_evidence": demo.summary["total"] > 0,
     }
     report: dict[str, object] = {
@@ -39,6 +51,7 @@ def run_audit(root: Path, output: Path) -> dict[str, object]:
         json.dumps(report, indent=2),
         encoding="utf-8",
     )
+    (output / package.filename).write_bytes(package.content)
     return report
 
 

--- a/src/veridra/exports.py
+++ b/src/veridra/exports.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import zipfile
+from dataclasses import dataclass
+
+from .core import Assessment
+from .reports import render_report
+
+
+@dataclass(frozen=True)
+class EvidencePackage:
+    filename: str
+    content: bytes
+    manifest: dict[str, str]
+
+
+def _json_bytes(assessment: Assessment) -> bytes:
+    payload = assessment.model_dump(mode="json")
+    return json.dumps(
+        payload,
+        indent=2,
+        sort_keys=True,
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def build_evidence_package(assessment: Assessment) -> EvidencePackage:
+    assessment_json = _json_bytes(assessment)
+    report_html = render_report(assessment).encode("utf-8")
+    manifest = {
+        "assessment.json": _sha256(assessment_json),
+        "report.html": _sha256(report_html),
+    }
+    manifest_bytes = "".join(
+        f"{digest}  {name}\n" for name, digest in sorted(manifest.items())
+    ).encode("utf-8")
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(
+        buffer,
+        mode="w",
+        compression=zipfile.ZIP_DEFLATED,
+        compresslevel=9,
+    ) as archive:
+        for name, content in (
+            ("assessment.json", assessment_json),
+            ("report.html", report_html),
+            ("manifest.sha256", manifest_bytes),
+        ):
+            info = zipfile.ZipInfo(name)
+            info.date_time = (1980, 1, 1, 0, 0, 0)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, content)
+
+    target_host = assessment.target.host or "website"
+    safe_host = "".join(
+        character if character.isalnum() or character in {"-", "."} else "-"
+        for character in target_host
+    ).strip("-.") or "website"
+    filename = f"veridra-{safe_host}-evidence.zip"
+    return EvidencePackage(
+        filename=filename,
+        content=buffer.getvalue(),
+        manifest=manifest,
+    )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import zipfile
+from io import BytesIO
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -21,6 +24,7 @@ def test_dashboard_contract() -> None:
     assert "not a penetration test" in response.text
     assert "name='url'" in response.text
     assert "/report?demo=true" in response.text
+    assert "/export?demo=true" in response.text
 
 
 def test_demo_api() -> None:
@@ -59,6 +63,7 @@ def test_live_dashboard_uses_assessment(
     assert response.status_code == 200
     assert "value='example.com'" in response.text
     assert "/report?url=example.com" in response.text
+    assert "/export?url=example.com" in response.text
 
 
 def test_dashboard_displays_safe_error(
@@ -83,4 +88,21 @@ def test_demo_report_route() -> None:
 
 def test_report_requires_target() -> None:
     response = client.get("/report")
+    assert response.status_code == 400
+
+
+def test_demo_export_route() -> None:
+    response = client.get("/export", params={"demo": "true"})
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+    assert "veridra-demo.veridra.local-evidence.zip" in response.headers[
+        "content-disposition"
+    ]
+    assert response.headers["x-content-type-options"] == "nosniff"
+    with zipfile.ZipFile(BytesIO(response.content)) as archive:
+        assert "manifest.sha256" in archive.namelist()
+
+
+def test_export_requires_target() -> None:
+    response = client.get("/export")
     assert response.status_code == 400

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from io import BytesIO
+
+from veridra.core import demo_assessment
+from veridra.exports import build_evidence_package
+
+
+def test_evidence_package_is_deterministic() -> None:
+    assessment = demo_assessment()
+    first = build_evidence_package(assessment)
+    second = build_evidence_package(assessment)
+
+    assert first.content == second.content
+    assert first.filename == "veridra-demo.veridra.local-evidence.zip"
+
+
+def test_evidence_package_contents_and_manifest() -> None:
+    package = build_evidence_package(demo_assessment())
+
+    with zipfile.ZipFile(BytesIO(package.content)) as archive:
+        assert set(archive.namelist()) == {
+            "assessment.json",
+            "report.html",
+            "manifest.sha256",
+        }
+        assessment_json = archive.read("assessment.json")
+        report_html = archive.read("report.html")
+        manifest_text = archive.read("manifest.sha256").decode("utf-8")
+
+    payload = json.loads(assessment_json)
+    assert payload["mode"] == "demo"
+    assert b"Veridra assessment report" in report_html
+    assert hashlib.sha256(assessment_json).hexdigest() in manifest_text
+    assert hashlib.sha256(report_html).hexdigest() in manifest_text


### PR DESCRIPTION
## Scope

Implements issue #10:

- exports assessment JSON, printable HTML, and SHA-256 manifest in one ZIP;
- uses fixed ZIP metadata for reproducible package bytes;
- adds safe hostname-based filenames;
- exposes loopback-local demo and live export routes;
- adds package integrity, deterministic-byte, and route tests;
- extends the deterministic audit and CI artifact output.

## Explicit exclusions

No PDF engine, email delivery, cloud storage, persistence database, accounts, billing, or public deployment.

## Required proof

- Ruff
- strict mypy
- pytest
- deterministic audit
- exact-head GitHub Actions success

Closes #10 after verified merge.