### PR TITLE
Add bounded DNS and email-domain posture checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,13 @@ dynamic = ["version"]
 description = "Automated website visibility, AI discoverability, trust, health and public security posture assessment"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["fastapi>=0.115,<1", "httpx>=0.27,<1", "pydantic>=2.8,<3", "uvicorn>=0.30,<1"]
+dependencies = [
+    "dnspython>=2.7,<3",
+    "fastapi>=0.115,<1",
+    "httpx>=0.27,<1",
+    "pydantic>=2.8,<3",
+    "uvicorn>=0.30,<1",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/src/veridra/dns_posture.py
+++ b/src/veridra/dns_posture.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import dns.exception
+import dns.resolver
+
+from .core import Finding, Status
+
+
+class DnsLookupError(RuntimeError):
+    pass
+
+
+RecordLookup = Callable[[str, str], list[str]]
+
+
+@dataclass(frozen=True)
+class DomainPosture:
+    domain: str
+    nameservers: tuple[str, ...] | None
+    mail_exchangers: tuple[str, ...] | None
+    txt_records: tuple[str, ...] | None
+    dmarc_records: tuple[str, ...] | None
+
+
+def live_lookup(name: str, record_type: str) -> list[str]:
+    resolver = dns.resolver.Resolver(configure=True)
+    resolver.timeout = 2.0
+    resolver.lifetime = 4.0
+    try:
+        answer = resolver.resolve(name, record_type, search=False)
+    except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+        return []
+    except (dns.resolver.NoNameservers, dns.exception.Timeout) as exc:
+        raise DnsLookupError(f"DNS lookup failed for {name} {record_type}: {exc}") from exc
+    return [str(item).strip().strip('"') for item in answer]
+
+
+def _safe_lookup(lookup: RecordLookup, name: str, record_type: str) -> tuple[str, ...] | None:
+    try:
+        return tuple(sorted(set(lookup(name, record_type))))
+    except DnsLookupError:
+        return None
+
+
+def collect_domain_posture(
+    domain: str,
+    *,
+    lookup: RecordLookup = live_lookup,
+) -> DomainPosture:
+    normalized = domain.rstrip(".").lower()
+    return DomainPosture(
+        domain=normalized,
+        nameservers=_safe_lookup(lookup, normalized, "NS"),
+        mail_exchangers=_safe_lookup(lookup, normalized, "MX"),
+        txt_records=_safe_lookup(lookup, normalized, "TXT"),
+        dmarc_records=_safe_lookup(lookup, f"_dmarc.{normalized}", "TXT"),
+    )
+
+
+def _unavailable(identifier: str, title: str, recommendation: str) -> Finding:
+    return Finding(
+        id=identifier,
+        area="Trust signals",
+        title=title,
+        status=Status.unavailable,
+        severity="low",
+        summary=f"{title} could not be verified within the bounded DNS lookup.",
+        recommendation=recommendation,
+    )
+
+
+def analyze_domain_posture(posture: DomainPosture) -> list[Finding]:
+    nameservers = posture.nameservers
+    if nameservers is None:
+        nameserver_finding = _unavailable(
+            "dns.nameservers",
+            "Authoritative nameservers",
+            "Retry later or verify delegation with the domain operator.",
+        )
+    else:
+        redundant = len(nameservers) >= 2
+        nameserver_finding = Finding(
+            id="dns.nameservers",
+            area="Trust signals",
+            title="Authoritative nameservers",
+            status=Status.passed if redundant else Status.attention,
+            severity="info" if redundant else "medium",
+            summary=f"{len(nameservers)} authoritative nameserver records were found.",
+            recommendation=(
+                None
+                if redundant
+                else "Use at least two authoritative nameservers on independent infrastructure."
+            ),
+            evidence={"nameservers": list(nameservers)},
+        )
+
+    mail_exchangers = posture.mail_exchangers
+    if mail_exchangers is None:
+        mx_finding = _unavailable(
+            "email.mx",
+            "Mail exchanger records",
+            "Retry later or verify the domain MX records.",
+        )
+    else:
+        present = bool(mail_exchangers)
+        mx_finding = Finding(
+            id="email.mx",
+            area="Trust signals",
+            title="Mail exchanger records",
+            status=Status.passed if present else Status.attention,
+            severity="info" if present else "medium",
+            summary=(
+                "Public mail exchanger records are present."
+                if present
+                else "No public mail exchanger records were returned."
+            ),
+            recommendation=(
+                None
+                if present
+                else "Publish MX records when the domain should receive email, or document that it is intentionally non-mail-enabled."
+            ),
+            evidence={"mail_exchangers": list(mail_exchangers)},
+        )
+
+    txt_records = posture.txt_records
+    if txt_records is None:
+        spf_finding = _unavailable(
+            "email.spf",
+            "SPF policy",
+            "Retry later or verify the domain TXT records.",
+        )
+    else:
+        spf_records = tuple(record for record in txt_records if record.lower().startswith("v=spf1"))
+        valid = len(spf_records) == 1
+        spf_finding = Finding(
+            id="email.spf",
+            area="Trust signals",
+            title="SPF policy",
+            status=Status.passed if valid else Status.attention,
+            severity="info" if valid else "medium",
+            summary=(
+                "Exactly one SPF policy was found."
+                if valid
+                else f"Expected exactly one SPF policy; found {len(spf_records)}."
+            ),
+            recommendation=(
+                None
+                if valid
+                else "Publish exactly one SPF record and consolidate all permitted senders into it."
+            ),
+            evidence={"spf_records": list(spf_records)},
+        )
+
+    dmarc_records = posture.dmarc_records
+    if dmarc_records is None:
+        dmarc_finding = _unavailable(
+            "email.dmarc",
+            "DMARC policy",
+            "Retry later or verify the _dmarc TXT record.",
+        )
+    else:
+        candidates = tuple(
+            record for record in dmarc_records if record.lower().startswith("v=dmarc1")
+        )
+        record = candidates[0] if len(candidates) == 1 else ""
+        tags = {
+            key.strip().lower(): value.strip().lower()
+            for part in record.split(";")
+            if "=" in part
+            for key, value in [part.split("=", 1)]
+        }
+        policy = tags.get("p")
+        valid = len(candidates) == 1 and policy is not None
+        enforcing = policy in {"quarantine", "reject"}
+        dmarc_finding = Finding(
+            id="email.dmarc",
+            area="Trust signals",
+            title="DMARC policy",
+            status=Status.passed if valid and enforcing else Status.attention,
+            severity="info" if valid and enforcing else "medium",
+            summary=(
+                f"A DMARC policy with p={policy} is published."
+                if valid
+                else f"Expected one valid DMARC policy; found {len(candidates)}."
+            ),
+            recommendation=(
+                None
+                if valid and enforcing
+                else "Publish one valid DMARC record and progress from monitoring to quarantine or reject when ready."
+            ),
+            evidence={"dmarc_records": list(candidates), "policy": policy},
+        )
+
+    return [nameserver_finding, mx_finding, spf_finding, dmarc_finding]

--- a/src/veridra/dns_posture.py
+++ b/src/veridra/dns_posture.py
@@ -34,11 +34,17 @@ def live_lookup(name: str, record_type: str) -> list[str]:
     except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
         return []
     except (dns.resolver.NoNameservers, dns.exception.Timeout) as exc:
-        raise DnsLookupError(f"DNS lookup failed for {name} {record_type}: {exc}") from exc
+        raise DnsLookupError(
+            f"DNS lookup failed for {name} {record_type}: {exc}"
+        ) from exc
     return [str(item).strip().strip('"') for item in answer]
 
 
-def _safe_lookup(lookup: RecordLookup, name: str, record_type: str) -> tuple[str, ...] | None:
+def _safe_lookup(
+    lookup: RecordLookup,
+    name: str,
+    record_type: str,
+) -> tuple[str, ...] | None:
     try:
         return tuple(sorted(set(lookup(name, record_type))))
     except DnsLookupError:
@@ -60,7 +66,11 @@ def collect_domain_posture(
     )
 
 
-def _unavailable(identifier: str, title: str, recommendation: str) -> Finding:
+def _unavailable(
+    identifier: str,
+    title: str,
+    recommendation: str,
+) -> Finding:
     return Finding(
         id=identifier,
         area="Trust signals",
@@ -92,7 +102,10 @@ def analyze_domain_posture(posture: DomainPosture) -> list[Finding]:
             recommendation=(
                 None
                 if redundant
-                else "Use at least two authoritative nameservers on independent infrastructure."
+                else (
+                    "Use at least two authoritative nameservers on independent "
+                    "infrastructure."
+                )
             ),
             evidence={"nameservers": list(nameservers)},
         )
@@ -120,7 +133,10 @@ def analyze_domain_posture(posture: DomainPosture) -> list[Finding]:
             recommendation=(
                 None
                 if present
-                else "Publish MX records when the domain should receive email, or document that it is intentionally non-mail-enabled."
+                else (
+                    "Publish MX records when the domain should receive email, "
+                    "or document that it is intentionally non-mail-enabled."
+                )
             ),
             evidence={"mail_exchangers": list(mail_exchangers)},
         )
