### PR TITLE
Synchronize documentation for Veridra 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Automated website assessment for visibility, AI discoverability, trust signals, 
 - homepage and `robots.txt` evidence collection without authentication or active scanning;
 - bounded NS, MX, SPF, and DMARC posture checks with deterministic resolver fixtures;
 - responsive operator dashboard with assessment-area summaries and a five-item priority-action queue;
+- server-side finding filters and dedicated Website health, Search visibility, AI discoverability, Trust signals, and Security posture views;
 - JSON API plus printable HTML reports with metadata, prioritised actions, per-area summaries, full evidence, and recommendations;
 - deterministic ZIP evidence packages containing JSON, HTML, and a SHA-256 manifest;
+- explicit local assessment history with deterministic identifiers, atomic writes, comparisons, retention, and deletion controls;
 - Ruff, strict mypy, pytest, deterministic repository audit, and Chromium browser acceptance checks in GitHub Actions;
 - desktop and mobile screenshots plus machine-readable audit artifacts retained by CI.
 
@@ -27,10 +29,16 @@ python -m venv .venv
 
 Open `http://127.0.0.1:8000`.
 
+## Local history
+
+Veridra does not save assessments automatically. The operator must select **Save locally** for an assessment to be written to the local data directory. Saved data is limited to the existing assessment model; Veridra does not store credentials, cookies, form submissions, or request bodies.
+
+Set `VERIDRA_DATA_DIR` to choose the parent data directory. When it is not set, Veridra uses `~/.veridra/history`.
+
 ## Safety boundary
 
 Veridra is limited to bounded public evidence collection. It is not a penetration test, does not authenticate, does not submit forms, and must reject private or non-public targets before any website request. DNS posture checks are passive and do not connect to mail servers, transfer zones, enumerate subdomains, or guess DKIM selectors.
 
 ## Development status
 
-The verified local MVP is under active development. Safe local history and comparisons, deployment controls, public multi-tenant operation, accounts, billing, external backlink providers, and sampled LLM visibility checks remain deferred until their operational and commercial requirements are justified.
+Veridra 1.0.0 is a verified loopback-local product. Public deployment controls, multi-tenant operation, accounts, billing, external backlink providers, and sampled LLM visibility checks remain deferred until their operational and commercial requirements are justified.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,17 +10,22 @@
 - Expanded robots.txt interpretation and passive discoverability/trust signals.
 - Bounded NS, MX, SPF, and DMARC posture checks with deterministic DNS fixtures.
 - Dashboard and printable-report priority-action sections.
+- Server-side finding filters and dedicated assessment-area views.
 - Deterministic ZIP evidence packages with JSON, HTML, and SHA-256 manifest.
+- Explicit local assessment history with deterministic identifiers and atomic writes.
+- Local comparison of added, resolved, changed, and unchanged findings.
+- Local retention and explicit deletion controls.
 - GitHub Actions verification with preserved diagnostic artifacts.
 - Chromium desktop/mobile visual and accessibility acceptance checks.
+- Verified loopback-local 1.0.0 milestone.
 
 ## Next
 
-1. Add safe local assessment history and deterministic comparison without multi-tenant exposure.
-2. Add finding filters and dedicated area views using browser evidence.
-3. Define deployment controls: rate limiting, bounded concurrency, job isolation, abuse monitoring, and retention.
+1. Define deployment controls: rate limiting, bounded concurrency, job isolation, abuse monitoring, and retention.
+2. Complete local Windows acceptance testing and operator workflow review.
+3. Prepare a controlled private-deployment milestone only after local acceptance evidence is complete.
 4. Add optional provider interfaces for backlinks and sampled AI visibility only after commercial validation.
-5. Prepare a controlled private-deployment milestone after local acceptance evidence is complete.
+5. Define release packaging and upgrade behavior for non-developer operators.
 
 ## Deferred until justified
 


### PR DESCRIPTION
## Scope

Implements issue #30:

- documents server-side finding filters and dedicated area views;
- documents explicit local saves, deterministic identifiers, comparisons, retention, and deletion;
- states clearly that assessments are never saved automatically;
- documents `VERIDRA_DATA_DIR` and the default local history location;
- moves completed filtering and history milestones out of the roadmap's Next section;
- preserves loopback-only and deferred public-deployment boundaries.

## Required proof

All existing GitHub Actions gates must pass on the exact PR head.

Closes #30 after verified merge.