### PR TITLE
Add bounded multi-page crawl

### DIFF
--- a/src/veridra/crawl.py
+++ b/src/veridra/crawl.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from urllib.parse import urljoin, urlparse, urlunparse
+
+from .collector import CollectionError, PageEvidence, collect_page
+from .core import Finding, Status, UnsafeTargetError
+
+
+@dataclass(frozen=True)
+class CrawlLimits:
+    max_pages: int = 10
+    max_depth: int = 1
+    max_total_bytes: int = 5_000_000
+    per_page_bytes: int = 750_000
+    timeout: float = 8.0
+
+
+@dataclass(frozen=True)
+class CrawledPage:
+    evidence: PageEvidence
+    depth: int
+
+
+@dataclass(frozen=True)
+class CrawlResult:
+    pages: tuple[CrawledPage, ...]
+    skipped_urls: tuple[str, ...]
+    exhausted_page_limit: bool
+    exhausted_byte_limit: bool
+
+
+PageCollector = Callable[..., PageEvidence]
+
+
+class _PageSignals(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+        self.has_title = False
+        self.has_description = False
+        self.has_h1 = False
+        self.has_canonical = False
+        self.has_mixed_content = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        data = {key.lower(): (value or "") for key, value in attrs}
+        lowered = {key: value.lower() for key, value in data.items()}
+        if tag == "title":
+            self.has_title = True
+        if tag == "h1":
+            self.has_h1 = True
+        if tag == "meta" and lowered.get("name") == "description":
+            self.has_description = bool(data.get("content", "").strip())
+        if tag == "link" and "canonical" in lowered.get("rel", ""):
+            self.has_canonical = bool(data.get("href", "").strip())
+        if tag == "a" and data.get("href"):
+            self.links.append(data["href"])
+        if any(lowered.get(name, "").startswith("http://") for name in ("src", "href")):
+            self.has_mixed_content = True
+
+
+def _crawl_url(raw: str, base_url: str) -> str | None:
+    joined = urljoin(base_url, raw)
+    parsed = urlparse(joined)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    base = urlparse(base_url)
+    if parsed.hostname.lower() != (base.hostname or "").lower():
+        return None
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    base_port = base.port or (443 if base.scheme == "https" else 80)
+    if port != base_port:
+        return None
+    path = parsed.path or "/"
+    return urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+
+
+def crawl_site(
+    start_url: str,
+    *,
+    limits: CrawlLimits = CrawlLimits(),
+    collector: PageCollector = collect_page,
+) -> CrawlResult:
+    if limits.max_pages < 1 or limits.max_depth < 0:
+        raise ValueError("Crawl limits must allow at least one page and non-negative depth.")
+    queue: deque[tuple[str, int]] = deque([(start_url, 0)])
+    seen: set[str] = set()
+    pages: list[CrawledPage] = []
+    skipped: set[str] = set()
+    total_bytes = 0
+    byte_limit = False
+
+    while queue and len(pages) < limits.max_pages:
+        raw_url, depth = queue.popleft()
+        normalized = _crawl_url(raw_url, start_url)
+        if normalized is None or normalized in seen:
+            continue
+        seen.add(normalized)
+        try:
+            page = collector(
+                normalized,
+                timeout=limits.timeout,
+                max_bytes=limits.per_page_bytes,
+            )
+        except (CollectionError, UnsafeTargetError):
+            skipped.add(normalized)
+            continue
+        content_type = page.headers.get("content-type", "").lower()
+        if "text/html" not in content_type:
+            skipped.add(page.final_url)
+            continue
+        body_bytes = len(page.body.encode("utf-8"))
+        if total_bytes + body_bytes > limits.max_total_bytes:
+            byte_limit = True
+            break
+        total_bytes += body_bytes
+        pages.append(CrawledPage(page, depth))
+        if depth >= limits.max_depth:
+            continue
+        parser = _PageSignals()
+        parser.feed(page.body)
+        for link in parser.links:
+            candidate = _crawl_url(link, page.final_url)
+            if candidate is not None and candidate not in seen:
+                queue.append((candidate, depth + 1))
+
+    return CrawlResult(
+        pages=tuple(pages),
+        skipped_urls=tuple(sorted(skipped)),
+        exhausted_page_limit=bool(queue) and len(pages) >= limits.max_pages,
+        exhausted_byte_limit=byte_limit,
+    )
+
+
+def analyze_crawl(result: CrawlResult) -> list[Finding]:
+    checks: dict[str, tuple[str, str, list[str]]] = {
+        "crawl.http-status": ("Page response", "high", []),
+        "crawl.title": ("Document title", "medium", []),
+        "crawl.description": ("Meta description", "medium", []),
+        "crawl.h1": ("Primary heading", "medium", []),
+        "crawl.canonical": ("Canonical URL", "medium", []),
+        "crawl.mixed-content": ("No obvious mixed content", "high", []),
+    }
+    for crawled in result.pages:
+        page = crawled.evidence
+        parser = _PageSignals()
+        parser.feed(page.body)
+        if not 200 <= page.status_code < 400:
+            checks["crawl.http-status"][2].append(page.final_url)
+        if not parser.has_title:
+            checks["crawl.title"][2].append(page.final_url)
+        if not parser.has_description:
+            checks["crawl.description"][2].append(page.final_url)
+        if not parser.has_h1:
+            checks["crawl.h1"][2].append(page.final_url)
+        if not parser.has_canonical:
+            checks["crawl.canonical"][2].append(page.final_url)
+        if parser.has_mixed_content:
+            checks["crawl.mixed-content"][2].append(page.final_url)
+
+    findings: list[Finding] = []
+    for identifier, (title, severity, affected) in checks.items():
+        passed = not affected
+        findings.append(
+            Finding(
+                id=identifier,
+                area="Website health" if identifier in {"crawl.http-status", "crawl.title", "crawl.h1"} else "Search visibility",
+                title=f"Multi-page {title.lower()}",
+                status=Status.passed if passed else Status.attention,
+                severity="info" if passed else severity,
+                summary=(
+                    f"All {len(result.pages)} crawled HTML pages passed this check."
+                    if passed
+                    else f"{len(affected)} of {len(result.pages)} crawled HTML pages need attention."
+                ),
+                recommendation=None if passed else f"Review and correct the affected pages for {title.lower()}.",
+                evidence={
+                    "affected_urls": sorted(affected),
+                    "crawled_pages": len(result.pages),
+                    "skipped_urls": list(result.skipped_urls),
+                    "page_limit_reached": result.exhausted_page_limit,
+                    "byte_limit_reached": result.exhausted_byte_limit,
+                },
+            )
+        )
+    return findings

--- a/src/veridra/crawl.py
+++ b/src/veridra/crawl.py
@@ -89,10 +89,11 @@ def _crawl_url(raw: str, base_url: str) -> str | None:
 def crawl_site(
     start_url: str,
     *,
-    limits: CrawlLimits = CrawlLimits(),
+    limits: CrawlLimits | None = None,
     collector: PageCollector = collect_page,
 ) -> CrawlResult:
-    if limits.max_pages < 1 or limits.max_depth < 0:
+    active_limits = limits or CrawlLimits()
+    if active_limits.max_pages < 1 or active_limits.max_depth < 0:
         raise ValueError(
             "Crawl limits must allow at least one page and non-negative depth."
         )
@@ -103,7 +104,7 @@ def crawl_site(
     total_bytes = 0
     byte_limit = False
 
-    while queue and len(pages) < limits.max_pages:
+    while queue and len(pages) < active_limits.max_pages:
         raw_url, depth = queue.popleft()
         normalized = _crawl_url(raw_url, start_url)
         if normalized is None or normalized in seen:
@@ -112,8 +113,8 @@ def crawl_site(
         try:
             page = collector(
                 normalized,
-                timeout=limits.timeout,
-                max_bytes=limits.per_page_bytes,
+                timeout=active_limits.timeout,
+                max_bytes=active_limits.per_page_bytes,
             )
         except (CollectionError, UnsafeTargetError):
             skipped.add(normalized)
@@ -123,12 +124,12 @@ def crawl_site(
             skipped.add(page.final_url)
             continue
         body_bytes = len(page.body.encode("utf-8"))
-        if total_bytes + body_bytes > limits.max_total_bytes:
+        if total_bytes + body_bytes > active_limits.max_total_bytes:
             byte_limit = True
             break
         total_bytes += body_bytes
         pages.append(CrawledPage(page, depth))
-        if depth >= limits.max_depth:
+        if depth >= active_limits.max_depth:
             continue
         parser = _PageSignals()
         parser.feed(page.body)
@@ -140,7 +141,9 @@ def crawl_site(
     return CrawlResult(
         pages=tuple(pages),
         skipped_urls=tuple(sorted(skipped)),
-        exhausted_page_limit=bool(queue) and len(pages) >= limits.max_pages,
+        exhausted_page_limit=(
+            bool(queue) and len(pages) >= active_limits.max_pages
+        ),
         exhausted_byte_limit=byte_limit,
     )
 

--- a/src/veridra/crawl.py
+++ b/src/veridra/crawl.py
@@ -46,7 +46,11 @@ class _PageSignals(HTMLParser):
         self.has_canonical = False
         self.has_mixed_content = False
 
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
         data = {key.lower(): (value or "") for key, value in attrs}
         lowered = {key: value.lower() for key, value in data.items()}
         if tag == "title":
@@ -59,7 +63,10 @@ class _PageSignals(HTMLParser):
             self.has_canonical = bool(data.get("href", "").strip())
         if tag == "a" and data.get("href"):
             self.links.append(data["href"])
-        if any(lowered.get(name, "").startswith("http://") for name in ("src", "href")):
+        if any(
+            lowered.get(name, "").startswith("http://")
+            for name in ("src", "href")
+        ):
             self.has_mixed_content = True
 
 
@@ -86,7 +93,9 @@ def crawl_site(
     collector: PageCollector = collect_page,
 ) -> CrawlResult:
     if limits.max_pages < 1 or limits.max_depth < 0:
-        raise ValueError("Crawl limits must allow at least one page and non-negative depth.")
+        raise ValueError(
+            "Crawl limits must allow at least one page and non-negative depth."
+        )
     queue: deque[tuple[str, int]] = deque([(start_url, 0)])
     seen: set[str] = set()
     pages: list[CrawledPage] = []
@@ -163,21 +172,40 @@ def analyze_crawl(result: CrawlResult) -> list[Finding]:
             checks["crawl.mixed-content"][2].append(page.final_url)
 
     findings: list[Finding] = []
+    website_health_ids = {
+        "crawl.http-status",
+        "crawl.title",
+        "crawl.h1",
+    }
     for identifier, (title, severity, affected) in checks.items():
         passed = not affected
         findings.append(
             Finding(
                 id=identifier,
-                area="Website health" if identifier in {"crawl.http-status", "crawl.title", "crawl.h1"} else "Search visibility",
+                area=(
+                    "Website health"
+                    if identifier in website_health_ids
+                    else "Search visibility"
+                ),
                 title=f"Multi-page {title.lower()}",
                 status=Status.passed if passed else Status.attention,
                 severity="info" if passed else severity,
                 summary=(
                     f"All {len(result.pages)} crawled HTML pages passed this check."
                     if passed
-                    else f"{len(affected)} of {len(result.pages)} crawled HTML pages need attention."
+                    else (
+                        f"{len(affected)} of {len(result.pages)} crawled HTML "
+                        "pages need attention."
+                    )
                 ),
-                recommendation=None if passed else f"Review and correct the affected pages for {title.lower()}.",
+                recommendation=(
+                    None
+                    if passed
+                    else (
+                        "Review and correct the affected pages for "
+                        f"{title.lower()}."
+                    )
+                ),
                 evidence={
                     "affected_urls": sorted(affected),
                     "crawled_pages": len(result.pages),

--- a/src/veridra/service.py
+++ b/src/veridra/service.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 from time import perf_counter
 from urllib.parse import urlparse
 
-from .collector import Requester, SiteEvidence, _request_once, collect_site
+from .collector import (
+    PageEvidence,
+    Requester,
+    SiteEvidence,
+    _request_once,
+    collect_page,
+    collect_site,
+)
 from .core import Assessment, Finding, Status, analyze_document
+from .crawl import CrawlLimits, analyze_crawl, crawl_site
 from .dns_posture import (
     RecordLookup,
     analyze_domain_posture,
@@ -68,6 +76,7 @@ def assess_url(
     *,
     requester: Requester = _request_once,
     dns_lookup: RecordLookup = live_lookup,
+    crawl_limits: CrawlLimits = CrawlLimits(),
 ) -> Assessment:
     started = perf_counter()
     evidence = collect_site(raw_url, requester=requester)
@@ -80,6 +89,27 @@ def assess_url(
             robots_text,
         )
     )
+
+    def collect_crawl_page(
+        url: str,
+        *,
+        timeout: float,
+        max_bytes: int,
+    ) -> PageEvidence:
+        return collect_page(
+            url,
+            timeout=timeout,
+            max_bytes=max_bytes,
+            requester=requester,
+        )
+
+    crawl = crawl_site(
+        evidence.homepage.final_url,
+        limits=crawl_limits,
+        collector=collect_crawl_page,
+    )
+    findings.extend(analyze_crawl(crawl))
+
     hostname = urlparse(evidence.homepage.final_url).hostname
     if hostname is not None:
         findings.extend(

--- a/src/veridra/service.py
+++ b/src/veridra/service.py
@@ -76,7 +76,7 @@ def assess_url(
     *,
     requester: Requester = _request_once,
     dns_lookup: RecordLookup = live_lookup,
-    crawl_limits: CrawlLimits = CrawlLimits(),
+    crawl_limits: CrawlLimits | None = None,
 ) -> Assessment:
     started = perf_counter()
     evidence = collect_site(raw_url, requester=requester)

--- a/src/veridra/version.py
+++ b/src/veridra/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from veridra.collector import PageEvidence
-from veridra.crawl import CrawlLimits, analyze_crawl, crawl_site
 from veridra.core import Status
+from veridra.crawl import CrawlLimits, analyze_crawl, crawl_site
 
 
 def _page(url: str, body: str, *, content_type: str = "text/html") -> PageEvidence:

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-
 from veridra.collector import PageEvidence
 from veridra.crawl import CrawlLimits, analyze_crawl, crawl_site
 from veridra.core import Status

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from veridra.collector import PageEvidence
 from veridra.crawl import CrawlLimits, analyze_crawl, crawl_site
 from veridra.core import Status
@@ -18,7 +20,10 @@ def _page(url: str, body: str, *, content_type: str = "text/html") -> PageEviden
     )
 
 
-def _collector(pages: dict[str, PageEvidence], calls: list[str]):
+def _collector(
+    pages: dict[str, PageEvidence],
+    calls: list[str],
+) -> Callable[..., PageEvidence]:
     def collect(url: str, **_: object) -> PageEvidence:
         calls.append(url)
         return pages[url]
@@ -58,7 +63,10 @@ def test_crawl_reports_page_limit() -> None:
             "https://example.com/",
             "<a href='/one'>One</a><a href='/two'>Two</a>",
         ),
-        "https://example.com/one": _page("https://example.com/one", "<p>One</p>"),
+        "https://example.com/one": _page(
+            "https://example.com/one",
+            "<p>One</p>",
+        ),
     }
     result = crawl_site(
         "https://example.com/",
@@ -81,14 +89,25 @@ def test_crawl_respects_total_byte_limit() -> None:
 
 
 def test_aggregate_findings_include_affected_urls() -> None:
-    complete = "<html><head><title>Good</title><meta name='description' content='Good'><link rel='canonical' href='https://example.com/'></head><body><h1>Good</h1></body></html>"
-    incomplete = "<html><body><img src='http://example.com/image.png'></body></html>"
+    complete = (
+        "<html><head><title>Good</title>"
+        "<meta name='description' content='Good'>"
+        "<link rel='canonical' href='https://example.com/'>"
+        "</head><body><h1>Good</h1></body></html>"
+    )
+    incomplete = (
+        "<html><body><img src='http://example.com/image.png'>"
+        "</body></html>"
+    )
     pages = {
         "https://example.com/": _page(
             "https://example.com/",
             complete + "<a href='/bad'>Bad</a>",
         ),
-        "https://example.com/bad": _page("https://example.com/bad", incomplete),
+        "https://example.com/bad": _page(
+            "https://example.com/bad",
+            incomplete,
+        ),
     }
     result = crawl_site(
         "https://example.com/",

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from veridra.collector import PageEvidence
+from veridra.crawl import CrawlLimits, analyze_crawl, crawl_site
+from veridra.core import Status
+
+
+def _page(url: str, body: str, *, content_type: str = "text/html") -> PageEvidence:
+    return PageEvidence(
+        requested_url=url,
+        final_url=url,
+        status_code=200,
+        headers={"content-type": content_type},
+        body=body,
+        redirect_chain=(),
+        connected_ip="93.184.216.34",
+        validated_ips=("93.184.216.34",),
+    )
+
+
+def _collector(pages: dict[str, PageEvidence], calls: list[str]):
+    def collect(url: str, **_: object) -> PageEvidence:
+        calls.append(url)
+        return pages[url]
+
+    return collect
+
+
+def test_crawl_is_same_origin_sequential_and_bounded() -> None:
+    pages = {
+        "https://example.com/": _page(
+            "https://example.com/",
+            "<html><head><title>Home</title></head><body><h1>Home</h1>"
+            "<a href='/about?utm_source=x#team'>About</a>"
+            "<a href='https://other.example/path'>External</a></body></html>",
+        ),
+        "https://example.com/about": _page(
+            "https://example.com/about",
+            "<html><head><title>About</title></head><body><h1>About</h1>"
+            "<a href='/deep'>Deep</a></body></html>",
+        ),
+    }
+    calls: list[str] = []
+    result = crawl_site(
+        "https://example.com/",
+        limits=CrawlLimits(max_pages=2, max_depth=1),
+        collector=_collector(pages, calls),
+    )
+
+    assert calls == ["https://example.com/", "https://example.com/about"]
+    assert [page.evidence.final_url for page in result.pages] == calls
+    assert result.exhausted_page_limit is False
+
+
+def test_crawl_reports_page_limit() -> None:
+    pages = {
+        "https://example.com/": _page(
+            "https://example.com/",
+            "<a href='/one'>One</a><a href='/two'>Two</a>",
+        ),
+        "https://example.com/one": _page("https://example.com/one", "<p>One</p>"),
+    }
+    result = crawl_site(
+        "https://example.com/",
+        limits=CrawlLimits(max_pages=2, max_depth=1),
+        collector=_collector(pages, []),
+    )
+    assert len(result.pages) == 2
+    assert result.exhausted_page_limit is True
+
+
+def test_crawl_respects_total_byte_limit() -> None:
+    page = _page("https://example.com/", "x" * 20)
+    result = crawl_site(
+        "https://example.com/",
+        limits=CrawlLimits(max_total_bytes=10),
+        collector=_collector({"https://example.com/": page}, []),
+    )
+    assert result.pages == ()
+    assert result.exhausted_byte_limit is True
+
+
+def test_aggregate_findings_include_affected_urls() -> None:
+    complete = "<html><head><title>Good</title><meta name='description' content='Good'><link rel='canonical' href='https://example.com/'></head><body><h1>Good</h1></body></html>"
+    incomplete = "<html><body><img src='http://example.com/image.png'></body></html>"
+    pages = {
+        "https://example.com/": _page(
+            "https://example.com/",
+            complete + "<a href='/bad'>Bad</a>",
+        ),
+        "https://example.com/bad": _page("https://example.com/bad", incomplete),
+    }
+    result = crawl_site(
+        "https://example.com/",
+        limits=CrawlLimits(max_pages=2, max_depth=1),
+        collector=_collector(pages, []),
+    )
+    findings = {finding.id: finding for finding in analyze_crawl(result)}
+
+    assert findings["crawl.title"].status == Status.attention
+    assert findings["crawl.title"].evidence["affected_urls"] == [
+        "https://example.com/bad"
+    ]
+    assert findings["crawl.mixed-content"].status == Status.attention
+    assert findings["crawl.http-status"].status == Status.passed
+
+
+def test_non_html_pages_are_skipped() -> None:
+    pages = {
+        "https://example.com/": _page(
+            "https://example.com/",
+            "<a href='/file.pdf'>PDF</a>",
+        ),
+        "https://example.com/file.pdf": _page(
+            "https://example.com/file.pdf",
+            "%PDF",
+            content_type="application/pdf",
+        ),
+    }
+    result = crawl_site(
+        "https://example.com/",
+        limits=CrawlLimits(max_pages=3, max_depth=1),
+        collector=_collector(pages, []),
+    )
+    assert len(result.pages) == 1
+    assert result.skipped_urls == ("https://example.com/file.pdf",)


### PR DESCRIPTION
Implements issue #32 with a sequential same-origin HTML crawl, strict page/depth/byte limits, page-level evidence, aggregate affected-URL findings, deterministic tests, and version 1.1.0. No authentication, forms, script execution, parallel crawling, private targets, or active scanning. Merge only after all exact-head CI gates pass.