### PR TITLE
Add browser-based visual and accessibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
           python-version: "3.11"
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -e ".[dev]"
+      - name: Install Chromium
+        run: python -m playwright install --with-deps chromium
       - name: Ruff
         shell: bash
         run: |
@@ -38,6 +40,12 @@ jobs:
           mkdir -p artifacts/ci
           set -o pipefail
           python -m veridra.audit 2>&1 | tee artifacts/ci/audit.log
+      - name: Browser audit
+        shell: bash
+        run: |
+          mkdir -p artifacts/ci
+          set -o pipefail
+          python tools/browser_audit.py 2>&1 | tee artifacts/ci/browser-audit.log
       - name: Upload verification evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,14 @@ requires-python = ">=3.11"
 dependencies = ["fastapi>=0.115,<1", "httpx>=0.27,<1", "pydantic>=2.8,<3", "uvicorn>=0.30,<1"]
 
 [project.optional-dependencies]
-dev = ["mypy>=1.11,<2", "pytest>=8,<9", "pytest-asyncio>=0.24,<1", "pytest-cov>=5,<7", "ruff>=0.6,<1"]
+dev = [
+    "mypy>=1.11,<2",
+    "playwright>=1.52,<2",
+    "pytest>=8,<9",
+    "pytest-asyncio>=0.24,<1",
+    "pytest-cov>=5,<7",
+    "ruff>=0.6,<1",
+]
 
 [project.scripts]
 veridra-api = "veridra.app:main"

--- a/tools/browser_audit.py
+++ b/tools/browser_audit.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.request import urlopen
+
+from playwright.sync_api import Page, sync_playwright
+
+OUTPUT = Path("artifacts/browser")
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_until_ready(url: str, timeout: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(f"{url}/health", timeout=1) as response:
+                if response.status == 200:
+                    return
+        except OSError:
+            time.sleep(0.2)
+    raise RuntimeError("Veridra did not become ready for browser auditing.")
+
+
+def _keyboard_contract(page: Page) -> bool:
+    page.locator("body").click(position={"x": 1, "y": 1})
+    input_reached = False
+    for _ in range(12):
+        page.keyboard.press("Tab")
+        if page.evaluate("document.activeElement && document.activeElement.id") == "url":
+            input_reached = True
+            break
+    if not input_reached:
+        return False
+    page.keyboard.press("Tab")
+    return page.evaluate(
+        "document.activeElement && document.activeElement.textContent.trim()"
+    ) == "Run assessment"
+
+
+def _check_viewport(page: Page, name: str, width: int, height: int) -> dict[str, bool]:
+    page.set_viewport_size({"width": width, "height": height})
+    page.goto(page.url, wait_until="networkidle")
+    checks = {
+        "single_main_heading": page.locator("main h2").count() == 1,
+        "navigation_landmark": page.locator("nav").count() == 1,
+        "labelled_url_input": page.get_by_label("Public website").count() == 1,
+        "primary_action": page.get_by_role("button", name="Run assessment").count() == 1,
+        "report_action": page.get_by_role("link", name="Open report").count() == 1,
+        "no_horizontal_overflow": bool(
+            page.evaluate(
+                "document.documentElement.scrollWidth <= window.innerWidth"
+            )
+        ),
+        "keyboard_navigation": _keyboard_contract(page),
+    }
+    page.screenshot(path=OUTPUT / f"dashboard-{name}.png", full_page=True)
+    return checks
+
+
+def main() -> None:
+    OUTPUT.mkdir(parents=True, exist_ok=True)
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "veridra.app:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    report: dict[str, object] = {"passed": False, "checks": {}}
+    try:
+        _wait_until_ready(base_url)
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch()
+            page = browser.new_page()
+            page.goto(base_url, wait_until="networkidle")
+            checks = {
+                "desktop": _check_viewport(page, "desktop", 1440, 1000),
+                "mobile": _check_viewport(page, "mobile", 390, 844),
+            }
+            browser.close()
+        passed = all(all(values.values()) for values in checks.values())
+        report = {"passed": passed, "checks": checks}
+    except Exception as exc:
+        report = {"passed": False, "checks": {}, "error": str(exc)}
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+        (OUTPUT / "browser-audit.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    raise SystemExit(0 if report["passed"] else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Scope

Implements issue #14 with deterministic real-browser acceptance checks:

- launches the loopback-only Veridra app in CI;
- runs Chromium at approved desktop and mobile widths;
- verifies heading, navigation, labelled input, primary/report actions, keyboard reachability, and horizontal overflow;
- captures desktop and mobile screenshots;
- writes a machine-readable browser audit report;
- uploads all browser evidence even when another gate fails.

## Safety boundary

The browser audit uses only the deterministic demo dashboard. It does not access public websites or alter collector behavior.

## Required proof

- Ruff
- strict mypy
- pytest
- deterministic audit
- Chromium browser audit
- exact-head GitHub Actions success

Closes #14 after verified merge.