@@ -133,7 +149,11 @@ def analyze_domain_posture(posture: DomainPosture) -> list[Finding]:
             "Retry later or verify the domain TXT records.",
         )
     else:
-        spf_records = tuple(record for record in txt_records if record.lower().startswith("v=spf1"))
+        spf_records = tuple(
+            record
+            for record in txt_records
+            if record.lower().startswith("v=spf1")
+        )
         valid = len(spf_records) == 1
         spf_finding = Finding(
             id="email.spf",
@@ -149,7 +169,10 @@ def analyze_domain_posture(posture: DomainPosture) -> list[Finding]:
             recommendation=(
                 None
                 if valid
-                else "Publish exactly one SPF record and consolidate all permitted senders into it."
+                else (
+                    "Publish exactly one SPF record and consolidate all permitted "
+                    "senders into it."
+                )
             ),
             evidence={"spf_records": list(spf_records)},
         )
@@ -163,7 +186,9 @@ def analyze_domain_posture(posture: DomainPosture) -> list[Finding]:
         )
     else:
         candidates = tuple(
-            record for record in dmarc_records if record.lower().startswith("v=dmarc1")
+            record
+            for record in dmarc_records
+            if record.lower().startswith("v=dmarc1")
         )
         record = candidates[0] if len(candidates) == 1 else ""
         tags = {
@@ -189,7 +214,10 @@ def analyze_domain_posture(posture: DomainPosture) -> list[Finding]:
             recommendation=(
                 None
                 if valid and enforcing
-                else "Publish one valid DMARC record and progress from monitoring to quarantine or reject when ready."
+                else (
+                    "Publish one valid DMARC record and progress from monitoring "
+                    "to quarantine or reject when ready."
+                )
             ),
             evidence={"dmarc_records": list(candidates), "policy": policy},
         )

