### PR TITLE
Add report launch and profile editing workflow

### DIFF
--- a/src/veridra/profile_store.py
+++ b/src/veridra/profile_store.py
@@ -73,6 +73,18 @@ class ProfileStore:
         temporary_path.replace(destination)
         return entry_id
 
+    def replace(self, entry_id: str, profile: ReportProfile) -> str:
+        current_path = self._path(entry_id)
+        if not current_path.exists():
+            raise ProfileStoreError("Saved profile was not found.")
+        replacement_id = self.save(profile)
+        if replacement_id != entry_id:
+            try:
+                current_path.unlink()
+            except FileNotFoundError as exc:
+                raise ProfileStoreError("Saved profile was not found.") from exc
+        return replacement_id
+
     def load(self, entry_id: str) -> ReportProfile:
         path = self._path(entry_id)
         try:

--- a/src/veridra/profile_web.py
+++ b/src/veridra/profile_web.py
@@ -21,10 +21,39 @@ def _page(body: str, *, title: str = "Report profiles") -> str:
     return f"""<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>*{{box-sizing:border-box}}body{{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}}main{{max-width:980px;margin:36px auto;padding:0 20px}}section{{background:white;border:1px solid #dfe3e8;border-radius:9px;padding:22px;margin-bottom:18px}}label{{display:block;font-weight:700;margin:13px 0 5px}}input,textarea,select{{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}}textarea{{min-height:90px}}button,.button{{display:inline-block;border:0;border-radius:7px;background:#22272d;color:white;padding:10px 15px;text-decoration:none;cursor:pointer}}.secondary{{background:#5f6873}}.danger{{background:#b42318}}.row{{display:grid;grid-template-columns:1fr 1fr;gap:14px}}table{{width:100%;border-collapse:collapse}}th,td{{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}}.muted{{color:#68707a}}.actions{{display:flex;gap:8px;flex-wrap:wrap}}@media(max-width:700px){{.row{{grid-template-columns:1fr}}table{{display:block;overflow:auto}}}}</style></head><body><main>{body}</main></body></html>"""
 
 
-def _profile_form(profile: ReportProfile | None = None) -> str:
+def _profile_form(
+    profile: ReportProfile | None = None,
+    *,
+    action: str = "/profiles",
+    heading: str = "Create report profile",
+    button_label: str = "Save profile locally",
+) -> str:
     item = profile or ReportProfile()
     checked = " checked" if item.show_raw_evidence else ""
