### PR TITLE
Add safe local assessment history and comparisons

### DIFF
--- a/src/veridra/app.py
+++ b/src/veridra/app.py
@@ -9,11 +9,13 @@ from fastapi.responses import HTMLResponse
 from .collector import CollectionError
 from .core import Assessment, Finding, Status, UnsafeTargetError, demo_assessment
 from .exports import build_evidence_package
+from .history_web import router as history_router
 from .reports import render_report
 from .service import assess_url
 from .version import __version__
 
 app = FastAPI(title="Veridra", version=__version__)
+app.include_router(history_router)
 
 _AREAS = (
     "Website health",
@@ -124,6 +126,7 @@ def dashboard(
     base = _query_base(submitted_url, demo_mode)
     report_link = f"/report?{urlencode(base)}"
     export_link = f"/export?{urlencode(base)}"
+    save_link = f"/history/save?{urlencode(base)}"
     nav_links = _nav_links(base, area)
     area_options = "<option value=''>All areas</option>" + "".join(
         f"<option value='{html.escape(value, quote=True)}'{' selected' if value == area else ''}>{html.escape(value)}</option>"
@@ -140,7 +143,7 @@ def dashboard(
     )
     return f"""<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>Veridra</title><style>
 *{{box-sizing:border-box}}html,body{{max-width:100%;overflow-x:hidden}}body{{margin:0;font:14px Arial,sans-serif;background:#f7f8fa;color:#17191c}}aside{{position:fixed;inset:0 auto 0 0;width:230px;background:#f1f3f6;padding:28px 18px;border-right:1px solid #e0e3e8}}aside h1{{margin:0 0 36px;font-size:24px}}nav a{{display:block;padding:12px;border-radius:8px;color:#333;text-decoration:none;margin:4px 0}}nav a.active{{background:#dde1e6;font-weight:700}}main{{margin-left:230px;padding:42px;max-width:1600px;min-width:0}}header{{display:flex;justify-content:space-between;gap:24px;align-items:start;border-bottom:1px solid #e2e5e9;padding-bottom:24px;min-width:0}}h2{{font-size:28px;margin:0}}h3{{margin-top:0}}.muted{{color:#6c737d}}form{{display:flex;gap:8px;min-width:min(620px,100%);max-width:100%}}input,select{{flex:1;min-width:160px;max-width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px;background:white}}button,.button{{border:0;border-radius:7px;background:#22272d;color:white;padding:11px 16px;text-decoration:none;cursor:pointer}}.button.secondary{{background:#59616b}}.actions,.filters{{display:flex;gap:8px;align-items:center;flex-wrap:wrap}}.cards{{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:14px;margin:24px 0}}article{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:18px;min-width:0}}article span{{display:block;color:#6c737d;text-transform:uppercase;font-size:12px}}article strong{{display:block;font-size:28px;margin-top:10px}}.overview-grid{{display:grid;grid-template-columns:minmax(0,1.4fr) minmax(0,.8fr);gap:18px;margin-bottom:18px;min-width:0}}section{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:20px;margin-bottom:18px;min-width:0}}.priority-list{{list-style:none;margin:0;padding:0}}.priority-list li{{display:grid;grid-template-columns:minmax(0,1fr) minmax(0,.7fr);gap:18px;padding:16px 0;border-bottom:1px solid #e8eaed}}.priority-list p{{overflow-wrap:anywhere}}.eyebrow{{font-size:11px;text-transform:uppercase;color:#69717b}}table{{width:100%;max-width:100%;border-collapse:collapse;table-layout:fixed}}th,td{{text-align:left;padding:13px;border-bottom:1px solid #e8eaed;vertical-align:top;overflow-wrap:anywhere}}th{{font-size:11px;text-transform:uppercase;color:#69717b}}.pill{{display:inline-block;padding:4px 8px;border-radius:999px;border:1px solid}}.passed{{color:#16794a;background:#f0faf5}}.attention{{color:#946200;background:#fff9e8}}.unavailable{{color:#5f6873;background:#f3f4f6}}.error{{margin-top:18px;padding:13px;border-left:3px solid #b42318;background:#fff1f0;color:#7a271a}}.finding-head{{display:flex;justify-content:space-between;gap:16px;align-items:end;flex-wrap:wrap}}.empty{{text-align:center;color:#69717b;padding:28px}}@media(max-width:1100px){{.overview-grid{{grid-template-columns:1fr}}}}@media(max-width:1000px){{header{{display:block}}form{{margin-top:18px}}}}@media(max-width:800px){{aside{{position:static;width:auto}}main{{margin:0;padding:20px}}.cards{{grid-template-columns:repeat(2,minmax(0,1fr))}}table{{display:block;overflow:auto}}form{{display:block;min-width:0}}input,select{{width:100%;min-width:0;margin-bottom:8px}}.priority-list li{{grid-template-columns:1fr}}}}
-</style></head><body><aside><h1>Veridra</h1><nav>{nav_links}<a href='{html.escape(report_link, quote=True)}'>Reports</a></nav></aside><main><header><div><h2>Website assessment</h2><p class='muted'>Visibility, trust and public security evidence.</p></div><div><form method='get' action='/'><label class='muted' for='url'>Public website</label><input id='url' name='url' type='text' maxlength='2048' placeholder='example.com' value='{escaped_url}' required><div class='actions'><button type='submit'>Run assessment</button><a class='button' href='{html.escape(report_link, quote=True)}'>Open report</a><a class='button secondary' href='{html.escape(export_link, quote=True)}'>Export evidence</a></div></form></div></header>{error_panel}<div class='cards'>{cards}</div><div class='overview-grid'><section aria-labelledby='priority-heading'><h3 id='priority-heading'>Priority actions</h3><p class='muted'>The first five attention findings in deterministic severity order.</p><ol class='priority-list'>{priorities}</ol></section><section aria-labelledby='areas-heading'><h3 id='areas-heading'>Assessment areas</h3><table><thead><tr><th>Area</th><th>Passed</th><th>Attention</th><th>Unavailable</th><th>Total</th></tr></thead><tbody>{area_rows}</tbody></table></section></div><section><div class='finding-head'><div><h3>Evidence-backed findings</h3><p class='muted'>{len(findings)} of {len(assessment.findings)} findings displayed.</p></div><form class='filters' method='get' action='/'>{hidden_target}<label for='area'>Area</label><select id='area' name='area'>{area_options}</select><label for='status'>Status</label><select id='status' name='status'>{status_options}</select><button type='submit'>Apply filters</button></form></div><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th></tr></thead><tbody>{rows}</tbody></table><p class='muted'>Scope: bounded public checks only. This is not a penetration test.</p></section></main></body></html>"""
+</style></head><body><aside><h1>Veridra</h1><nav>{nav_links}<a href='{html.escape(report_link, quote=True)}'>Reports</a><a href='/history'>History</a></nav></aside><main><header><div><h2>Website assessment</h2><p class='muted'>Visibility, trust and public security evidence.</p></div><div><form method='get' action='/'><label class='muted' for='url'>Public website</label><input id='url' name='url' type='text' maxlength='2048' placeholder='example.com' value='{escaped_url}' required><div class='actions'><button type='submit'>Run assessment</button><a class='button' href='{html.escape(report_link, quote=True)}'>Open report</a><a class='button secondary' href='{html.escape(export_link, quote=True)}'>Export evidence</a><button type='submit' formmethod='post' formaction='{html.escape(save_link, quote=True)}'>Save locally</button></div></form></div></header>{error_panel}<div class='cards'>{cards}</div><div class='overview-grid'><section aria-labelledby='priority-heading'><h3 id='priority-heading'>Priority actions</h3><p class='muted'>The first five attention findings in deterministic severity order.</p><ol class='priority-list'>{priorities}</ol></section><section aria-labelledby='areas-heading'><h3 id='areas-heading'>Assessment areas</h3><table><thead><tr><th>Area</th><th>Passed</th><th>Attention</th><th>Unavailable</th><th>Total</th></tr></thead><tbody>{area_rows}</tbody></table></section></div><section><div class='finding-head'><div><h3>Evidence-backed findings</h3><p class='muted'>{len(findings)} of {len(assessment.findings)} findings displayed.</p></div><form class='filters' method='get' action='/'>{hidden_target}<label for='area'>Area</label><select id='area' name='area'>{area_options}</select><label for='status'>Status</label><select id='status' name='status'>{status_options}</select><button type='submit'>Apply filters</button></form></div><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Observation</th><th>Recommended action</th></tr></thead><tbody>{rows}</tbody></table><p class='muted'>Scope: bounded public checks only. This is not a penetration test.</p></section></main></body></html>"""
 
 
 def _resolve_assessment(url: str | None, demo: bool) -> Assessment:
@@ -173,14 +176,27 @@ def assess(url: str = Query(min_length=1, max_length=2048)) -> dict[str, object]
 
 
 @app.get("/report", response_class=HTMLResponse)
-def report(url: str | None = Query(default=None, min_length=1, max_length=2048), demo: bool = False) -> str:
+def report(
+    url: str | None = Query(default=None, min_length=1, max_length=2048),
+    demo: bool = False,
+) -> str:
     return render_report(_resolve_assessment(url, demo))
 
 
 @app.get("/export")
-def export(url: str | None = Query(default=None, min_length=1, max_length=2048), demo: bool = False) -> Response:
+def export(
+    url: str | None = Query(default=None, min_length=1, max_length=2048),
+    demo: bool = False,
+) -> Response:
     package = build_evidence_package(_resolve_assessment(url, demo))
-    return Response(content=package.content, media_type="application/zip", headers={"Content-Disposition": f'attachment; filename="{package.filename}"', "X-Content-Type-Options": "nosniff"})
+    return Response(
+        content=package.content,
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{package.filename}"',
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -195,7 +211,14 @@ def index(
     try:
         return dashboard(assess_url(url), submitted_url=url, area=area, status=status)
     except (UnsafeTargetError, CollectionError) as exc:
-        return dashboard(demo_assessment(), submitted_url=url, error=str(exc), demo_mode=True, area=area, status=status)
+        return dashboard(
+            demo_assessment(),
+            submitted_url=url,
+            error=str(exc),
+            demo_mode=True,
+            area=area,
+            status=status,
+        )
 
 
 def main() -> None:

--- a/src/veridra/history.py
+++ b/src/veridra/history.py
@@ -71,7 +71,10 @@ class HistoryStore:
         self.directory = directory or default_history_directory()
 
     def _path(self, entry_id: str) -> Path:
-        if len(entry_id) != 24 or any(char not in "0123456789abcdef" for char in entry_id):
+        valid = len(entry_id) == 24 and all(
+            char in "0123456789abcdef" for char in entry_id
+        )
+        if not valid:
             raise HistoryError("Invalid assessment identifier.")
         return self.directory / f"{entry_id}.json"
 
@@ -111,7 +114,9 @@ class HistoryStore:
         entries: list[HistoryEntry] = []
         for path in sorted(self.directory.glob("*.json")):
             try:
-                assessment = Assessment.model_validate_json(path.read_text(encoding="utf-8"))
+                assessment = Assessment.model_validate_json(
+                    path.read_text(encoding="utf-8")
+                )
             except (OSError, ValueError):
                 continue
             entries.append(
@@ -123,7 +128,11 @@ class HistoryStore:
                     total_findings=assessment.summary["total"],
                 )
             )
-        return sorted(entries, key=lambda item: (item.generated_at, item.id), reverse=True)
+        return sorted(
+            entries,
+            key=lambda item: (item.generated_at, item.id),
+            reverse=True,
+        )
 
     def delete(self, entry_id: str) -> None:
         path = self._path(entry_id)
@@ -153,7 +162,8 @@ class HistoryStore:
         changed = sorted(
             identifier
             for identifier in common
-            if _finding_signature(before_map[identifier]) != _finding_signature(after_map[identifier])
+            if _finding_signature(before_map[identifier])
+            != _finding_signature(after_map[identifier])
         )
         unchanged = sorted(common - set(changed))
         return Comparison(

--- a/src/veridra/history.py
+++ b/src/veridra/history.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from .core import Assessment, Finding
+
+
+class HistoryError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class HistoryEntry:
+    id: str
+    target: str
+    generated_at: str
+    mode: str
+    total_findings: int
+
+
+@dataclass(frozen=True)
+class Comparison:
+    before_id: str
+    after_id: str
+    added: tuple[str, ...]
+    resolved: tuple[str, ...]
+    changed: tuple[str, ...]
+    unchanged: tuple[str, ...]
+
+
+def default_history_directory() -> Path:
+    configured = os.environ.get("VERIDRA_DATA_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve() / "history"
+    return Path.home() / ".veridra" / "history"
+
+
+def _canonical_bytes(assessment: Assessment) -> bytes:
+    payload = assessment.model_dump(mode="json")
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def assessment_id(assessment: Assessment) -> str:
+    return hashlib.sha256(_canonical_bytes(assessment)).hexdigest()[:24]
+
+
+def _finding_signature(finding: Finding) -> str:
+    payload = finding.model_dump(mode="json")
+    return hashlib.sha256(
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+class HistoryStore:
+    def __init__(self, directory: Path | None = None) -> None:
+        self.directory = directory or default_history_directory()
+
+    def _path(self, entry_id: str) -> Path:
+        if len(entry_id) != 24 or any(char not in "0123456789abcdef" for char in entry_id):
+            raise HistoryError("Invalid assessment identifier.")
+        return self.directory / f"{entry_id}.json"
+
+    def save(self, assessment: Assessment) -> str:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        entry_id = assessment_id(assessment)
+        destination = self._path(entry_id)
+        content = _canonical_bytes(assessment)
+        if destination.exists():
+            return entry_id
+        with NamedTemporaryFile(
+            mode="wb",
+            dir=self.directory,
+            prefix=f".{entry_id}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(destination)
+        return entry_id
+
+    def load(self, entry_id: str) -> Assessment:
+        path = self._path(entry_id)
+        try:
+            return Assessment.model_validate_json(path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise HistoryError("Saved assessment was not found.") from exc
+        except (OSError, ValueError) as exc:
+            raise HistoryError("Saved assessment could not be read safely.") from exc
+
+    def list(self) -> list[HistoryEntry]:
+        if not self.directory.exists():
+            return []
+        entries: list[HistoryEntry] = []
+        for path in sorted(self.directory.glob("*.json")):
+            try:
+                assessment = Assessment.model_validate_json(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            entries.append(
+                HistoryEntry(
+                    id=path.stem,
+                    target=str(assessment.target),
+                    generated_at=assessment.generated_at.isoformat(),
+                    mode=assessment.mode,
+                    total_findings=assessment.summary["total"],
+                )
+            )
+        return sorted(entries, key=lambda item: (item.generated_at, item.id), reverse=True)
+
+    def delete(self, entry_id: str) -> None:
+        path = self._path(entry_id)
+        try:
+            path.unlink()
+        except FileNotFoundError as exc:
+            raise HistoryError("Saved assessment was not found.") from exc
+
+    def prune(self, keep: int) -> tuple[str, ...]:
+        if keep < 0:
+            raise HistoryError("Retention count cannot be negative.")
+        entries = self.list()
+        removed: list[str] = []
+        for entry in entries[keep:]:
+            self.delete(entry.id)
+            removed.append(entry.id)
+        return tuple(removed)
+
+    def compare(self, before_id: str, after_id: str) -> Comparison:
+        before = self.load(before_id)
+        after = self.load(after_id)
+        before_map = {item.id: item for item in before.findings}
+        after_map = {item.id: item for item in after.findings}
+        before_ids = set(before_map)
+        after_ids = set(after_map)
+        common = before_ids & after_ids
+        changed = sorted(
+            identifier
+            for identifier in common
+            if _finding_signature(before_map[identifier]) != _finding_signature(after_map[identifier])
+        )
+        unchanged = sorted(common - set(changed))
+        return Comparison(
+            before_id=before_id,
+            after_id=after_id,
+            added=tuple(sorted(after_ids - before_ids)),
+            resolved=tuple(sorted(before_ids - after_ids)),
+            changed=tuple(changed),
+            unchanged=tuple(unchanged),
+        )

--- a/src/veridra/history_web.py
+++ b/src/veridra/history_web.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import html
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .collector import CollectionError
+from .core import Assessment, UnsafeTargetError, demo_assessment
+from .history import Comparison, HistoryError, HistoryStore
+from .service import assess_url
+
+router = APIRouter()
+
+
+def _store() -> HistoryStore:
+    return HistoryStore()
+
+
+def _resolve(url: str | None, demo: bool) -> Assessment:
+    if demo:
+        return demo_assessment()
+    if url is None:
+        raise HTTPException(status_code=400, detail="A target URL is required.")
+    try:
+        return assess_url(url)
+    except (UnsafeTargetError, CollectionError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _page(title: str, body: str) -> str:
+    return f"""<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)} · Veridra</title><style>
+*{{box-sizing:border-box}}body{{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}}main{{max-width:1100px;margin:32px auto;padding:0 20px}}header{{display:flex;justify-content:space-between;align-items:center;margin-bottom:22px}}a{{color:#24292f}}section{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:20px;margin-bottom:16px}}table{{width:100%;border-collapse:collapse}}th,td{{text-align:left;padding:12px;border-bottom:1px solid #e8eaed;vertical-align:top}}th{{font-size:11px;text-transform:uppercase;color:#69717b}}button,.button{{border:0;border-radius:7px;background:#22272d;color:white;padding:9px 13px;text-decoration:none;cursor:pointer}}.danger{{background:#9b1c1c}}.muted{{color:#6c737d}}form{{display:inline}}.counts{{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}}.counts article{{border:1px solid #dfe3e8;padding:14px}}.counts strong{{display:block;font-size:24px}}@media(max-width:700px){{.counts{{grid-template-columns:repeat(2,1fr)}}table{{display:block;overflow:auto}}}}
+</style></head><body><main><header><div><h1>{html.escape(title)}</h1><p class='muted'>Local operator-controlled storage only.</p></div><a href='/'>Back to assessment</a></header>{body}</main></body></html>"""
+
+
+def _comparison_list(label: str, values: tuple[str, ...]) -> str:
+    items = "".join(f"<li><code>{html.escape(value)}</code></li>" for value in values)
+    return f"<section><h2>{html.escape(label)} ({len(values)})</h2><ul>{items or '<li>None</li>'}</ul></section>"
+
+
+@router.post("/history/save")
+def save_history(
+    url: str | None = Query(default=None, min_length=1, max_length=2048),
+    demo: bool = False,
+) -> RedirectResponse:
+    entry_id = _store().save(_resolve(url, demo))
+    return RedirectResponse(f"/history/{entry_id}", status_code=303)
+
+
+@router.get("/history", response_class=HTMLResponse)
+def history_index() -> str:
+    entries = _store().list()
+    rows = "".join(
+        "<tr><td><a href='/history/{id}'><code>{id}</code></a></td><td>{target}</td>"
+        "<td>{generated}</td><td>{mode}</td><td>{total}</td></tr>".format(
+            id=entry.id,
+            target=html.escape(entry.target),
+            generated=html.escape(entry.generated_at),
+            mode=html.escape(entry.mode),
+            total=entry.total_findings,
+        )
+        for entry in entries
+    )
+    if not rows:
+        rows = "<tr><td colspan='5'>No assessments have been explicitly saved.</td></tr>"
+    body = f"""<section><h2>Saved assessments</h2><p>Veridra saves nothing here unless the operator explicitly uses the save action.</p><table><thead><tr><th>ID</th><th>Target</th><th>Generated</th><th>Mode</th><th>Findings</th></tr></thead><tbody>{rows}</tbody></table></section><section><h2>Retention</h2><form method='post' action='/history/prune?keep=20'><button type='submit'>Keep newest 20</button></form></section>"""
+    return _page("Assessment history", body)
+
+
+@router.get("/history/compare", response_class=HTMLResponse)
+def compare_history(
+    before: str = Query(min_length=24, max_length=24),
+    after: str = Query(min_length=24, max_length=24),
+) -> str:
+    try:
+        comparison = _store().compare(before, after)
+    except HistoryError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    body = (
+        f"<section><p><strong>Before:</strong> <code>{comparison.before_id}</code><br>"
+        f"<strong>After:</strong> <code>{comparison.after_id}</code></p></section>"
+        + _comparison_list("Added findings", comparison.added)
+        + _comparison_list("Resolved findings", comparison.resolved)
+        + _comparison_list("Changed findings", comparison.changed)
+        + _comparison_list("Unchanged findings", comparison.unchanged)
+    )
+    return _page("Assessment comparison", body)
+
+
+@router.get("/history/{entry_id}", response_class=HTMLResponse)
+def history_detail(entry_id: str) -> str:
+    try:
+        assessment = _store().load(entry_id)
+    except HistoryError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    entries = [entry for entry in _store().list() if entry.id != entry_id]
+    compare_links = "".join(
+        "<li><a href='/history/compare?{query}'>Compare with {id}</a></li>".format(
+            query=html.escape(
+                urlencode({"before": entry.id, "after": entry_id}),
+                quote=True,
+            ),
+            id=entry.id,
+        )
+        for entry in entries[:10]
+    )
+    body = f"""<section><h2>{html.escape(str(assessment.target))}</h2><p><strong>ID:</strong> <code>{entry_id}</code><br><strong>Generated:</strong> {html.escape(assessment.generated_at.isoformat())}<br><strong>Mode:</strong> {assessment.mode}<br><strong>Findings:</strong> {assessment.summary['total']}</p><form method='post' action='/history/{entry_id}/delete'><button class='danger' type='submit'>Delete saved assessment</button></form></section><section><h2>Compare</h2><ul>{compare_links or '<li>Save another assessment to compare changes.</li>'}</ul></section>"""
+    return _page("Saved assessment", body)
+
+
+@router.post("/history/{entry_id}/delete")
+def delete_history(entry_id: str) -> RedirectResponse:
+    try:
+        _store().delete(entry_id)
+    except HistoryError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return RedirectResponse("/history", status_code=303)
+
+
+@router.post("/history/prune")
+def prune_history(keep: int = Query(default=20, ge=0, le=1000)) -> RedirectResponse:
+    try:
+        _store().prune(keep)
+    except HistoryError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return RedirectResponse("/history", status_code=303)

--- a/src/veridra/history_web.py
+++ b/src/veridra/history_web.py
@@ -8,7 +8,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 
 from .collector import CollectionError
 from .core import Assessment, UnsafeTargetError, demo_assessment
-from .history import Comparison, HistoryError, HistoryStore
+from .history import HistoryError, HistoryStore
 from .service import assess_url
 
 router = APIRouter()
@@ -30,14 +30,85 @@ def _resolve(url: str | None, demo: bool) -> Assessment:
 
 
 def _page(title: str, body: str) -> str:
-    return f"""<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)} · Veridra</title><style>
-*{{box-sizing:border-box}}body{{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}}main{{max-width:1100px;margin:32px auto;padding:0 20px}}header{{display:flex;justify-content:space-between;align-items:center;margin-bottom:22px}}a{{color:#24292f}}section{{background:white;border:1px solid #dfe3e8;border-radius:8px;padding:20px;margin-bottom:16px}}table{{width:100%;border-collapse:collapse}}th,td{{text-align:left;padding:12px;border-bottom:1px solid #e8eaed;vertical-align:top}}th{{font-size:11px;text-transform:uppercase;color:#69717b}}button,.button{{border:0;border-radius:7px;background:#22272d;color:white;padding:9px 13px;text-decoration:none;cursor:pointer}}.danger{{background:#9b1c1c}}.muted{{color:#6c737d}}form{{display:inline}}.counts{{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}}.counts article{{border:1px solid #dfe3e8;padding:14px}}.counts strong{{display:block;font-size:24px}}@media(max-width:700px){{.counts{{grid-template-columns:repeat(2,1fr)}}table{{display:block;overflow:auto}}}}
-</style></head><body><main><header><div><h1>{html.escape(title)}</h1><p class='muted'>Local operator-controlled storage only.</p></div><a href='/'>Back to assessment</a></header>{body}</main></body></html>"""
+    escaped_title = html.escape(title)
+    return f"""<!doctype html>
+<html lang='en'>
+<head>
+<meta charset='utf-8'>
+<meta name='viewport' content='width=device-width,initial-scale=1'>
+<title>{escaped_title} · Veridra</title>
+<style>
+* {{ box-sizing: border-box; }}
+body {{
+  margin: 0;
+  background: #f7f8fa;
+  color: #17191c;
+  font: 14px Arial, sans-serif;
+}}
+main {{ max-width: 1100px; margin: 32px auto; padding: 0 20px; }}
+header {{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 22px;
+}}
+a {{ color: #24292f; }}
+section {{
+  background: white;
+  border: 1px solid #dfe3e8;
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 16px;
+}}
+table {{ width: 100%; border-collapse: collapse; }}
+th, td {{
+  text-align: left;
+  padding: 12px;
+  border-bottom: 1px solid #e8eaed;
+  vertical-align: top;
+}}
+th {{ font-size: 11px; text-transform: uppercase; color: #69717b; }}
+button, .button {{
+  border: 0;
+  border-radius: 7px;
+  background: #22272d;
+  color: white;
+  padding: 9px 13px;
+  text-decoration: none;
+  cursor: pointer;
+}}
+.danger {{ background: #9b1c1c; }}
+.muted {{ color: #6c737d; }}
+form {{ display: inline; }}
+@media (max-width: 700px) {{
+  table {{ display: block; overflow: auto; }}
+}}
+</style>
+</head>
+<body>
+<main>
+<header>
+  <div>
+    <h1>{escaped_title}</h1>
+    <p class='muted'>Local operator-controlled storage only.</p>
+  </div>
+  <a href='/'>Back to assessment</a>
+</header>
+{body}
+</main>
+</body>
+</html>"""
 
 
 def _comparison_list(label: str, values: tuple[str, ...]) -> str:
-    items = "".join(f"<li><code>{html.escape(value)}</code></li>" for value in values)
-    return f"<section><h2>{html.escape(label)} ({len(values)})</h2><ul>{items or '<li>None</li>'}</ul></section>"
+    items = "".join(
+        f"<li><code>{html.escape(value)}</code></li>" for value in values
+    )
+    content = items or "<li>None</li>"
+    return (
+        f"<section><h2>{html.escape(label)} ({len(values)})</h2>"
+        f"<ul>{content}</ul></section>"
+    )
 
 
 @router.post("/history/save")
@@ -53,19 +124,39 @@ def save_history(
 def history_index() -> str:
     entries = _store().list()
     rows = "".join(
-        "<tr><td><a href='/history/{id}'><code>{id}</code></a></td><td>{target}</td>"
-        "<td>{generated}</td><td>{mode}</td><td>{total}</td></tr>".format(
-            id=entry.id,
-            target=html.escape(entry.target),
-            generated=html.escape(entry.generated_at),
-            mode=html.escape(entry.mode),
-            total=entry.total_findings,
+        (
+            f"<tr><td><a href='/history/{entry.id}'><code>{entry.id}</code></a></td>"
+            f"<td>{html.escape(entry.target)}</td>"
+            f"<td>{html.escape(entry.generated_at)}</td>"
+            f"<td>{html.escape(entry.mode)}</td>"
+            f"<td>{entry.total_findings}</td></tr>"
         )
         for entry in entries
     )
     if not rows:
-        rows = "<tr><td colspan='5'>No assessments have been explicitly saved.</td></tr>"
-    body = f"""<section><h2>Saved assessments</h2><p>Veridra saves nothing here unless the operator explicitly uses the save action.</p><table><thead><tr><th>ID</th><th>Target</th><th>Generated</th><th>Mode</th><th>Findings</th></tr></thead><tbody>{rows}</tbody></table></section><section><h2>Retention</h2><form method='post' action='/history/prune?keep=20'><button type='submit'>Keep newest 20</button></form></section>"""
+        rows = (
+            "<tr><td colspan='5'>"
+            "No assessments have been explicitly saved."
+            "</td></tr>"
+        )
+    body = f"""
+<section>
+<h2>Saved assessments</h2>
+<p>Veridra saves nothing here unless the operator explicitly uses the save action.</p>
+<table>
+<thead>
+<tr><th>ID</th><th>Target</th><th>Generated</th><th>Mode</th><th>Findings</th></tr>
+</thead>
+<tbody>{rows}</tbody>
+</table>
+</section>
+<section>
+<h2>Retention</h2>
+<form method='post' action='/history/prune?keep=20'>
+<button type='submit'>Keep newest 20</button>
+</form>
+</section>
+"""
     return _page("Assessment history", body)
 
 
@@ -79,8 +170,10 @@ def compare_history(
     except HistoryError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     body = (
-        f"<section><p><strong>Before:</strong> <code>{comparison.before_id}</code><br>"
-        f"<strong>After:</strong> <code>{comparison.after_id}</code></p></section>"
+        f"<section><p><strong>Before:</strong> "
+        f"<code>{comparison.before_id}</code><br>"
+        f"<strong>After:</strong> <code>{comparison.after_id}</code>"
+        "</p></section>"
         + _comparison_list("Added findings", comparison.added)
         + _comparison_list("Resolved findings", comparison.resolved)
         + _comparison_list("Changed findings", comparison.changed)
@@ -97,16 +190,41 @@ def history_detail(entry_id: str) -> str:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     entries = [entry for entry in _store().list() if entry.id != entry_id]
     compare_links = "".join(
-        "<li><a href='/history/compare?{query}'>Compare with {id}</a></li>".format(
+        (
+            "<li><a href='/history/compare?{query}'>"
+            "Compare with {entry_id}</a></li>"
+        ).format(
             query=html.escape(
                 urlencode({"before": entry.id, "after": entry_id}),
                 quote=True,
             ),
-            id=entry.id,
+            entry_id=entry.id,
         )
         for entry in entries[:10]
     )
-    body = f"""<section><h2>{html.escape(str(assessment.target))}</h2><p><strong>ID:</strong> <code>{entry_id}</code><br><strong>Generated:</strong> {html.escape(assessment.generated_at.isoformat())}<br><strong>Mode:</strong> {assessment.mode}<br><strong>Findings:</strong> {assessment.summary['total']}</p><form method='post' action='/history/{entry_id}/delete'><button class='danger' type='submit'>Delete saved assessment</button></form></section><section><h2>Compare</h2><ul>{compare_links or '<li>Save another assessment to compare changes.</li>'}</ul></section>"""
+    compare_content = compare_links or (
+        "<li>Save another assessment to compare changes.</li>"
+    )
+    target = html.escape(str(assessment.target))
+    generated = html.escape(assessment.generated_at.isoformat())
+    body = f"""
+<section>
+<h2>{target}</h2>
+<p>
+<strong>ID:</strong> <code>{entry_id}</code><br>
+<strong>Generated:</strong> {generated}<br>
+<strong>Mode:</strong> {assessment.mode}<br>
+<strong>Findings:</strong> {assessment.summary['total']}
+</p>
+<form method='post' action='/history/{entry_id}/delete'>
+<button class='danger' type='submit'>Delete saved assessment</button>
+</form>
+</section>
+<section>
+<h2>Compare</h2>
+<ul>{compare_content}</ul>
+</section>
+"""
     return _page("Saved assessment", body)
 
 
@@ -120,7 +238,9 @@ def delete_history(entry_id: str) -> RedirectResponse:
 
 
 @router.post("/history/prune")
-def prune_history(keep: int = Query(default=20, ge=0, le=1000)) -> RedirectResponse:
+def prune_history(
+    keep: int = Query(default=20, ge=0, le=1000),
+) -> RedirectResponse:
     try:
         _store().prune(keep)
     except HistoryError as exc:

--- a/src/veridra/version.py
+++ b/src/veridra/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.9.0"
+__version__ = "1.0.0"

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from veridra.core import Assessment, Finding, Status
+from veridra.history import HistoryError, HistoryStore, assessment_id
+
+
+def _assessment(
+    title: str,
+    *,
+    generated_at: datetime,
+    include_extra: bool = False,
+) -> Assessment:
+    findings = [
+        Finding(
+            id="health.title",
+            area="Website health",
+            title=title,
+            status=Status.attention,
+            severity="medium",
+            summary="Needs attention.",
+            recommendation="Fix it.",
+        )
+    ]
+    if include_extra:
+        findings.append(
+            Finding(
+                id="security.hsts",
+                area="Security posture",
+                title="HSTS",
+                status=Status.passed,
+                severity="info",
+                summary="Present.",
+            )
+        )
+    return Assessment.build(
+        "https://example.com",
+        findings,
+        generated_at=generated_at,
+    )
+
+
+def test_save_is_deterministic_and_atomic(tmp_path: Path) -> None:
+    store = HistoryStore(tmp_path)
+    assessment = _assessment("Title", generated_at=datetime(2026, 1, 1, tzinfo=UTC))
+
+    first = store.save(assessment)
+    second = store.save(assessment)
+
+    assert first == second == assessment_id(assessment)
+    assert (tmp_path / f"{first}.json").is_file()
+    assert not list(tmp_path.glob("*.tmp"))
+    assert store.load(first) == assessment
+
+
+def test_list_is_newest_first(tmp_path: Path) -> None:
+    store = HistoryStore(tmp_path)
+    older = _assessment("Older", generated_at=datetime(2026, 1, 1, tzinfo=UTC))
+    newer = _assessment("Newer", generated_at=datetime(2026, 1, 2, tzinfo=UTC))
+    older_id = store.save(older)
+    newer_id = store.save(newer)
+
+    entries = store.list()
+
+    assert [entry.id for entry in entries] == [newer_id, older_id]
+    assert entries[0].target == "https://example.com/"
+
+
+def test_compare_classifies_changes(tmp_path: Path) -> None:
+    store = HistoryStore(tmp_path)
+    before = _assessment("Old title", generated_at=datetime(2026, 1, 1, tzinfo=UTC))
+    after = _assessment(
+        "New title",
+        generated_at=datetime(2026, 1, 2, tzinfo=UTC),
+        include_extra=True,
+    )
+    before_id = store.save(before)
+    after_id = store.save(after)
+
+    comparison = store.compare(before_id, after_id)
+
+    assert comparison.changed == ("health.title",)
+    assert comparison.added == ("security.hsts",)
+    assert comparison.resolved == ()
+    assert comparison.unchanged == ()
+
+
+def test_prune_and_delete(tmp_path: Path) -> None:
+    store = HistoryStore(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    identifiers = [
+        store.save(_assessment(f"Title {index}", generated_at=base + timedelta(days=index)))
+        for index in range(3)
+    ]
+
+    removed = store.prune(keep=1)
+
+    assert set(removed) == set(identifiers[:2])
+    assert [entry.id for entry in store.list()] == [identifiers[2]]
+    store.delete(identifiers[2])
+    assert store.list() == []
+
+
+def test_invalid_identifier_and_missing_entry(tmp_path: Path) -> None:
+    store = HistoryStore(tmp_path)
+    with pytest.raises(HistoryError, match="Invalid"):
+        store.load("../unsafe")
+    with pytest.raises(HistoryError, match="not found"):
+        store.load("0" * 24)
+    with pytest.raises(HistoryError, match="negative"):
+        store.prune(-1)

--- a/tests/test_history_web.py
+++ b/tests/test_history_web.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from veridra.app import app
+
+client = TestClient(app)
+
+
+def _configure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))
+
+
+def test_history_starts_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure(monkeypatch, tmp_path)
+    response = client.get("/history")
+    assert response.status_code == 200
+    assert "No assessments have been explicitly saved" in response.text
+    assert "Local operator-controlled storage only" in response.text
+
+
+def test_demo_save_detail_and_delete(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure(monkeypatch, tmp_path)
+    saved = client.post("/history/save", params={"demo": "true"}, follow_redirects=False)
+    assert saved.status_code == 303
+    location = saved.headers["location"]
+    entry_id = location.rsplit("/", 1)[1]
+
+    detail = client.get(location)
+    assert detail.status_code == 200
+    assert "demo.veridra.local" in detail.text
+    assert entry_id in detail.text
+
+    listing = client.get("/history")
+    assert entry_id in listing.text
+
+    deleted = client.post(f"/history/{entry_id}/delete", follow_redirects=False)
+    assert deleted.status_code == 303
+    assert client.get("/history").text.count(entry_id) == 0
+
+
+def test_comparison_route(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure(monkeypatch, tmp_path)
+    first = client.post("/history/save", params={"demo": "true"}, follow_redirects=False)
+    first_id = first.headers["location"].rsplit("/", 1)[1]
+
+    history_file = tmp_path / "history" / f"{first_id}.json"
+    content = history_file.read_text(encoding="utf-8")
+    changed = content.replace('"elapsed_ms":0', '"elapsed_ms":1')
+    second_file = tmp_path / "history" / ("f" * 24 + ".json")
+    second_file.write_text(changed, encoding="utf-8")
+
+    response = client.get(
+        "/history/compare",
+        params={"before": first_id, "after": "f" * 24},
+    )
+    assert response.status_code == 200
+    assert "Assessment comparison" in response.text
+    assert "Unchanged findings" in response.text
+
+
+def test_retention_route(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure(monkeypatch, tmp_path)
+    client.post("/history/save", params={"demo": "true"})
+    response = client.post("/history/prune", params={"keep": 0}, follow_redirects=False)
+    assert response.status_code == 303
+    assert "No assessments have been explicitly saved" in client.get("/history").text
+
+
+def test_invalid_history_identifier_is_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _configure(monkeypatch, tmp_path)
+    response = client.get("/history/not-valid")
+    assert response.status_code == 404


### PR DESCRIPTION
## Scope

Implements issue #28:

- explicit local saves only;
- deterministic assessment identifiers;
- atomic JSON writes;
- injectable local storage directory;
- history listing and detail views;
- added, resolved, changed, and unchanged comparison results;
- explicit deletion and retention pruning;
- no accounts, shared database, cookies, credentials, request bodies, or multi-tenant exposure;
- dashboard History and Save locally actions;
- application version advanced to 1.0.0;
- deterministic storage and route tests using temporary directories.

## Required proof

- Ruff
- strict mypy
- pytest
- deterministic audit
- Chromium browser audit
- exact-head GitHub Actions success

Closes #28 after verified merge.