--- a/src/veridra/service.py
+++ b/src/veridra/service.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 from time import perf_counter
+from urllib.parse import urlparse
 
 from .collector import Requester, SiteEvidence, _request_once, collect_site
 from .core import Assessment, Finding, Status, analyze_document
+from .dns_posture import (
+    RecordLookup,
+    analyze_domain_posture,
+    collect_domain_posture,
+    live_lookup,
+)
 
 
 def _transport_findings(evidence: SiteEvidence) -> list[Finding]:
@@ -60,6 +67,7 @@ def assess_url(
     raw_url: str,
     *,
     requester: Requester = _request_once,
+    dns_lookup: RecordLookup = live_lookup,
 ) -> Assessment:
     started = perf_counter()
     evidence = collect_site(raw_url, requester=requester)
@@ -72,6 +80,13 @@ def assess_url(
             robots_text,
         )
     )
+    hostname = urlparse(evidence.homepage.final_url).hostname
+    if hostname is not None:
+        findings.extend(
+            analyze_domain_posture(
+                collect_domain_posture(hostname, lookup=dns_lookup)
+            )
+        )
     elapsed_ms = round((perf_counter() - started) * 1000)
     return Assessment.build(
         evidence.homepage.final_url,

--- a/src/veridra/version.py
+++ b/src/veridra/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/tests/test_dns_posture.py
+++ b/tests/test_dns_posture.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from veridra.core import Status
+from veridra.dns_posture import (
+    DnsLookupError,
+    analyze_domain_posture,
+    collect_domain_posture,
+)
+
+
+def test_complete_domain_posture_passes() -> None:
+    records = {
+        ("example.com", "NS"): ["ns1.example.net.", "ns2.example.net."],
+        ("example.com", "MX"): ["10 mail.example.com."],
+        ("example.com", "TXT"): ["v=spf1 include:_spf.example.net -all"],
+        ("_dmarc.example.com", "TXT"): ["v=DMARC1; p=reject; rua=mailto:dmarc@example.com"],
+    }
+
+    posture = collect_domain_posture(
+        "Example.COM.",
+        lookup=lambda name, record_type: records.get((name, record_type), []),
+    )
+    findings = {item.id: item for item in analyze_domain_posture(posture)}
+
+    assert posture.domain == "example.com"
+    assert all(item.status == Status.passed for item in findings.values())
+    assert findings["email.dmarc"].evidence["policy"] == "reject"
+
+
+def test_missing_and_monitoring_records_need_attention() -> None:
+    records = {
+        ("example.com", "NS"): ["ns1.example.net."],
+        ("example.com", "MX"): [],
+        ("example.com", "TXT"): [
+            "v=spf1 -all",
+            "v=spf1 include:mail.example.net -all",
+        ],
+        ("_dmarc.example.com", "TXT"): ["v=DMARC1; p=none"],
+    }
+
+    posture = collect_domain_posture(
+        "example.com",
+        lookup=lambda name, record_type: records.get((name, record_type), []),
+    )
+    findings = {item.id: item for item in analyze_domain_posture(posture)}
+
+    assert findings["dns.nameservers"].status == Status.attention
+    assert findings["email.mx"].status == Status.attention
+    assert findings["email.spf"].status == Status.attention
+    assert findings["email.dmarc"].status == Status.attention
+    assert findings["email.dmarc"].evidence["policy"] == "none"
+
+
+def test_lookup_failures_are_unavailable() -> None:
+    def failing_lookup(name: str, record_type: str) -> list[str]:
+        raise DnsLookupError(f"unavailable: {name} {record_type}")
+
+    posture = collect_domain_posture("example.com", lookup=failing_lookup)
+    findings = analyze_domain_posture(posture)
+
+    assert all(item.status == Status.unavailable for item in findings)
+
+
+def test_no_dmarc_record_is_attention() -> None:
+    posture = collect_domain_posture(
+        "example.com",
+        lookup=lambda name, record_type: [],
+    )
+    findings = {item.id: item for item in analyze_domain_posture(posture)}
+
+    assert findings["email.dmarc"].status == Status.attention
+    assert findings["email.dmarc"].evidence["dmarc_records"] == []


### PR DESCRIPTION
## Scope

Implements issue #18:

- bounded NS, MX, TXT, and _dmarc TXT lookups;
- strict resolver timeout and lifetime limits;
- authoritative nameserver redundancy finding;
- MX availability finding;
- SPF uniqueness finding;
- DMARC validity and enforcement finding;
- resolver failures represented as unavailable rather than failed posture;
- injectable DNS lookup fixtures for deterministic tests;
- application version advanced to 0.6.0.

## Safety boundary

Passive DNS only. No SMTP connections, email sending, zone transfers, subdomain enumeration, DKIM selector guessing, or active security testing.

## Required proof

- Ruff
- strict mypy
- pytest
- deterministic audit
- Chromium browser audit
- exact-head GitHub Actions success

Closes #18 after verified merge.