### PR TITLE
Add finding filters and dedicated area views

### DIFF
--- a/src/veridra/app.py
+++ b/src/veridra/app.py
@@ -7,13 +7,22 @@ from fastapi import FastAPI, HTTPException, Query, Response
 from fastapi.responses import HTMLResponse
 
 from .collector import CollectionError
-from .core import Assessment, Status, UnsafeTargetError, demo_assessment
+from .core import Assessment, Finding, Status, UnsafeTargetError, demo_assessment
 from .exports import build_evidence_package
 from .reports import render_report
 from .service import assess_url
 from .version import __version__
 
 app = FastAPI(title="Veridra", version=__version__)
+
+_AREAS = (
+    "Website health",
+    "Search visibility",
+    "AI discoverability",
+    "Trust signals",
+    "Security posture",
+)
+_STATUSES = ("passed", "attention", "unavailable")
 
 
 def _summary_cards(assessment: Assessment) -> str:
@@ -54,10 +63,45 @@ def _area_rows(assessment: Assessment) -> str:
     )
 
 
-def _finding_rows(assessment: Assessment) -> str:
+def _filtered_findings(
+    assessment: Assessment,
+    area: str | None,
+    status: str | None,
+) -> list[Finding]:
+    if area is not None and area not in _AREAS:
+        raise HTTPException(status_code=400, detail="Unknown assessment area.")
+    if status is not None and status not in _STATUSES:
+        raise HTTPException(status_code=400, detail="Unknown finding status.")
+    return [
+        item
+        for item in assessment.findings
+        if (area is None or item.area == area)
+        and (status is None or item.status.value == status)
+    ]
+
+
+def _finding_rows(findings: list[Finding]) -> str:
+    if not findings:
+        return "<tr><td colspan='5' class='empty'>No findings match the selected filters.</td></tr>"
     return "".join(
         f"<tr><td><span class='pill {item.status}'>{html.escape(item.status.value)}</span></td><td>{html.escape(item.area)}</td><td><strong>{html.escape(item.title)}</strong></td><td>{html.escape(item.summary)}</td><td>{html.escape(item.recommendation or 'No action required.')}</td></tr>"
-        for item in assessment.findings
+        for item in findings
+    )
+
+
+def _query_base(submitted_url: str, demo_mode: bool) -> dict[str, str]:
+    return {"demo": "true"} if demo_mode else {"url": submitted_url}
+
+
+def _nav_links(base: dict[str, str], selected_area: str | None) -> str:
+    links = [("Overview", None), *((area, area) for area in _AREAS)]
+    return "".join(
+        "<a class='{active}' href='/?{query}'>{label}</a>".format(
+            active="active" if area == selected_area else "",
+            query=html.escape(urlencode({**base, **({"area": area} if area else {})}), quote=True),
+            label=html.escape(label),
+        )
+        for label, area in links
     )
 
 
@@ -67,21 +111,36 @@ def dashboard(
     submitted_url: str = "",
     error: str | None = None,
     demo_mode: bool = False,
+    area: str | None = None,
+    status: str | None = None,
 ) -> str:
+    findings = _filtered_findings(assessment, area, status)
     cards = _summary_cards(assessment)
     priorities = _priority_actions(assessment)
     area_rows = _area_rows(assessment)
-    rows = _finding_rows(assessment)
+    rows = _finding_rows(findings)
     escaped_url = html.escape(submitted_url, quote=True)