-    return f"""<section><h1>Create report profile</h1><p class='muted'>Profiles are saved only on this device and only after submission.</p><form method='post' action='/profiles'><div class='row'><div><label for='organisation_name'>Organisation</label><input id='organisation_name' name='organisation_name' maxlength='120' required value='{html.escape(item.organisation_name, quote=True)}'></div><div><label for='client_name'>Client</label><input id='client_name' name='client_name' maxlength='120' value='{html.escape(item.client_name or '', quote=True)}'></div></div><div class='row'><div><label for='consultant_name'>Consultant</label><input id='consultant_name' name='consultant_name' maxlength='120' value='{html.escape(item.consultant_name or '', quote=True)}'></div><div><label for='accent_colour'>Accent colour</label><input id='accent_colour' name='accent_colour' pattern='#[0-9A-Fa-f]{{6}}' required value='{html.escape(item.accent_colour, quote=True)}'></div></div><label for='introduction'>Introduction</label><textarea id='introduction' name='introduction' maxlength='1200'>{html.escape(item.introduction or '')}</textarea><div class='row'><div><label for='call_to_action_label'>Call-to-action label</label><input id='call_to_action_label' name='call_to_action_label' maxlength='80' value='{html.escape(item.call_to_action_label or '', quote=True)}'></div><div><label for='call_to_action_url'>Call-to-action URL</label><input id='call_to_action_url' name='call_to_action_url' maxlength='2048' value='{html.escape(item.call_to_action_url or '', quote=True)}'></div></div><div class='row'><div><label for='language'>Language</label><select id='language' name='language'><option value='en'{' selected' if item.language == 'en' else ''}>English</option><option value='es'{' selected' if item.language == 'es' else ''}>Spanish</option></select></div><div><label for='show_raw_evidence'>Evidence</label><label><input style='width:auto' id='show_raw_evidence' name='show_raw_evidence' type='checkbox' value='true'{checked}> Include raw evidence</label></div></div><p><button type='submit'>Save profile locally</button> <a class='button secondary' href='/'>Back to assessment</a></p></form></section>"""
+    return f"""<section><h1>{html.escape(heading)}</h1><p class='muted'>Profiles are saved only on this device and only after submission.</p><form method='post' action='{html.escape(action, quote=True)}'><div class='row'><div><label for='organisation_name'>Organisation</label><input id='organisation_name' name='organisation_name' maxlength='120' required value='{html.escape(item.organisation_name, quote=True)}'></div><div><label for='client_name'>Client</label><input id='client_name' name='client_name' maxlength='120' value='{html.escape(item.client_name or '', quote=True)}'></div></div><div class='row'><div><label for='consultant_name'>Consultant</label><input id='consultant_name' name='consultant_name' maxlength='120' value='{html.escape(item.consultant_name or '', quote=True)}'></div><div><label for='accent_colour'>Accent colour</label><input id='accent_colour' name='accent_colour' pattern='#[0-9A-Fa-f]{{6}}' required value='{html.escape(item.accent_colour, quote=True)}'></div></div><label for='introduction'>Introduction</label><textarea id='introduction' name='introduction' maxlength='1200'>{html.escape(item.introduction or '')}</textarea><div class='row'><div><label for='call_to_action_label'>Call-to-action label</label><input id='call_to_action_label' name='call_to_action_label' maxlength='80' value='{html.escape(item.call_to_action_label or '', quote=True)}'></div><div><label for='call_to_action_url'>Call-to-action URL</label><input id='call_to_action_url' name='call_to_action_url' maxlength='2048' value='{html.escape(item.call_to_action_url or '', quote=True)}'></div></div><div class='row'><div><label for='language'>Language</label><select id='language' name='language'><option value='en'{' selected' if item.language == 'en' else ''}>English</option><option value='es'{' selected' if item.language == 'es' else ''}>Spanish</option></select></div><div><label for='show_raw_evidence'>Evidence</label><label><input style='width:auto' id='show_raw_evidence' name='show_raw_evidence' type='checkbox' value='true'{checked}> Include raw evidence</label></div></div><p><button type='submit'>{html.escape(button_label)}</button> <a class='button secondary' href='/profiles'>Back to profiles</a></p></form></section>"""
+
+
+async def _profile_from_request(request: Request) -> ReportProfile:
+    values = parse_qs((await request.body()).decode("utf-8"), keep_blank_values=True)
+
+    def value(name: str) -> str | None:
+        raw = values.get(name, [""])[0].strip()
+        return raw or None
+
+    try:
+        return ReportProfile(
+            organisation_name=value("organisation_name") or "Veridra",
+            client_name=value("client_name"),
+            consultant_name=value("consultant_name"),
+            accent_colour=value("accent_colour") or "#22272d",
+            introduction=value("introduction"),
+            call_to_action_label=value("call_to_action_label"),
+            call_to_action_url=value("call_to_action_url"),
+            language=value("language") or "en",
+            show_raw_evidence=value("show_raw_evidence") == "true",
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="Invalid report profile.") from exc
 
 
 @router.get("", response_class=HTMLResponse)
