### PR TITLE
Align release metadata and delivery documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@ Automated website assessment for visibility, AI discoverability, trust signals, 
 
 ## Current vertical slice
 
-- deterministic demo assessment;
-- evidence model and findings;
-- checks for page structure, AI crawler readiness and public security headers;
-- responsive operator dashboard;
-- JSON demo API;
-- deterministic repository audit;
-- Ruff, strict mypy, pytest and GitHub Actions verification.
+- bounded live public-website assessment with DNS/IP validation and pinned connections;
+- redirect revalidation, response-size limits, and loopback-only operation;
+- deterministic demo assessment for testing and review;
+- evidence-backed findings for page structure, search readiness, AI crawler access, trust signals, and passive public security headers;
+- homepage and `robots.txt` evidence collection without authentication or active scanning;
+- responsive operator dashboard and JSON API;
+- printable HTML reports with metadata, per-area summaries, prioritised findings, evidence, and recommendations;
+- deterministic ZIP evidence packages containing JSON, HTML, and a SHA-256 manifest;
+- Ruff, strict mypy, pytest, deterministic repository audit, and Chromium browser acceptance checks in GitHub Actions;
+- desktop and mobile screenshots plus machine-readable audit artifacts retained by CI.
 
 ## Run locally
 
@@ -29,4 +32,4 @@ Veridra is limited to bounded public evidence collection. It is not a penetratio
 
 ## Development status
 
-This repository is temporarily public during development and is intended to become private after completion.
+The verified local MVP is under active development. Public multi-tenant deployment, accounts, billing, external backlink providers, and sampled LLM visibility checks remain deferred until their operational and commercial requirements are justified.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,16 +6,19 @@
 - Bounded public-target collector with DNS/IP validation and pinned connections.
 - Redirect revalidation, response limits, and loopback-only API.
 - Live dashboard workflow and printable HTML report.
+- Assessment metadata, deterministic prioritisation, and per-area summaries.
+- Expanded robots.txt interpretation and passive discoverability/trust signals.
+- Deterministic ZIP evidence packages with JSON, HTML, and SHA-256 manifest.
 - GitHub Actions verification with preserved diagnostic artifacts.
+- Chromium desktop/mobile visual and accessibility acceptance checks.
 
 ## Next
 
-1. Expand deterministic assessment rules and robots.txt interpretation.
-2. Improve report prioritisation and evidence detail.
-3. Add browser-based visual and accessibility checks in CI.
-4. Add controlled DNS and email-domain posture checks.
-5. Add optional provider adapters for backlinks and sampled AI visibility.
-6. Prepare deployment controls, rate limiting, job isolation, and data retention.
+1. Add controlled DNS and email-domain posture checks with deterministic resolver fixtures.
+2. Improve dashboard information architecture and finding filters using browser evidence.
+3. Add safe local assessment history and comparison without multi-tenant exposure.
+4. Define deployment controls: rate limiting, bounded concurrency, job isolation, abuse monitoring, and retention.
+5. Add optional provider interfaces for backlinks and sampled AI visibility only after commercial validation.
 
 ## Deferred until justified
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "veridra"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Automated website visibility, AI discoverability, trust, health and public security posture assessment"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,6 +23,9 @@ dev = [
 [project.scripts]
 veridra-api = "veridra.app:main"
 veridra-audit = "veridra.audit:main"
+
+[tool.setuptools.dynamic]
+version = {attr = "veridra.version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/veridra/app.py
+++ b/src/veridra/app.py
@@ -11,8 +11,9 @@ from .core import Assessment, UnsafeTargetError, demo_assessment
 from .exports import build_evidence_package
 from .reports import render_report
 from .service import assess_url
+from .version import __version__
 
-app = FastAPI(title="Veridra", version="0.4.0")
+app = FastAPI(title="Veridra", version=__version__)
 
 
 def dashboard(

--- a/src/veridra/version.py
+++ b/src/veridra/version.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__version__ = "0.5.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from importlib.metadata import version
+
+from veridra.app import app
+from veridra.version import __version__
+
+
+def test_application_and_package_versions_match() -> None:
+    assert app.version == __version__
+    assert version("veridra") == __version__


### PR DESCRIPTION
## Scope

Implements issue #16:

- introduces `veridra.version.__version__` as the single version source;
- uses it for package and FastAPI metadata;
- adds a regression test preventing version drift;
- refreshes README capabilities to match the implemented product;
- refreshes the roadmap so completed work is no longer listed as pending.

## Required proof

- Ruff
- strict mypy
- pytest
- deterministic audit
- Chromium browser audit
- exact-head GitHub Actions success

Closes #16 after verified merge.