-    error_panel = (
-        f"<div class='error' role='alert'>{html.escape(error)}</div>" if error else ""
+    error_panel = f"<div class='error' role='alert'>{html.escape(error)}</div>" if error else ""
+    base = _query_base(submitted_url, demo_mode)
+    report_link = f"/report?{urlencode(base)}"
+    export_link = f"/export?{urlencode(base)}"
+    nav_links = _nav_links(base, area)
+    area_options = "<option value=''>All areas</option>" + "".join(
+        f"<option value='{html.escape(value, quote=True)}'{' selected' if value == area else ''}>{html.escape(value)}</option>"
+        for value in _AREAS
     )
-    query = urlencode({"demo": "true"}) if demo_mode else urlencode({"url": submitted_url})
-    report_link = f"/report?{query}"
-    export_link = f"/export?{query}"
+    status_options = "<option value=''>All statuses</option>" + "".join(
+        f"<option value='{value}'{' selected' if value == status else ''}>{value.title()}</option>"
+        for value in _STATUSES
+    )
+    hidden_target = (
+        "<input type='hidden' name='demo' value='true'>"
+        if demo_mode
+        else f"<input type='hidden' name='url' value='{escaped_url}'>"
+    )
     return f"""<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>Veridra</title><style>
-*{{box-sizing:border-box}}html,body{{max-width:100%;overflow-x:hidden}}body{{margin:0;font:14px Arial,sans-serif;background:#f7f8fa;color:#17191c}}aside{{position:fixed;inset:0 auto 0 0;width:230px;background:#f1f3f6;padding:28px 18px;border-right:1px solid #e0e3e8}}aside h1{{margin:0 0 36px;font-size:24px}}nav a{{display:block;padding:12px;border-radius:8px;color:#333;text-decoration:none;margin:4px 0}}nav a.active{{background:#dde1e6;font-weight:700}}main{{margin-left:230px;padding:42px;max-width:1600px;min-width:0}}header{{display:flex;justify-content:space-between;gap:24px;align-items:start;border-bottom:1px solid #e2e5e9;padding-bottom:24px;min-width:0}}h2{{font-size:28px;margin:0}}h3{{margin-top:0}}.muted{{color:#6c737d}}form{{display:flex;gap:8px;min-width:min(620px,100%);max-width:100%}}input{{flex:1;min-width:220px;max-width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px}}button,.button{{border:0;border-radius:7px;background:#22272d;color:white;padding:11px 16px;text-decoration:none;cursor:pointer}}.button.secondary{{background:#59616b}}.actions{{display:flex;gap:8px;align-items:center;flex-wrap:wrap}}.cards{{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:14px;margin:24px 0}}article{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:18px;min-width:0}}article span{{display:block;color:#6c737d;text-transform:uppercase;font-size:12px}}article strong{{display:block;font-size:28px;margin-top:10px}}.overview-grid{{display:grid;grid-template-columns:minmax(0,1.4fr) minmax(0,.8fr);gap:18px;margin-bottom:18px;min-width:0}}.overview-grid>section{{min-width:0}}section{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:20px;margin-bottom:18px;min-width:0}}.priority-list{{list-style:none;margin:0;padding:0}}.priority-list li{{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,.7fr);gap:18px;padding:16px 0;border-bottom:1px solid #e8eaed;min-width:0}}.priority-list li:last-child{{border-bottom:0}}.priority-list strong{{display:block;font-size:15px;margin:4px 0}}.priority-list p{{margin:4px 0;line-height:1.45;overflow-wrap:anywhere}}.eyebrow{{font-size:11px;text-transform:uppercase;color:#69717b}}.recommendation{{color:#4f5863}}table{{width:100%;max-width:100%;border-collapse:collapse;table-layout:fixed}}th,td{{text-align:left;padding:13px;border-bottom:1px solid #e8eaed;vertical-align:top;overflow-wrap:anywhere}}th{{font-size:11px;text-transform:uppercase;color:#69717b}}.pill{{display:inline-block;padding:4px 8px;border-radius:999px;border:1px solid}}.passed{{color:#16794a;background:#f0faf5}}.attention{{color:#946200;background:#fff9e8}}.unavailable{{color:#5f6873;background:#f3f4f6}}.error{{margin-top:18px;padding:13px;border-left:3px solid #b42318;background:#fff1f0;color:#7a271a}}@media(max-width:1100px){{.overview-grid{{grid-template-columns:1fr}}}}@media(max-width:1000px){{header{{display:block}}form{{margin-top:18px}}}}@media(max-width:800px){{aside{{position:static;width:auto}}main{{margin:0;padding:20px}}.cards{{grid-template-columns:repeat(2,minmax(0,1fr))}}table{{display:block;overflow:auto}}form{{display:block;min-width:0}}input{{width:100%;min-width:0;margin-bottom:8px}}.priority-list li{{grid-template-columns:1fr}}}}
-</style></head><body><aside><h1>Veridra</h1><nav><a class='active'>Overview</a><a>Website health</a><a>Search visibility</a><a>AI discoverability</a><a>Trust signals</a><a>Security posture</a><a href='{html.escape(report_link, quote=True)}'>Reports</a></nav></aside><main><header><div><h2>Website assessment</h2><p class='muted'>Visibility, trust and public security evidence.</p></div><div><form method='get' action='/'><label class='muted' for='url'>Public website</label><input id='url' name='url' type='text' maxlength='2048' placeholder='example.com' value='{escaped_url}' required><div class='actions'><button type='submit'>Run assessment</button><a class='button' href='{html.escape(report_link, quote=True)}'>Open report</a><a class='button secondary' href='{html.escape(export_link, quote=True)}'>Export evidence</a></div></form></div></header>{error_panel}<div class='cards'>{cards}</div><div class='overview-grid'><section aria-labelledby='priority-heading'><h3 id='priority-heading'>Priority actions</h3><p class='muted'>The first five attention findings in deterministic severity order.</p><ol class='priority-list'>{priorities}</ol></section><section aria-labelledby='areas-heading'><h3 id='areas-heading'>Assessment areas</h3><table><thead><tr><th>Area</th><th>Passed</th><th>Attention</th><th>Unavailable</th><th>Total</th></tr></thead><tbody>{area_rows}</tbody></table></section></div><section><h3>Evidence-backed findings</h3><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th></tr></thead><tbody>{rows}</tbody></table><p class='muted'>Scope: bounded public checks only. This is not a penetration test.</p></section></main></body></html>"""
+*{{box-sizing:border-box}}html,body{{max-width:100%;overflow-x:hidden}}body{{margin:0;font:14px Arial,sans-serif;background:#f7f8fa;color:#17191c}}aside{{position:fixed;inset:0 auto 0 0;width:230px;background:#f1f3f6;padding:28px 18px;border-right:1px solid #e0e3e8}}aside h1{{margin:0 0 36px;font-size:24px}}nav a{{display:block;padding:12px;border-radius:8px;color:#333;text-decoration:none;margin:4px 0}}nav a.active{{background:#dde1e6;font-weight:700}}main{{margin-left:230px;padding:42px;max-width:1600px;min-width:0}}header{{display:flex;justify-content:space-between;gap:24px;align-items:start;border-bottom:1px solid #e2e5e9;padding-bottom:24px;min-width:0}}h2{{font-size:28px;margin:0}}h3{{margin-top:0}}.muted{{color:#6c737d}}form{{display:flex;gap:8px;min-width:min(620px,100%);max-width:100%}}input,select{{flex:1;min-width:160px;max-width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px;background:white}}button,.button{{border:0;border-radius:7px;background:#22272d;color:white;padding:11px 16px;text-decoration:none;cursor:pointer}}.button.secondary{{background:#59616b}}.actions,.filters{{display:flex;gap:8px;align-items:center;flex-wrap:wrap}}.cards{{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:14px;margin:24px 0}}article{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:18px;min-width:0}}article span{{display:block;color:#6c737d;text-transform:uppercase;font-size:12px}}article strong{{display:block;font-size:28px;margin-top:10px}}.overview-grid{{display:grid;grid-template-columns:minmax(0,1.4fr) minmax(0,.8fr);gap:18px;margin-bottom:18px;min-width:0}}section{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:20px;margin-bottom:18px;min-width:0}}.priority-list{{list-style:none;margin:0;padding:0}}.priority-list li{{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,.7fr);gap:18px;padding:16px 0;border-bottom:1px solid #e8eaed}}.priority-list p{{overflow-wrap:anywhere}}.eyebrow{{font-size:11px;text-transform:uppercase;color:#69717b}}table{{width:100%;max-width:100%;border-collapse:collapse;table-layout:fixed}}th,td{{text-align:left;padding:13px;border-bottom:1px solid #e8eaed;vertical-align:top;overflow-wrap:anywhere}}th{{font-size:11px;text-transform:uppercase;color:#69717b}}.pill{{display:inline-block;padding:4px 8px;border-radius:999px;border:1px solid}}.passed{{color:#16794a;background:#f0faf5}}.attention{{color:#946200;background:#fff9e8}}.unavailable{{color:#5f6873;background:#f3f4f6}}.error{{margin-top:18px;padding:13px;border-left:3px solid #b42318;background:#fff1f0;color:#7a271a}}.finding-head{{display:flex;justify-content:space-between;gap:16px;align-items:end;flex-wrap:wrap}}.empty{{text-align:center;color:#69717b;padding:28px}}@media(max-width:1100px){{.overview-grid{{grid-template-columns:1fr}}}}@media(max-width:1000px){{header{{display:block}}form{{margin-top:18px}}}}@media(max-width:800px){{aside{{position:static;width:auto}}main{{margin:0;padding:20px}}.cards{{grid-template-columns:repeat(2,minmax(0,1fr))}}table{{display:block;overflow:auto}}form{{display:block;min-width:0}}input,select{{width:100%;min-width:0;margin-bottom:8px}}.priority-list li{{grid-template-columns:1fr}}}}
+</style></head><body><aside><h1>Veridra</h1><nav>{nav_links}<a href='{html.escape(report_link, quote=True)}'>Reports</a></nav></aside><main><header><div><h2>Website assessment</h2><p class='muted'>Visibility, trust and public security evidence.</p></div><div><form method='get' action='/'><label class='muted' for='url'>Public website</label><input id='url' name='url' type='text' maxlength='2048' placeholder='example.com' value='{escaped_url}' required><div class='actions'><button type='submit'>Run assessment</button><a class='button' href='{html.escape(report_link, quote=True)}'>Open report</a><a class='button secondary' href='{html.escape(export_link, quote=True)}'>Export evidence</a></div></form></div></header>{error_panel}<div class='cards'>{cards}</div><div class='overview-grid'><section aria-labelledby='priority-heading'><h3 id='priority-heading'>Priority actions</h3><p class='muted'>The first five attention findings in deterministic severity order.</p><ol class='priority-list'>{priorities}</ol></section><section aria-labelledby='areas-heading'><h3 id='areas-heading'>Assessment areas</h3><table><thead><tr><th>Area</th><th>Passed</th><th>Attention</th><th>Unavailable</th><th>Total</th></tr></thead><tbody>{area_rows}</tbody></table></section></div><section><div class='finding-head'><div><h3>Evidence-backed findings</h3><p class='muted'>{len(findings)} of {len(assessment.findings)} findings displayed.</p></div><form class='filters' method='get' action='/'>{hidden_target}<label for='area'>Area</label><select id='area' name='area'>{area_options}</select><label for='status'>Status</label><select id='status' name='status'>{status_options}</select><button type='submit'>Apply filters</button></form></div><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th></tr></thead><tbody>{rows}</tbody></table><p class='muted'>Scope: bounded public checks only. This is not a penetration test.</p></section></main></body></html>"""
 
 
 def _resolve_assessment(url: str | None, demo: bool) -> Assessment:
@@ -114,45 +173,29 @@ def assess(url: str = Query(min_length=1, max_length=2048)) -> dict[str, object]
 
 
 @app.get("/report", response_class=HTMLResponse)
-def report(
-    url: str | None = Query(default=None, min_length=1, max_length=2048),
-    demo: bool = False,
-) -> str:
+def report(url: str | None = Query(default=None, min_length=1, max_length=2048), demo: bool = False) -> str:
     return render_report(_resolve_assessment(url, demo))
 
 
 @app.get("/export")
-def export(
-    url: str | None = Query(default=None, min_length=1, max_length=2048),
-    demo: bool = False,
-) -> Response:
+def export(url: str | None = Query(default=None, min_length=1, max_length=2048), demo: bool = False) -> Response:
     package = build_evidence_package(_resolve_assessment(url, demo))
-    return Response(
-        content=package.content,
-        media_type="application/zip",
-        headers={
-            "Content-Disposition": f'attachment; filename="{package.filename}"',
-            "X-Content-Type-Options": "nosniff",
-        },
-    )
+    return Response(content=package.content, media_type="application/zip", headers={"Content-Disposition": f'attachment; filename="{package.filename}"', "X-Content-Type-Options": "nosniff"})
 
 
 @app.get("/", response_class=HTMLResponse)
 def index(
     url: str | None = Query(default=None, min_length=1, max_length=2048),
+    demo: bool = False,
+    area: str | None = Query(default=None, max_length=64),
+    status: str | None = Query(default=None, max_length=16),
 ) -> str:
-    if url is None:
-        return dashboard(demo_assessment(), demo_mode=True)
+    if demo or url is None:
+        return dashboard(demo_assessment(), demo_mode=True, area=area, status=status)
     try:
-        assessment = assess_url(url)
-        return dashboard(assessment, submitted_url=url)
+        return dashboard(assess_url(url), submitted_url=url, area=area, status=status)
     except (UnsafeTargetError, CollectionError) as exc:
-        return dashboard(
-            demo_assessment(),
-            submitted_url=url,
-            error=str(exc),
-            demo_mode=True,
-        )
+        return dashboard(demo_assessment(), submitted_url=url, error=str(exc), demo_mode=True, area=area, status=status)
 
 
 def main() -> None:

--- a/src/veridra/version.py
+++ b/src/veridra/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import veridra.app as app_module
+from veridra.app import app, dashboard
+from veridra.core import Assessment, Finding, Status
+
+client = TestClient(app)
+
+
+def _assessment() -> Assessment:
+    return Assessment.build(
+        "https://example.com",
+        [
+            Finding(
+                id="health-pass",
+                area="Website health",
+                title="Healthy",
+                status=Status.passed,
+                severity="info",
+                summary="Healthy response.",
+            ),
+            Finding(
+                id="security-attention",
+                area="Security posture",
+                title="Missing policy",
+                status=Status.attention,
+                severity="medium",
+                summary="Policy missing.",
+                recommendation="Publish the policy.",
+            ),
+        ],
+    )
+
+
+def test_dashboard_filters_by_area_and_status() -> None:
+    rendered = dashboard(
+        _assessment(),
+        demo_mode=True,
+        area="Security posture",
+        status="attention",
+    )
+    assert "1 of 2 findings displayed" in rendered
+    assert "Missing policy" in rendered
+    assert rendered.count("Healthy response.") == 0
+    assert "area=Security+posture" in rendered
+    assert "value='attention' selected" in rendered
+
+
+def test_dashboard_empty_filter_state() -> None:
+    rendered = dashboard(
+        _assessment(),
+        demo_mode=True,
+        area="Website health",
+        status="unavailable",
+    )
+    assert "0 of 2 findings displayed" in rendered
+    assert "No findings match the selected filters" in rendered
+
+
+def test_invalid_filters_are_rejected() -> None:
+    assert client.get("/", params={"demo": "true", "area": "Unknown"}).status_code == 400
+    assert client.get("/", params={"demo": "true", "status": "broken"}).status_code == 400
+
+
+def test_live_target_is_preserved_in_area_links(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(app_module, "assess_url", lambda url: _assessment())
+    response = client.get(
+        "/",
+        params={"url": "example.com", "area": "Security posture"},
+    )
+    assert response.status_code == 200
+    assert "url=example.com&amp;area=Website+health" in response.text
+    assert "2 findings" not in response.text
+    assert "1 of 2 findings displayed" in response.text

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -75,5 +75,5 @@ def test_live_target_is_preserved_in_area_links(
     )
     assert response.status_code == 200
     assert "url=example.com&amp;area=Website+health" in response.text
-    assert "2 findings" not in response.text
+    assert "value='example.com'" in response.text
     assert "1 of 2 findings displayed" in response.text


### PR DESCRIPTION
## Scope

Implements issue #26:

- server-side filters for assessment area and finding status;
- dedicated sidebar links for each assessment area;
- preservation of live target or demo mode while navigating;
- explicit displayed-finding counts and empty states;
- validation of filter inputs;
- complete-assessment priority actions and area summaries remain unchanged;
- application version advanced to 0.9.0;
- deterministic route and rendering tests.

## Required proof

- Ruff
- strict mypy
- pytest
- deterministic audit
- Chromium browser audit
- exact-head GitHub Actions success

Closes #26 after verified merge.