@@ -32,7 +61,7 @@ def profile_list() -> str:
     entries = _store().list()
     if entries:
         rows = "".join(
-            "<tr><td><strong>{organisation}</strong><br><span class='muted'>{client}</span></td><td>{consultant}</td><td><div class='actions'><a class='button secondary' href='/profiles/{identifier}'>Review</a><form method='post' action='/profiles/{identifier}/delete'><button class='danger' type='submit'>Delete</button></form></div></td></tr>".format(
+            "<tr><td><strong>{organisation}</strong><br><span class='muted'>{client}</span></td><td>{consultant}</td><td><div class='actions'><a class='button secondary' href='/profiles/{identifier}'>Review</a><a class='button secondary' href='/profiles/{identifier}/edit'>Edit</a><form method='post' action='/profiles/{identifier}/delete'><button class='danger' type='submit'>Delete</button></form></div></td></tr>".format(
                 organisation=html.escape(entry.organisation_name),
                 client=html.escape(entry.client_name or "No client"),
                 consultant=html.escape(entry.consultant_name or "—"),
@@ -52,27 +81,7 @@ def profile_list() -> str:
 
 @router.post("")
 async def save_profile(request: Request) -> RedirectResponse:
-    values = parse_qs((await request.body()).decode("utf-8"), keep_blank_values=True)
-
-    def value(name: str) -> str | None:
-        raw = values.get(name, [""])[0].strip()
-        return raw or None
-
-    try:
-        profile = ReportProfile(
-            organisation_name=value("organisation_name") or "Veridra",
-            client_name=value("client_name"),
-            consultant_name=value("consultant_name"),
-            accent_colour=value("accent_colour") or "#22272d",
-            introduction=value("introduction"),
-            call_to_action_label=value("call_to_action_label"),
-            call_to_action_url=value("call_to_action_url"),
-            language=value("language") or "en",
-            show_raw_evidence=value("show_raw_evidence") == "true",
-        )
-    except ValidationError as exc:
-        raise HTTPException(status_code=400, detail="Invalid report profile.") from exc
-    entry_id = _store().save(profile)
+    entry_id = _store().save(await _profile_from_request(request))
     return RedirectResponse(f"/profiles/{entry_id}", status_code=303)
 
 
@@ -82,8 +91,34 @@ def profile_detail(entry_id: str) -> str:
         profile = _store().load(entry_id)
     except ProfileStoreError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    details = f"""<section><h1>{html.escape(profile.organisation_name)}</h1><p><strong>Client:</strong> {html.escape(profile.client_name or 'Not set')}</p><p><strong>Consultant:</strong> {html.escape(profile.consultant_name or 'Not set')}</p><p><strong>Language:</strong> {html.escape(profile.language)}</p><p><strong>Accent:</strong> {html.escape(profile.accent_colour)}</p><p><strong>Raw evidence:</strong> {'Included' if profile.show_raw_evidence else 'Hidden'}</p><div class='actions'><a class='button' href='/report?demo=true&profile={entry_id}'>Preview demo report</a><a class='button secondary' href='/export?demo=true&profile={entry_id}'>Export demo evidence</a><a class='button secondary' href='/profiles'>Back</a></div></section>"""
+    details = f"""<section><h1>{html.escape(profile.organisation_name)}</h1><p><strong>Client:</strong> {html.escape(profile.client_name or 'Not set')}</p><p><strong>Consultant:</strong> {html.escape(profile.consultant_name or 'Not set')}</p><p><strong>Language:</strong> {html.escape(profile.language)}</p><p><strong>Accent:</strong> {html.escape(profile.accent_colour)}</p><p><strong>Raw evidence:</strong> {'Included' if profile.show_raw_evidence else 'Hidden'}</p><div class='actions'><a class='button' href='/report?demo=true&amp;profile={entry_id}'>Preview demo report</a><a class='button secondary' href='/export?demo=true&amp;profile={entry_id}'>Export demo evidence</a><a class='button secondary' href='/profiles/{entry_id}/edit'>Edit profile</a><a class='button secondary' href='/profiles'>Back</a></div></section><section><h2>Launch branded assessment</h2><p class='muted'>Enter a public website to generate a report or evidence package with this profile.</p><form method='get'><input type='hidden' name='profile' value='{entry_id}'><label for='target_url'>Public website</label><input id='target_url' name='url' maxlength='2048' placeholder='example.com' required><p class='actions'><button type='submit' formaction='/report'>Open report</button><button class='secondary' type='submit' formaction='/export'>Export evidence</button></p></form></section>"""
     return _page(details, title=profile.organisation_name)
+
+
+@router.get("/{entry_id}/edit", response_class=HTMLResponse)
+def edit_profile(entry_id: str) -> str:
+    try:
+        profile = _store().load(entry_id)
+    except ProfileStoreError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return _page(
+        _profile_form(
+            profile,
+            action=f"/profiles/{entry_id}",
+            heading="Edit report profile",
+            button_label="Save changes",
+        ),
+        title=f"Edit {profile.organisation_name}",
+    )
+
+
+@router.post("/{entry_id}")
+async def update_profile(entry_id: str, request: Request) -> RedirectResponse:
+    try:
+        replacement_id = _store().replace(entry_id, await _profile_from_request(request))
+    except ProfileStoreError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return RedirectResponse(f"/profiles/{replacement_id}", status_code=303)
 
 
 @router.post("/{entry_id}/delete")

--- a/src/veridra/version.py
+++ b/src/veridra/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -40,6 +40,28 @@ def test_profile_store_overwrites_same_identifier_atomically(tmp_path: Path) -> 
     assert len(list(tmp_path.glob("*.json"))) == 1
 
 
+def test_profile_store_replaces_profile_and_removes_old_identifier(tmp_path: Path) -> None:
+    store = ProfileStore(tmp_path)
+    original = ReportProfile(organisation_name="Original Agency")
+    original_id = store.save(original)
+    replacement = ReportProfile(organisation_name="Updated Agency")
+
+    replacement_id = store.replace(original_id, replacement)
+
+    assert replacement_id == profile_id(replacement)
+    assert store.load(replacement_id) == replacement
+    with pytest.raises(ProfileStoreError, match="not found"):
+        store.load(original_id)
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_profile_store_replace_requires_existing_profile(tmp_path: Path) -> None:
+    store = ProfileStore(tmp_path)
+
+    with pytest.raises(ProfileStoreError, match="not found"):
+        store.replace("a" * 24, ReportProfile(organisation_name="New"))
+
+
 def test_profile_store_rejects_invalid_identifier(tmp_path: Path) -> None:
     store = ProfileStore(tmp_path)
 

--- a/tests/test_profile_web.py
+++ b/tests/test_profile_web.py
@@ -12,12 +12,8 @@ from veridra.app import app
 client = TestClient(app)
 
 
-def test_profile_workflow_and_report_selection(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def _create_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
     monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))
-
     created = client.post(
         "/profiles",
         data={
@@ -34,15 +30,27 @@ def test_profile_workflow_and_report_selection(
     )
     assert created.status_code == 303
     location = created.headers["location"]
-    entry_id = location.rsplit("/", 1)[1]
+    return location, location.rsplit("/", 1)[1]
+
+
+def test_profile_workflow_and_report_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    location, entry_id = _create_profile(tmp_path, monkeypatch)
 
     listing = client.get("/profiles")
     assert listing.status_code == 200
     assert "Agency &lt;One&gt;" in listing.text
+    assert f"/profiles/{entry_id}/edit" in listing.text
 
     detail = client.get(location)
     assert detail.status_code == 200
-    assert f"/report?demo=true&profile={entry_id}" in detail.text
+    assert f"/report?demo=true&amp;profile={entry_id}" in detail.text
+    assert "Launch branded assessment" in detail.text
+    assert "formaction='/report'" in detail.text
+    assert "formaction='/export'" in detail.text
+    assert f"name='profile' value='{entry_id}'" in detail.text
 
     report = client.get("/report", params={"demo": "true", "profile": entry_id})
     assert report.status_code == 200
@@ -58,6 +66,42 @@ def test_profile_workflow_and_report_selection(
     deleted = client.post(f"/profiles/{entry_id}/delete", follow_redirects=False)
     assert deleted.status_code == 303
     assert client.get(location).status_code == 404
+
+
+def test_profile_can_be_edited_and_redirects_to_new_identifier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_location, original_id = _create_profile(tmp_path, monkeypatch)
+
+    edit_page = client.get(f"/profiles/{original_id}/edit")
+    assert edit_page.status_code == 200
+    assert "Edit report profile" in edit_page.text
+    assert "Agency &lt;One&gt;" in edit_page.text
+
+    updated = client.post(
+        f"/profiles/{original_id}",
+        data={
+            "organisation_name": "Updated Agency",
+            "client_name": "Updated Client",
+            "consultant_name": "Rafael",
+            "accent_colour": "#654321",
+            "language": "es",
+            "show_raw_evidence": "true",
+        },
+        follow_redirects=False,
+    )
+    assert updated.status_code == 303
+    replacement_location = updated.headers["location"]
+    replacement_id = replacement_location.rsplit("/", 1)[1]
+    assert replacement_id != original_id
+    assert client.get(original_location).status_code == 404
+
+    detail = client.get(replacement_location)
+    assert detail.status_code == 200
+    assert "Updated Agency" in detail.text
+    assert "Updated Client" in detail.text
+    assert "<strong>Language:</strong> es" in detail.text
 
 
 def test_unknown_profile_is_not_silently_ignored(


### PR DESCRIPTION
Implements issue #38 with atomic saved-profile replacement, local edit forms, and direct branded report/evidence launch forms for real public targets. Existing anonymous and default Veridra reporting remain unchanged. No accounts, uploads, remote assets, arbitrary CSS, billing, or shared storage. Advances version to 1.4.0. Merge only after all exact-head CI gates pass.