### PR TITLE
Add durable tenant monitoring jobs and worker leases

### DIFF
--- a/docs/architecture/durable-monitoring-jobs.md
+++ b/docs/architecture/durable-monitoring-jobs.md
@@ -1,0 +1,43 @@
+# Durable tenant monitoring jobs
+
+## Purpose
+
+This milestone introduces a durable local job foundation for scheduled tenant monitoring without embedding an infinite worker loop inside the web process.
+
+## Security boundary
+
+Every job is qualified by both `tenant_id` and `project_id`. API callers may enqueue, list or cancel jobs only after the existing authenticated tenant and capability checks succeed. Worker execution must reload the tenant project before running and must write assessments and delivery attempts only through tenant-qualified stores.
+
+## Job lifecycle
+
+Jobs use explicit states:
+
+- `queued`: eligible when `next_attempt_at` is due;
+- `leased`: owned temporarily by one worker until `lease_expires_at`;
+- `succeeded`: terminal successful execution;
+- `failed`: terminal after the configured retry limit;
+- `cancelled`: terminal administrative cancellation.
+
+A failed attempt that still has retries remaining returns the job to `queued`, increments the attempt counter, records the last error and sets a future `next_attempt_at`.
+
+## Idempotency
+
+Enqueue uses a deterministic key derived from tenant, project and logical run window. Re-enqueueing the same logical run must return the existing job rather than creating duplicate monitoring work.
+
+## Leasing
+
+Lease acquisition is transactional. Only one worker can transition a due queued job to leased. Expired leases may be recovered by another worker. Completion and failure operations must verify the current lease owner.
+
+## Worker boundary
+
+The first implementation is a narrow command-line worker that leases and executes a bounded number of jobs, then exits. Process supervision and scheduling belong to deployment tooling, not the web application.
+
+## Explicit exclusions
+
+- Redis, SQS, Celery or other distributed queue infrastructure;
+- multi-region coordination;
+- production SMTP configuration;
+- billing and quota enforcement;
+- deployment orchestration.
+
+Related to issue #83.

--- a/docs/operations/durable-monitoring-worker.md
+++ b/docs/operations/durable-monitoring-worker.md
@@ -1,0 +1,79 @@
+# Durable monitoring worker operations
+
+## Purpose
+
+`veridra-monitoring-worker` leases and executes a bounded number of due tenant-monitoring jobs, then exits. It is intentionally not an infinite in-process thread and does not schedule itself.
+
+## Required configuration
+
+Set the tenant data root through either:
+
+```text
+VERIDRA_TENANT_DATA_ROOT=/absolute/path/to/tenant-data
+```
+
+or the command-line option:
+
+```text
+veridra-monitoring-worker --tenant-data-root /absolute/path/to/tenant-data
+```
+
+The worker and web application must use the same tenant data root. The durable queue database is stored at:
+
+```text
+<tenant-data-root>/monitoring-jobs.sqlite3
+```
+
+## Running a bounded worker pass
+
+```text
+veridra-monitoring-worker --limit 10
+```
+
+The command reports how many jobs were leased, succeeded, returned for retry, or reached terminal failure. `--limit` must remain between 1 and 100.
+
+Run the command from an external supervisor such as a systemd timer, Windows Task Scheduler, container cron replacement, or a managed job runner. Deployment supervision is outside the web application.
+
+## Job lifecycle
+
+- `queued`: eligible after `next_attempt_at`.
+- `leased`: temporarily owned by one worker token until lease expiry.
+- `succeeded`: terminal successful execution.
+- `failed`: terminal after the configured attempt limit.
+- `cancelled`: terminal administrative cancellation.
+
+A worker crash leaves the job leased until `lease_expires_at`. A later worker can recover that stale lease. Completion and failure require the current opaque lease token; an earlier worker cannot finish a recovered job.
+
+## Retry and idempotency behavior
+
+Enqueueing is idempotent for one tenant, project and logical run window. Repeating the same enqueue request returns the existing job.
+
+A failed attempt records the error and either:
+
+- returns the job to `queued` with a future retry time; or
+- marks it `failed` when the attempt limit is reached.
+
+A successful or cancelled job is never leased again.
+
+## Tenant boundary
+
+Every job contains a tenant ID and project ID. The API validates the project inside the authenticated tenant before enqueueing. Worker execution reloads that tenant-qualified project and writes assessments and delivery attempts only beneath the same tenant root.
+
+The worker does not accept tenant IDs, project definitions, targets or roles from untrusted HTTP input during execution. Those values come from the durable job and are revalidated against tenant-qualified project storage.
+
+## Operational checks
+
+Before enabling a recurring supervisor:
+
+1. Confirm the web application and worker use the same absolute tenant-data root.
+2. Enqueue one test job through the authenticated API.
+3. Run the worker with `--limit 1`.
+4. Confirm the job becomes `succeeded` or records a bounded retry error.
+5. Confirm the assessment exists beneath the expected tenant/project directory.
+6. Confirm no global legacy history directory was written by the worker.
+
+Back up the SQLite queue database and tenant data together when a consistent operational snapshot is required.
+
+## Explicit exclusions
+
+This implementation does not provide Redis, SQS, Celery, multi-region coordination, production process supervision, SMTP configuration, billing quotas or deployment orchestration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ veridra-api = "veridra.runtime:main"
 veridra-audit = "veridra.audit:main"
 veridra-project-migrate = "veridra.project_migration_cli:main"
 veridra-identity-bootstrap = "veridra.identity_bootstrap_cli:main"
+veridra-monitoring-worker = "veridra.monitoring_worker_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/monitoring_job_api.py
+++ b/src/veridra/monitoring_job_api.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from .identity_tenancy import RequestIdentity, TenantCapability
+from .monitoring_job_store import MonitoringJob, MonitoringJobError, SQLiteMonitoringJobStore
+from .request_security import require_request_capability
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+
+router = APIRouter(prefix="/api/tenant/monitoring-jobs", tags=["tenant-monitoring-jobs"])
+MonitoringReader = Annotated[
+    RequestIdentity,
+    Depends(require_request_capability(TenantCapability.view_data)),
+]
+MonitoringManager = Annotated[
+    RequestIdentity,
+    Depends(require_request_capability(TenantCapability.manage_monitoring)),
+]
+
+
+class MonitoringJobEnqueueRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    project_id: str = Field(min_length=24, max_length=24)
+    run_window: str = Field(min_length=1, max_length=160)
+    max_attempts: int = Field(default=3, ge=1, le=10)
+
+
+class MonitoringJobResponse(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str
+    project_id: str
+    run_window: str
+    state: str
+    attempt_count: int
+    max_attempts: int
+    next_attempt_at: datetime
+    lease_expires_at: datetime | None
+    last_error: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+def _root(request: Request) -> Path:
+    configured = getattr(request.app.state, "veridra_tenant_data_root", None)
+    if not isinstance(configured, Path):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Tenant data storage is not configured.",
+        )
+    return configured
+
+
+def _store(request: Request) -> SQLiteMonitoringJobStore:
+    return SQLiteMonitoringJobStore(_root(request) / "monitoring-jobs.sqlite3")
+
+
+def _response(job: MonitoringJob) -> MonitoringJobResponse:
+    return MonitoringJobResponse(
+        id=job.id,
+        project_id=job.project_id,
+        run_window=job.run_window,
+        state=job.state.value,
+        attempt_count=job.attempt_count,
+        max_attempts=job.max_attempts,
+        next_attempt_at=job.next_attempt_at,
+        lease_expires_at=job.lease_expires_at,
+        last_error=job.last_error,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+    )
+
+
+def _require_project(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+) -> None:
+    projects = TenantProjectStore(_root(request))
+    try:
+        projects.load(identity, projects.ref(identity, project_id))
+    except TenantProjectStoreError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found.",
+        ) from exc
+
+
+@router.get("", response_model=list[MonitoringJobResponse])
+def list_monitoring_jobs(
+    request: Request,
+    identity: MonitoringReader,
+) -> list[MonitoringJobResponse]:
+    return [_response(job) for job in _store(request).list_for_tenant(identity.tenant_id)]
+
+
+@router.post("", response_model=MonitoringJobResponse, status_code=status.HTTP_201_CREATED)
+def enqueue_monitoring_job(
+    payload: MonitoringJobEnqueueRequest,
+    request: Request,
+    identity: MonitoringManager,
+) -> MonitoringJobResponse:
+    _require_project(request, identity, payload.project_id)
+    try:
+        job = _store(request).enqueue(
+            tenant_id=identity.tenant_id,
+            project_id=payload.project_id,
+            run_window=payload.run_window,
+            max_attempts=payload.max_attempts,
+            now=datetime.now(UTC),
+        )
+    except MonitoringJobError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _response(job)
+
+
+@router.delete("/{job_id}", response_model=MonitoringJobResponse)
+def cancel_monitoring_job(
+    job_id: str,
+    request: Request,
+    identity: MonitoringManager,
+) -> MonitoringJobResponse:
+    try:
+        job = _store(request).cancel(
+            tenant_id=identity.tenant_id,
+            job_id=job_id,
+            now=datetime.now(UTC),
+        )
+    except MonitoringJobError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Monitoring job not found.",
+        ) from exc
+    return _response(job)

--- a/src/veridra/monitoring_job_api.py
+++ b/src/veridra/monitoring_job_api.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict, Field
 
 from .identity_tenancy import RequestIdentity, TenantCapability
-from .monitoring_job_store import MonitoringJob, MonitoringJobError, SQLiteMonitoringJobStore
+from .monitoring_jobs import MonitoringJob, MonitoringJobError, SQLiteMonitoringJobStore
 from .request_security import require_request_capability
 from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
 

--- a/src/veridra/monitoring_jobs.py
+++ b/src/veridra/monitoring_jobs.py
@@ -120,7 +120,7 @@ class SQLiteMonitoringJobStore:
             raise MonitoringJobError("max_attempts must be at least 1.")
         timestamp = _utc(now)
         idempotency_key = hashlib.sha256(
-            f"{tenant_id}:{project_id}:{run_window}".encode("utf-8")
+            f"{tenant_id}:{project_id}:{run_window}".encode()
         ).hexdigest()
         job_id = idempotency_key[:24]
         self.initialize()
@@ -187,7 +187,7 @@ class SQLiteMonitoringJobStore:
             raise MonitoringJobError("lease_duration must be positive.")
         lease_expires_at = timestamp + lease_duration
         worker_token = secrets.token_urlsafe(32)
-        token_hash = hashlib.sha256(worker_token.encode("utf-8")).hexdigest()
+        token_hash = hashlib.sha256(worker_token.encode()).hexdigest()
         self.initialize()
         connection = self._connect()
         try:
@@ -318,7 +318,7 @@ class SQLiteMonitoringJobStore:
     ) -> MonitoringJob:
         job_id = _validate_identifier(job_id, field="job_id")
         timestamp = _utc(now)
-        token_hash = hashlib.sha256(worker_token.encode("utf-8")).hexdigest()
+        token_hash = hashlib.sha256(worker_token.encode()).hexdigest()
         self.initialize()
         connection = self._connect()
         try:

--- a/src/veridra/monitoring_jobs.py
+++ b/src/veridra/monitoring_jobs.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+
+
+class MonitoringJobError(RuntimeError):
+    pass
+
+
+class MonitoringJobState(StrEnum):
+    queued = "queued"
+    leased = "leased"
+    succeeded = "succeeded"
+    failed = "failed"
+    cancelled = "cancelled"
+
+
+@dataclass(frozen=True)
+class MonitoringJob:
+    id: str
+    tenant_id: str
+    project_id: str
+    run_window: str
+    idempotency_key: str
+    state: MonitoringJobState
+    attempt_count: int
+    max_attempts: int
+    next_attempt_at: datetime
+    lease_expires_at: datetime | None
+    last_error: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class MonitoringJobLease:
+    job: MonitoringJob
+    worker_token: str
+
+
+def _validate_identifier(value: str, *, field: str) -> str:
+    if len(value) != 24 or any(character not in "0123456789abcdef" for character in value):
+        raise MonitoringJobError(f"{field} must be 24 lowercase hexadecimal characters.")
+    return value
+
+
+def _utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise MonitoringJobError("Job timestamps must be timezone-aware.")
+    return value.astimezone(UTC)
+
+
+def _decode_optional(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value) if value else None
+
+
+class SQLiteMonitoringJobStore:
+    def __init__(self, database: Path) -> None:
+        self.database = database
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def initialize(self) -> None:
+        self.database.parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as connection:
+            connection.execute(
+                """CREATE TABLE IF NOT EXISTS monitoring_jobs (
+                    id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    project_id TEXT NOT NULL,
+                    run_window TEXT NOT NULL,
+                    idempotency_key TEXT NOT NULL UNIQUE,
+                    state TEXT NOT NULL,
+                    attempt_count INTEGER NOT NULL,
+                    max_attempts INTEGER NOT NULL,
+                    next_attempt_at TEXT NOT NULL,
+                    lease_token_hash TEXT,
+                    lease_expires_at TEXT,
+                    last_error TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    CHECK (state IN ('queued', 'leased', 'succeeded', 'failed', 'cancelled')),
+                    CHECK (attempt_count >= 0),
+                    CHECK (max_attempts >= 1),
+                    UNIQUE (tenant_id, id)
+                )"""
+            )
+            connection.execute(
+                """CREATE INDEX IF NOT EXISTS monitoring_jobs_due_idx
+                ON monitoring_jobs(state, next_attempt_at, created_at)"""
+            )
+            connection.execute(
+                """CREATE INDEX IF NOT EXISTS monitoring_jobs_tenant_idx
+                ON monitoring_jobs(tenant_id, created_at DESC)"""
+            )
+
+    def enqueue(
+        self,
+        *,
+        tenant_id: str,
+        project_id: str,
+        run_window: str,
+        now: datetime,
+        max_attempts: int = 3,
+    ) -> MonitoringJob:
+        tenant_id = _validate_identifier(tenant_id, field="tenant_id")
+        project_id = _validate_identifier(project_id, field="project_id")
+        if not run_window.strip():
+            raise MonitoringJobError("run_window is required.")
+        if max_attempts < 1:
+            raise MonitoringJobError("max_attempts must be at least 1.")
+        timestamp = _utc(now)
+        idempotency_key = hashlib.sha256(
+            f"{tenant_id}:{project_id}:{run_window}".encode("utf-8")
+        ).hexdigest()
+        job_id = idempotency_key[:24]
+        self.initialize()
+        with self._connect() as connection:
+            connection.execute(
+                """INSERT OR IGNORE INTO monitoring_jobs
+                (id, tenant_id, project_id, run_window, idempotency_key, state,
+                 attempt_count, max_attempts, next_attempt_at, lease_token_hash,
+                 lease_expires_at, last_error, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, NULL, NULL, NULL, ?, ?)""",
+                (
+                    job_id,
+                    tenant_id,
+                    project_id,
+                    run_window,
+                    idempotency_key,
+                    MonitoringJobState.queued.value,
+                    max_attempts,
+                    timestamp.isoformat(),
+                    timestamp.isoformat(),
+                    timestamp.isoformat(),
+                ),
+            )
+            row = connection.execute(
+                "SELECT * FROM monitoring_jobs WHERE idempotency_key = ?",
+                (idempotency_key,),
+            ).fetchone()
+        if row is None:
+            raise MonitoringJobError("Monitoring job could not be loaded after enqueue.")
+        return self._decode(row)
+
+    def list_for_tenant(self, tenant_id: str) -> tuple[MonitoringJob, ...]:
+        tenant_id = _validate_identifier(tenant_id, field="tenant_id")
+        self.initialize()
+        with self._connect() as connection:
+            rows = connection.execute(
+                """SELECT * FROM monitoring_jobs WHERE tenant_id = ?
+                ORDER BY created_at DESC, id DESC""",
+                (tenant_id,),
+            ).fetchall()
+        return tuple(self._decode(row) for row in rows)
+
+    def load(self, *, tenant_id: str, job_id: str) -> MonitoringJob:
+        tenant_id = _validate_identifier(tenant_id, field="tenant_id")
+        job_id = _validate_identifier(job_id, field="job_id")
+        self.initialize()
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM monitoring_jobs WHERE tenant_id = ? AND id = ?",
+                (tenant_id, job_id),
+            ).fetchone()
+        if row is None:
+            raise MonitoringJobError("Monitoring job not found.")
+        return self._decode(row)
+
+    def lease_next(
+        self,
+        *,
+        now: datetime,
+        lease_duration: timedelta,
+    ) -> MonitoringJobLease | None:
+        timestamp = _utc(now)
+        if lease_duration <= timedelta(0):
+            raise MonitoringJobError("lease_duration must be positive.")
+        lease_expires_at = timestamp + lease_duration
+        worker_token = secrets.token_urlsafe(32)
+        token_hash = hashlib.sha256(worker_token.encode("utf-8")).hexdigest()
+        self.initialize()
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """SELECT * FROM monitoring_jobs
+                WHERE (
+                    state = ? AND next_attempt_at <= ?
+                ) OR (
+                    state = ? AND lease_expires_at <= ?
+                )
+                ORDER BY next_attempt_at, created_at, id
+                LIMIT 1""",
+                (
+                    MonitoringJobState.queued.value,
+                    timestamp.isoformat(),
+                    MonitoringJobState.leased.value,
+                    timestamp.isoformat(),
+                ),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                return None
+            updated = connection.execute(
+                """UPDATE monitoring_jobs
+                SET state = ?, lease_token_hash = ?, lease_expires_at = ?, updated_at = ?
+                WHERE id = ? AND (
+                    (state = ? AND next_attempt_at <= ?) OR
+                    (state = ? AND lease_expires_at <= ?)
+                )""",
+                (
+                    MonitoringJobState.leased.value,
+                    token_hash,
+                    lease_expires_at.isoformat(),
+                    timestamp.isoformat(),
+                    row["id"],
+                    MonitoringJobState.queued.value,
+                    timestamp.isoformat(),
+                    MonitoringJobState.leased.value,
+                    timestamp.isoformat(),
+                ),
+            )
+            if updated.rowcount != 1:
+                connection.rollback()
+                return None
+            leased = connection.execute(
+                "SELECT * FROM monitoring_jobs WHERE id = ?",
+                (row["id"],),
+            ).fetchone()
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+        if leased is None:
+            raise MonitoringJobError("Leased job could not be reloaded.")
+        return MonitoringJobLease(job=self._decode(leased), worker_token=worker_token)
+
+    def succeed(
+        self,
+        *,
+        job_id: str,
+        worker_token: str,
+        now: datetime,
+    ) -> MonitoringJob:
+        return self._finish(
+            job_id=job_id,
+            worker_token=worker_token,
+            now=now,
+            error=None,
+            retry_delay=None,
+        )
+
+    def fail(
+        self,
+        *,
+        job_id: str,
+        worker_token: str,
+        now: datetime,
+        error: str,
+        retry_delay: timedelta,
+    ) -> MonitoringJob:
+        if not error.strip():
+            raise MonitoringJobError("error is required.")
+        if retry_delay < timedelta(0):
+            raise MonitoringJobError("retry_delay cannot be negative.")
+        return self._finish(
+            job_id=job_id,
+            worker_token=worker_token,
+            now=now,
+            error=error,
+            retry_delay=retry_delay,
+        )
+
+    def cancel(self, *, tenant_id: str, job_id: str, now: datetime) -> MonitoringJob:
+        tenant_id = _validate_identifier(tenant_id, field="tenant_id")
+        job_id = _validate_identifier(job_id, field="job_id")
+        timestamp = _utc(now)
+        self.initialize()
+        with self._connect() as connection:
+            updated = connection.execute(
+                """UPDATE monitoring_jobs
+                SET state = ?, lease_token_hash = NULL, lease_expires_at = NULL,
+                    updated_at = ?
+                WHERE tenant_id = ? AND id = ? AND state IN (?, ?)""",
+                (
+                    MonitoringJobState.cancelled.value,
+                    timestamp.isoformat(),
+                    tenant_id,
+                    job_id,
+                    MonitoringJobState.queued.value,
+                    MonitoringJobState.leased.value,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise MonitoringJobError("Cancellable monitoring job not found.")
+        return self.load(tenant_id=tenant_id, job_id=job_id)
+
+    def _finish(
+        self,
+        *,
+        job_id: str,
+        worker_token: str,
+        now: datetime,
+        error: str | None,
+        retry_delay: timedelta | None,
+    ) -> MonitoringJob:
+        job_id = _validate_identifier(job_id, field="job_id")
+        timestamp = _utc(now)
+        token_hash = hashlib.sha256(worker_token.encode("utf-8")).hexdigest()
+        self.initialize()
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """SELECT * FROM monitoring_jobs
+                WHERE id = ? AND state = ? AND lease_token_hash = ?""",
+                (job_id, MonitoringJobState.leased.value, token_hash),
+            ).fetchone()
+            if row is None:
+                raise MonitoringJobError("Current monitoring-job lease was not found.")
+            attempt_count = int(row["attempt_count"]) + 1
+            if error is None:
+                state = MonitoringJobState.succeeded
+                next_attempt_at = timestamp
+                last_error = None
+            elif attempt_count >= int(row["max_attempts"]):
+                state = MonitoringJobState.failed
+                next_attempt_at = timestamp
+                last_error = error
+            else:
+                state = MonitoringJobState.queued
+                next_attempt_at = timestamp + (retry_delay or timedelta(0))
+                last_error = error
+            connection.execute(
+                """UPDATE monitoring_jobs
+                SET state = ?, attempt_count = ?, next_attempt_at = ?,
+                    lease_token_hash = NULL, lease_expires_at = NULL,
+                    last_error = ?, updated_at = ?
+                WHERE id = ?""",
+                (
+                    state.value,
+                    attempt_count,
+                    next_attempt_at.isoformat(),
+                    last_error,
+                    timestamp.isoformat(),
+                    job_id,
+                ),
+            )
+            finished = connection.execute(
+                "SELECT * FROM monitoring_jobs WHERE id = ?",
+                (job_id,),
+            ).fetchone()
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+        if finished is None:
+            raise MonitoringJobError("Monitoring job could not be reloaded.")
+        return self._decode(finished)
+
+    @staticmethod
+    def _decode(row: sqlite3.Row) -> MonitoringJob:
+        return MonitoringJob(
+            id=str(row["id"]),
+            tenant_id=str(row["tenant_id"]),
+            project_id=str(row["project_id"]),
+            run_window=str(row["run_window"]),
+            idempotency_key=str(row["idempotency_key"]),
+            state=MonitoringJobState(str(row["state"])),
+            attempt_count=int(row["attempt_count"]),
+            max_attempts=int(row["max_attempts"]),
+            next_attempt_at=datetime.fromisoformat(str(row["next_attempt_at"])),
+            lease_expires_at=_decode_optional(row["lease_expires_at"]),
+            last_error=str(row["last_error"]) if row["last_error"] else None,
+            created_at=datetime.fromisoformat(str(row["created_at"])),
+            updated_at=datetime.fromisoformat(str(row["updated_at"])),
+        )

--- a/src/veridra/monitoring_worker.py
+++ b/src/veridra/monitoring_worker.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from .monitoring_job_store import MonitoringJobState, SQLiteMonitoringJobStore
+from .monitoring_jobs import MonitoringJobState, SQLiteMonitoringJobStore
 from .tenant_monitoring_execution import (
     TenantMonitoringExecutionResult,
     execute_tenant_monitoring,

--- a/src/veridra/monitoring_worker.py
+++ b/src/veridra/monitoring_worker.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from .monitoring_job_store import MonitoringJobState, SQLiteMonitoringJobStore
+from .tenant_monitoring_execution import (
+    TenantMonitoringExecutionResult,
+    execute_tenant_monitoring,
+)
+
+Execution = Callable[..., TenantMonitoringExecutionResult]
+
+
+@dataclass(frozen=True)
+class MonitoringWorkerResult:
+    leased: int
+    succeeded: int
+    retried: int
+    failed: int
+
+
+class MonitoringWorker:
+    def __init__(
+        self,
+        *,
+        root: Path,
+        store: SQLiteMonitoringJobStore | None = None,
+        execute: Execution = execute_tenant_monitoring,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.root = root
+        self.store = store or SQLiteMonitoringJobStore(root / "monitoring-jobs.sqlite3")
+        self.execute = execute
+        self.clock = clock or (lambda: datetime.now(UTC))
+
+    def run_once(
+        self,
+        *,
+        limit: int = 10,
+        lease_duration: timedelta = timedelta(minutes=15),
+        retry_delay: timedelta = timedelta(minutes=5),
+    ) -> MonitoringWorkerResult:
+        if limit < 1 or limit > 100:
+            raise ValueError("limit must be between 1 and 100.")
+        leased = 0
+        succeeded = 0
+        retried = 0
+        failed = 0
+        for _ in range(limit):
+            lease = self.store.lease_next(
+                now=self.clock(),
+                lease_duration=lease_duration,
+            )
+            if lease is None:
+                break
+            leased += 1
+            try:
+                self.execute(
+                    root=self.root,
+                    tenant_id=lease.job.tenant_id,
+                    project_id=lease.job.project_id,
+                )
+            except Exception as exc:
+                finished = self.store.fail(
+                    job_id=lease.job.id,
+                    worker_token=lease.worker_token,
+                    now=self.clock(),
+                    error=str(exc) or exc.__class__.__name__,
+                    retry_delay=retry_delay,
+                )
+                if finished.state is MonitoringJobState.failed:
+                    failed += 1
+                else:
+                    retried += 1
+            else:
+                self.store.succeed(
+                    job_id=lease.job.id,
+                    worker_token=lease.worker_token,
+                    now=self.clock(),
+                )
+                succeeded += 1
+        return MonitoringWorkerResult(
+            leased=leased,
+            succeeded=succeeded,
+            retried=retried,
+            failed=failed,
+        )

--- a/src/veridra/monitoring_worker_cli.py
+++ b/src/veridra/monitoring_worker_cli.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from .monitoring_worker import MonitoringWorker
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Lease and execute a bounded number of durable tenant monitoring jobs."
+    )
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument(
+        "--tenant-data-root",
+        type=Path,
+        default=None,
+        help="Tenant data root. Defaults to VERIDRA_TENANT_DATA_ROOT.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    configured = args.tenant_data_root or os.environ.get("VERIDRA_TENANT_DATA_ROOT")
+    if configured is None:
+        raise SystemExit(
+            "Tenant data root is required via --tenant-data-root or VERIDRA_TENANT_DATA_ROOT."
+        )
+    root = Path(configured).expanduser().resolve()
+    result = MonitoringWorker(root=root).run_once(limit=args.limit)
+    print(
+        "leased={leased} succeeded={succeeded} retried={retried} failed={failed}".format(
+            leased=result.leased,
+            succeeded=result.succeeded,
+            retried=result.retried,
+            failed=result.failed,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/veridra/monitoring_worker_cli.py
+++ b/src/veridra/monitoring_worker_cli.py
@@ -31,12 +31,8 @@ def main() -> None:
     root = Path(configured).expanduser().resolve()
     result = MonitoringWorker(root=root).run_once(limit=args.limit)
     print(
-        "leased={leased} succeeded={succeeded} retried={retried} failed={failed}".format(
-            leased=result.leased,
-            succeeded=result.succeeded,
-            retried=result.retried,
-            failed=result.failed,
-        )
+        f"leased={result.leased} succeeded={result.succeeded} "
+        f"retried={result.retried} failed={result.failed}"
     )
 
 

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -14,6 +14,7 @@ from .invitation_api import router as invitation_router
 from .lead_form_tenant_binding_api import router as lead_form_tenant_binding_router
 from .lead_web import router as lead_router
 from .member_assignments_web import router as member_assignments_router
+from .monitoring_job_api import router as monitoring_job_router
 from .monitoring_web import router as monitoring_router
 from .password_recovery_api import router as password_recovery_router
 from .pdf_web import router as pdf_router
@@ -76,6 +77,7 @@ app.include_router(tenant_lead_router)
 app.include_router(tenant_lead_form_router)
 app.include_router(tenant_task_router)
 app.include_router(tenant_monitoring_router)
+app.include_router(monitoring_job_router)
 app.include_router(tenant_profile_router)
 app.include_router(lead_form_tenant_binding_router)
 app.include_router(tenant_bound_lead_capture_router)

--- a/src/veridra/tenant_monitoring_execution.py
+++ b/src/veridra/tenant_monitoring_execution.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 
-from .collector import CollectionError
-from .core import UnsafeTargetError
 from .email_delivery import EmailAttemptStore, EmailDeliveryError, EmailStatus, send_monitoring_summary
 from .identity_tenancy import RequestIdentity, TenantRole
 from .service import assess_url
@@ -25,7 +24,7 @@ def _worker_identity(tenant_id: str) -> RequestIdentity:
         tenant_id=tenant_id,
         membership_role=TenantRole.owner,
         session_id="0" * 24,
-        authenticated_at=None,
+        authenticated_at=datetime.now(UTC),
     )
 
 
@@ -38,13 +37,10 @@ def execute_tenant_monitoring(
     identity = _worker_identity(tenant_id)
     projects = TenantProjectStore(root)
     project = projects.load(identity, projects.ref(identity, project_id))
-    try:
-        assessment = assess_url(
-            project.target_url,
-            crawl_profile=project.resolved_crawl_profile(),
-        )
-    except (UnsafeTargetError, CollectionError, ValueError):
-        raise
+    assessment = assess_url(
+        project.target_url,
+        crawl_profile=project.resolved_crawl_profile(),
+    )
 
     history = TenantHistoryStore(root)
     assessment_id = history.save(identity, project_id, assessment)

--- a/src/veridra/tenant_monitoring_execution.py
+++ b/src/veridra/tenant_monitoring_execution.py
@@ -4,7 +4,12 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from .email_delivery import EmailAttemptStore, EmailDeliveryError, EmailStatus, send_monitoring_summary
+from .email_delivery import (
+    EmailAttemptStore,
+    EmailDeliveryError,
+    EmailStatus,
+    send_monitoring_summary,
+)
 from .identity_tenancy import RequestIdentity, TenantRole
 from .service import assess_url
 from .tenant_history_store import TenantHistoryStore

--- a/src/veridra/tenant_monitoring_execution.py
+++ b/src/veridra/tenant_monitoring_execution.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .collector import CollectionError
+from .core import UnsafeTargetError
+from .email_delivery import EmailAttemptStore, EmailDeliveryError, EmailStatus, send_monitoring_summary
+from .identity_tenancy import RequestIdentity, TenantRole
+from .service import assess_url
+from .tenant_history_store import TenantHistoryStore
+from .tenant_project_store import TenantProjectStore
+
+
+@dataclass(frozen=True)
+class TenantMonitoringExecutionResult:
+    assessment_id: str
+    email_status: EmailStatus | None
+    email_error: str | None
+
+
+def _worker_identity(tenant_id: str) -> RequestIdentity:
+    return RequestIdentity(
+        user_id="0" * 24,
+        tenant_id=tenant_id,
+        membership_role=TenantRole.owner,
+        session_id="0" * 24,
+        authenticated_at=None,
+    )
+
+
+def execute_tenant_monitoring(
+    *,
+    root: Path,
+    tenant_id: str,
+    project_id: str,
+) -> TenantMonitoringExecutionResult:
+    identity = _worker_identity(tenant_id)
+    projects = TenantProjectStore(root)
+    project = projects.load(identity, projects.ref(identity, project_id))
+    try:
+        assessment = assess_url(
+            project.target_url,
+            crawl_profile=project.resolved_crawl_profile(),
+        )
+    except (UnsafeTargetError, CollectionError, ValueError):
+        raise
+
+    history = TenantHistoryStore(root)
+    assessment_id = history.save(identity, project_id, assessment)
+    email_status: EmailStatus | None = None
+    email_error: str | None = None
+    try:
+        attempt = send_monitoring_summary(
+            project_id=project_id,
+            project_name=project.name,
+            target_url=project.target_url,
+            assessment_id=assessment_id,
+            assessment=assessment,
+            recipient=(
+                str(project.monitoring_email)
+                if project.monitoring_email is not None
+                else None
+            ),
+            store=EmailAttemptStore(history.root / tenant_id / "email-deliveries"),
+        )
+        if attempt is not None:
+            email_status = attempt.status
+            email_error = attempt.error or None
+    except EmailDeliveryError as exc:
+        email_status = EmailStatus.failed
+        email_error = str(exc)
+
+    return TenantMonitoringExecutionResult(
+        assessment_id=assessment_id,
+        email_status=email_status,
+        email_error=email_error,
+    )

--- a/tests/test_monitoring_jobs.py
+++ b/tests/test_monitoring_jobs.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from veridra.monitoring_jobs import (
+    MonitoringJobError,
+    MonitoringJobState,
+    SQLiteMonitoringJobStore,
+)
+
+NOW = datetime(2026, 7, 26, 16, 0, tzinfo=UTC)
+TENANT_A = "a" * 24
+TENANT_B = "b" * 24
+PROJECT = "c" * 24
+
+
+def _store(tmp_path: Path) -> SQLiteMonitoringJobStore:
+    store = SQLiteMonitoringJobStore(tmp_path / "monitoring-jobs.sqlite3")
+    store.initialize()
+    return store
+
+
+def test_enqueue_is_idempotent_for_tenant_project_and_window(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    first = store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=PROJECT,
+        run_window="2026-07-26T16:00Z",
+        now=NOW,
+    )
+    second = store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=PROJECT,
+        run_window="2026-07-26T16:00Z",
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert second == first
+    assert store.list_for_tenant(TENANT_A) == (first,)
+
+
+def test_identical_project_and_window_are_isolated_by_tenant(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    first = store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=PROJECT,
+        run_window="daily:2026-07-26",
+        now=NOW,
+    )
+    second = store.enqueue(
+        tenant_id=TENANT_B,
+        project_id=PROJECT,
+        run_window="daily:2026-07-26",
+        now=NOW,
+    )
+
+    assert first.id != second.id
+    assert store.list_for_tenant(TENANT_A) == (first,)
+    assert store.list_for_tenant(TENANT_B) == (second,)
+    with pytest.raises(MonitoringJobError, match="not found"):
+        store.load(tenant_id=TENANT_A, job_id=second.id)
+
+
+def test_only_one_worker_can_lease_a_due_job(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    job = store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=PROJECT,
+        run_window="hourly:2026-07-26T16",
+        now=NOW,
+    )
+
+    first = store.lease_next(now=NOW, lease_duration=timedelta(minutes=5))
+    second = store.lease_next(now=NOW, lease_duration=timedelta(minutes=5))
+
+    assert first is not None
+    assert first.job.id == job.id
+    assert first.job.state is MonitoringJobState.leased
+    assert second is None
+
+
+def test_expired_lease_can_be_recovered_by_another_worker(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=PROJECT,
+        run_window="hourly:2026-07-26T16",
+        now=NOW,
+    )
+    first = store.lease_next(now=NOW, lease_duration=timedelta(minutes=5))
+    assert first is not None
+
+    recovered = store.lease_next(
+        now=NOW + timedelta(minutes=6),
+        lease_duration=timedelta(minutes=5),
+    )
+
+    assert recovered is not None
+    assert recovered.job.id == first.job.id
+    assert recovered.worker_token != first.worker_token
+    with pytest.raises(MonitoringJobError, match="lease was not found"):
+        store.succeed(
+            job_id=first.job.id,
+            worker_token=first.worker_token,
+            now=NOW + timedelta(minutes=7),
+        )
+
+
+def test_success_is_terminal_and_cannot_be_repeated(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=PROJECT,
+        run_window="daily:2026-07-26",
+        now=NOW,
+    )
+    lease = store.lease_next(now=NOW, lease_duration=timedelta(minutes=5))
+    assert lease is not None
+
+    succeeded = store.succeed(
+        job_id=lease.job.id,
+        worker_token=lease.worker_token,
+        now=NOW + timedelta(minutes=1),
+    )
+
+    assert succeeded.state is MonitoringJobState.succeeded
+    assert succeeded.attempt_count == 1
+    assert store.lease_next(
+        now=NOW + timedelta(hours=1),
+        lease_duration=timedelta(minutes=5),
+    ) is None
+    with pytest.raises(MonitoringJobError, match="lease was not found"):
+        store.succeed(
+            job_id=lease.job.id,
+            worker_token=lease.worker_token,
+            now=NOW + timedelta(minutes=2),
+        )
+
+
+def test_failure_requeues_then_becomes_terminal_at_retry_limit(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=PROJECT,
+        run_window="daily:2026-07-26",
+        now=NOW,
+        max_attempts=2,
+    )
+    first = store.lease_next(now=NOW, lease_duration=timedelta(minutes=5))
+    assert first is not None
+
+    queued = store.fail(
+        job_id=first.job.id,
+        worker_token=first.worker_token,
+        now=NOW + timedelta(minutes=1),
+        error="temporary network failure",
+        retry_delay=timedelta(minutes=10),
+    )
+
+    assert queued.state is MonitoringJobState.queued
+    assert queued.attempt_count == 1
+    assert queued.last_error == "temporary network failure"
+    assert queued.next_attempt_at == NOW + timedelta(minutes=11)
+    assert store.lease_next(
+        now=NOW + timedelta(minutes=10),
+        lease_duration=timedelta(minutes=5),
+    ) is None
+
+    second = store.lease_next(
+        now=NOW + timedelta(minutes=11),
+        lease_duration=timedelta(minutes=5),
+    )
+    assert second is not None
+    failed = store.fail(
+        job_id=second.job.id,
+        worker_token=second.worker_token,
+        now=NOW + timedelta(minutes=12),
+        error="still failing",
+        retry_delay=timedelta(minutes=10),
+    )
+
+    assert failed.state is MonitoringJobState.failed
+    assert failed.attempt_count == 2
+    assert failed.last_error == "still failing"
+    assert store.lease_next(
+        now=NOW + timedelta(days=1),
+        lease_duration=timedelta(minutes=5),
+    ) is None
+
+
+def test_cancellation_is_tenant_qualified_and_prevents_leasing(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    job = store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=PROJECT,
+        run_window="daily:2026-07-26",
+        now=NOW,
+    )
+
+    with pytest.raises(MonitoringJobError, match="not found"):
+        store.cancel(tenant_id=TENANT_B, job_id=job.id, now=NOW)
+
+    cancelled = store.cancel(tenant_id=TENANT_A, job_id=job.id, now=NOW)
+
+    assert cancelled.state is MonitoringJobState.cancelled
+    assert store.lease_next(now=NOW, lease_duration=timedelta(minutes=5)) is None
+
+
+def test_invalid_identifiers_are_rejected_before_storage(tmp_path: Path) -> None:
+    store = SQLiteMonitoringJobStore(tmp_path / "monitoring-jobs.sqlite3")
+
+    with pytest.raises(MonitoringJobError, match="tenant_id"):
+        store.enqueue(
+            tenant_id="../outside",
+            project_id=PROJECT,
+            run_window="daily:2026-07-26",
+            now=NOW,
+        )
+
+    assert not store.database.exists()

--- a/tests/test_monitoring_jobs_api_worker.py
+++ b/tests/test_monitoring_jobs_api_worker.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from veridra.monitoring_job_store import MonitoringJobState, SQLiteMonitoringJobStore
 
 from veridra.identity_middleware import VerifiedIdentityMiddleware
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.monitoring_job_api import router as monitoring_job_router
-from veridra.monitoring_job_store import MonitoringJobState, SQLiteMonitoringJobStore
 from veridra.monitoring_worker import MonitoringWorker
 from veridra.project_store import ClientProject
 from veridra.tenant_monitoring_execution import TenantMonitoringExecutionResult

--- a/tests/test_monitoring_jobs_api_worker.py
+++ b/tests/test_monitoring_jobs_api_worker.py
@@ -3,15 +3,19 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import veridra.tenant_monitoring_execution as monitoring_execution
+from veridra.core import Assessment
 from veridra.identity_middleware import VerifiedIdentityMiddleware
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.monitoring_job_api import router as monitoring_job_router
 from veridra.monitoring_jobs import MonitoringJobState, SQLiteMonitoringJobStore
 from veridra.monitoring_worker import MonitoringWorker
 from veridra.project_store import ClientProject
+from veridra.tenant_history_store import TenantHistoryStore
 from veridra.tenant_monitoring_execution import TenantMonitoringExecutionResult
 from veridra.tenant_project_store import TenantProjectStore
 
@@ -180,3 +184,51 @@ def test_worker_retries_then_marks_terminal_failure(tmp_path: Path) -> None:
     assert final.state is MonitoringJobState.failed
     assert final.attempt_count == 2
     assert final.last_error == "collector unavailable"
+
+
+def test_real_worker_execution_selects_only_tenant_local_stores(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    analyst = _identity(TENANT_A)
+    project_id = _project(tmp_path, analyst)
+    store = SQLiteMonitoringJobStore(tmp_path / "monitoring-jobs.sqlite3")
+    job = store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=project_id,
+        run_window="2026-07-27T08:00Z",
+        now=NOW,
+    )
+    assessment = Assessment.build("https://example.com", [], generated_at=NOW)
+    selected_email_roots: list[Path] = []
+
+    def fake_assess_url(*args: object, **kwargs: object) -> Assessment:
+        del args, kwargs
+        return assessment
+
+    def fake_send_monitoring_summary(*args: object, **kwargs: object) -> None:
+        del args
+        selected_email_roots.append(kwargs["store"].root)
+        return None
+
+    monkeypatch.setattr(monitoring_execution, "assess_url", fake_assess_url)
+    monkeypatch.setattr(
+        monitoring_execution,
+        "send_monitoring_summary",
+        fake_send_monitoring_summary,
+    )
+
+    result = MonitoringWorker(
+        root=tmp_path,
+        store=store,
+        execute=monitoring_execution.execute_tenant_monitoring,
+        clock=lambda: NOW,
+    ).run_once(limit=1)
+    final = store.load(tenant_id=TENANT_A, job_id=job.id)
+    entries = TenantHistoryStore(tmp_path).list(analyst, project_id)
+
+    assert result.succeeded == 1
+    assert final.state is MonitoringJobState.succeeded
+    assert len(entries) == 1
+    assert selected_email_roots == [tmp_path / TENANT_A / "email-deliveries"]
+    assert not (tmp_path / TENANT_B / "projects" / project_id / "assessments").exists()

--- a/tests/test_monitoring_jobs_api_worker.py
+++ b/tests/test_monitoring_jobs_api_worker.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 import veridra.tenant_monitoring_execution as monitoring_execution
 from veridra.core import Assessment
+from veridra.email_delivery import EmailAttemptStore
 from veridra.identity_middleware import VerifiedIdentityMiddleware
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.monitoring_job_api import router as monitoring_job_router
@@ -208,7 +209,9 @@ def test_real_worker_execution_selects_only_tenant_local_stores(
 
     def fake_send_monitoring_summary(*args: object, **kwargs: object) -> None:
         del args
-        selected_email_roots.append(kwargs["store"].root)
+        store_value = kwargs["store"]
+        assert isinstance(store_value, EmailAttemptStore)
+        selected_email_roots.append(store_value.directory)
         return None
 
     monkeypatch.setattr(monitoring_execution, "assess_url", fake_assess_url)

--- a/tests/test_monitoring_jobs_api_worker.py
+++ b/tests/test_monitoring_jobs_api_worker.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from veridra.monitoring_job_store import MonitoringJobState, SQLiteMonitoringJobStore
 
 from veridra.identity_middleware import VerifiedIdentityMiddleware
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.monitoring_job_api import router as monitoring_job_router
+from veridra.monitoring_jobs import MonitoringJobState, SQLiteMonitoringJobStore
 from veridra.monitoring_worker import MonitoringWorker
 from veridra.project_store import ClientProject
 from veridra.tenant_monitoring_execution import TenantMonitoringExecutionResult

--- a/tests/test_monitoring_jobs_api_worker.py
+++ b/tests/test_monitoring_jobs_api_worker.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.identity_middleware import VerifiedIdentityMiddleware
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.monitoring_job_api import router as monitoring_job_router
+from veridra.monitoring_job_store import MonitoringJobState, SQLiteMonitoringJobStore
+from veridra.monitoring_worker import MonitoringWorker
+from veridra.project_store import ClientProject
+from veridra.tenant_monitoring_execution import TenantMonitoringExecutionResult
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 26, 16, 0, tzinfo=UTC)
+TENANT_A = "a" * 24
+TENANT_B = "b" * 24
+
+
+class StaticAdapter:
+    def __init__(self, identity: RequestIdentity) -> None:
+        self.identity = identity
+
+    async def resolve(self, request: object) -> RequestIdentity:
+        del request
+        return self.identity
+
+
+def _identity(tenant_id: str, role: TenantRole = TenantRole.analyst) -> RequestIdentity:
+    return RequestIdentity(
+        user_id="c" * 24,
+        tenant_id=tenant_id,
+        membership_role=role,
+        session_id="session-identifier-value-01",
+        authenticated_at=NOW,
+    )
+
+
+def _project(root: Path, identity: RequestIdentity) -> str:
+    return TenantProjectStore(root).save(
+        identity,
+        ClientProject.build(name="Monitored", target_url="https://example.com"),
+    )
+
+
+def _client(root: Path, identity: RequestIdentity) -> TestClient:
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+    app.add_middleware(VerifiedIdentityMiddleware, adapter=StaticAdapter(identity))
+    app.include_router(monitoring_job_router)
+    return TestClient(app)
+
+
+def test_authenticated_job_api_is_tenant_qualified(tmp_path: Path) -> None:
+    analyst_a = _identity(TENANT_A)
+    analyst_b = _identity(TENANT_B)
+    project_a = _project(tmp_path, analyst_a)
+    project_b = _project(tmp_path, analyst_b)
+    client_a = _client(tmp_path, analyst_a)
+
+    created = client_a.post(
+        "/api/tenant/monitoring-jobs",
+        json={"project_id": project_a, "run_window": "2026-07-27T08:00Z"},
+    )
+    duplicate = client_a.post(
+        "/api/tenant/monitoring-jobs",
+        json={"project_id": project_a, "run_window": "2026-07-27T08:00Z"},
+    )
+    concealed = client_a.post(
+        "/api/tenant/monitoring-jobs",
+        json={"project_id": project_b, "run_window": "2026-07-27T08:00Z"},
+    )
+    listed = client_a.get("/api/tenant/monitoring-jobs")
+
+    assert created.status_code == 201
+    assert duplicate.status_code == 201
+    assert duplicate.json()["id"] == created.json()["id"]
+    assert concealed.status_code == 404
+    assert len(listed.json()) == 1
+
+
+def test_viewer_can_list_but_cannot_enqueue_or_cancel(tmp_path: Path) -> None:
+    analyst = _identity(TENANT_A)
+    project_id = _project(tmp_path, analyst)
+    viewer = _identity(TENANT_A, TenantRole.viewer)
+    viewer_client = _client(tmp_path, viewer)
+    store = SQLiteMonitoringJobStore(tmp_path / "monitoring-jobs.sqlite3")
+    job = store.enqueue(
+        tenant_id=TENANT_A,
+        project_id=project_id,
+        run_window="window",
+        now=NOW,
+    )
+
+    assert viewer_client.get("/api/tenant/monitoring-jobs").status_code == 200
+    assert viewer_client.post(
+        "/api/tenant/monitoring-jobs",
+        json={"project_id": project_id, "run_window": "other"},
+    ).status_code == 403
+    assert viewer_client.delete(f"/api/tenant/monitoring-jobs/{job.id}").status_code == 403
+
+
+def test_worker_executes_bounded_jobs_and_records_success(tmp_path: Path) -> None:
+    store = SQLiteMonitoringJobStore(tmp_path / "monitoring-jobs.sqlite3")
+    for index in range(3):
+        store.enqueue(
+            tenant_id=TENANT_A,
+            project_id=f"{index + 1:024x}",
+            run_window=f"window-{index}",
+            now=NOW,
+        )
+    calls: list[tuple[str, str]] = []
+
+    def execute(*, root: Path, tenant_id: str, project_id: str) -> TenantMonitoringExecutionResult:
+        assert root == tmp_path
+        calls.append((tenant_id, project_id))
+        return TenantMonitoringExecutionResult(
+            assessment_id="d" * 24,
+            email_status=None,
+            email_error=None,
+        )
+
+    result = MonitoringWorker(
+        root=tmp_path,
+        store=store,
+        execute=execute,
+        clock=lambda: NOW,
+    ).run_once(limit=2)
+
+    assert result.leased == 2
+    assert result.succeeded == 2
+    assert len(calls) == 2
+    states = [job.state for job in store.list_for_tenant(TENANT_A)]
+    assert states.count(MonitoringJobState.succeeded) == 2
+    assert states.count(MonitoringJobState.queued) == 1
+
+
+def test_worker_retries_then_marks_terminal_failure(tmp_path: Path) -> None:
+    store = SQLiteMonitoringJobStore(tmp_path / "monitoring-jobs.sqlite3")
+    job = store.enqueue(
+        tenant_id=TENANT_A,
+        project_id="1" * 24,
+        run_window="window",
+        now=NOW,
+        max_attempts=2,
+    )
+
+    def fail_execution(
+        *, root: Path, tenant_id: str, project_id: str
+    ) -> TenantMonitoringExecutionResult:
+        del root, tenant_id, project_id
+        raise RuntimeError("collector unavailable")
+
+    first = MonitoringWorker(
+        root=tmp_path,
+        store=store,
+        execute=fail_execution,
+        clock=lambda: NOW,
+    ).run_once(limit=1, retry_delay=timedelta(0))
+    second = MonitoringWorker(
+        root=tmp_path,
+        store=store,
+        execute=fail_execution,
+        clock=lambda: NOW + timedelta(seconds=1),
+    ).run_once(limit=1, retry_delay=timedelta(0))
+    final = store.load(tenant_id=TENANT_A, job_id=job.id)
+
+    assert first.retried == 1
+    assert second.failed == 1
+    assert final.state is MonitoringJobState.failed
+    assert final.attempt_count == 2
+    assert final.last_error == "collector unavailable"

--- a/tests/test_monitoring_jobs_api_worker.py
+++ b/tests/test_monitoring_jobs_api_worker.py
@@ -114,7 +114,9 @@ def test_worker_executes_bounded_jobs_and_records_success(tmp_path: Path) -> Non
         )
     calls: list[tuple[str, str]] = []
 
-    def execute(*, root: Path, tenant_id: str, project_id: str) -> TenantMonitoringExecutionResult:
+    def execute(
+        *, root: Path, tenant_id: str, project_id: str
+    ) -> TenantMonitoringExecutionResult:
         assert root == tmp_path
         calls.append((tenant_id, project_id))
         return TenantMonitoringExecutionResult(

--- a/tests/test_monitoring_jobs_api_worker.py
+++ b/tests/test_monitoring_jobs_api_worker.py
@@ -39,10 +39,15 @@ def _identity(tenant_id: str, role: TenantRole = TenantRole.analyst) -> RequestI
     )
 
 
-def _project(root: Path, identity: RequestIdentity) -> str:
+def _project(
+    root: Path,
+    identity: RequestIdentity,
+    *,
+    name: str = "Monitored",
+) -> str:
     return TenantProjectStore(root).save(
         identity,
-        ClientProject.build(name="Monitored", target_url="https://example.com"),
+        ClientProject.build(name=name, target_url="https://example.com"),
     )
 
 
@@ -58,7 +63,7 @@ def test_authenticated_job_api_is_tenant_qualified(tmp_path: Path) -> None:
     analyst_a = _identity(TENANT_A)
     analyst_b = _identity(TENANT_B)
     project_a = _project(tmp_path, analyst_a)
-    project_b = _project(tmp_path, analyst_b)
+    project_b = _project(tmp_path, analyst_b, name="Other tenant project")
     client_a = _client(tmp_path, analyst_a)
 
     created = client_a.post(

--- a/tests/test_tenant_monitoring_execution.py
+++ b/tests/test_tenant_monitoring_execution.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from veridra import tenant_monitoring_execution as execution_module
+from veridra.core import Assessment
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 26, 20, 0, tzinfo=UTC)
+TENANT_ID = "a" * 24
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="b" * 24,
+        tenant_id=TENANT_ID,
+        membership_role=TenantRole.owner,
+        session_id="worker-proof-session-value",
+        authenticated_at=NOW,
+    )
+
+
+def test_execution_writes_only_tenant_qualified_outputs(
+    tmp_path: Path,
+    monkeypatch: object,
+) -> None:
+    identity = _identity()
+    project_id = TenantProjectStore(tmp_path).save(
+        identity,
+        ClientProject.build(name="Worker project", target_url="https://example.com"),
+    )
+    assessment = Assessment.build(
+        "https://example.com",
+        [],
+        generated_at=NOW,
+    )
+    selected_email_directory: list[Path] = []
+
+    def fake_assess_url(raw_url: str, **kwargs: object) -> Assessment:
+        del kwargs
+        assert raw_url == "https://example.com/"
+        return assessment
+
+    def fake_send_monitoring_summary(**kwargs: object) -> None:
+        store = kwargs["store"]
+        selected_email_directory.append(store.directory)
+        return None
+
+    monkeypatch.setattr(execution_module, "assess_url", fake_assess_url)
+    monkeypatch.setattr(
+        execution_module,
+        "send_monitoring_summary",
+        fake_send_monitoring_summary,
+    )
+
+    result = execution_module.execute_tenant_monitoring(
+        root=tmp_path,
+        tenant_id=TENANT_ID,
+        project_id=project_id,
+    )
+
+    assessment_path = (
+        tmp_path
+        / TENANT_ID
+        / "projects"
+        / project_id
+        / "assessments"
+        / f"{result.assessment_id}.json"
+    )
+    assert assessment_path.exists()
+    assert selected_email_directory == [tmp_path / TENANT_ID / "email-deliveries"]
+    assert not (tmp_path / "history").exists()
+    assert not (tmp_path / "email-deliveries").exists()

--- a/tests/test_tenant_monitoring_execution.py
+++ b/tests/test_tenant_monitoring_execution.py
@@ -44,7 +44,7 @@ def test_execution_writes_only_tenant_qualified_outputs(
 
     def fake_assess_url(raw_url: str, **kwargs: object) -> Assessment:
         del kwargs
-        assert raw_url == "https://example.com/"
+        assert raw_url == "https://example.com"
         return assessment
 
     def fake_send_monitoring_summary(**kwargs: object) -> None:

--- a/tests/test_tenant_monitoring_execution.py
+++ b/tests/test_tenant_monitoring_execution.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from veridra import tenant_monitoring_execution as execution_module
 from veridra.core import Assessment
+from veridra.email_delivery import EmailAttemptStore
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.project_store import ClientProject
 from veridra.tenant_project_store import TenantProjectStore
@@ -25,7 +28,7 @@ def _identity() -> RequestIdentity:
 
 def test_execution_writes_only_tenant_qualified_outputs(
     tmp_path: Path,
-    monkeypatch: object,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     identity = _identity()
     project_id = TenantProjectStore(tmp_path).save(
@@ -46,6 +49,7 @@ def test_execution_writes_only_tenant_qualified_outputs(
 
     def fake_send_monitoring_summary(**kwargs: object) -> None:
         store = kwargs["store"]
+        assert isinstance(store, EmailAttemptStore)
         selected_email_directory.append(store.directory)
         return None
 


### PR DESCRIPTION
Implements issue #83 from merged authentication and tenant-isolation foundation `2d66e62607d5c5cef526f2a0a1ccd6817f1f6f50`.

## Implemented and proven

### Durable queue core
- SQLite monitoring-job records with tenant ID, project ID and logical run window;
- deterministic idempotency key per tenant, project and run window;
- explicit `queued`, `leased`, `succeeded`, `failed` and `cancelled` states;
- atomic `BEGIN IMMEDIATE` lease acquisition;
- opaque worker tokens stored only as SHA-256 hashes;
- stale-lease recovery;
- bounded attempts, retry scheduling and retained last-error evidence;
- terminal success and cancellation cannot be leased again.

### Authenticated tenant API
- `GET /api/tenant/monitoring-jobs` requires `view_data`;
- `POST /api/tenant/monitoring-jobs` requires `manage_monitoring`;
- `DELETE /api/tenant/monitoring-jobs/{job_id}` requires `manage_monitoring`;
- enqueue reloads the project through `TenantProjectStore` before creating a job;
- cross-tenant or missing projects return the same generic `404` boundary;
- duplicate enqueue returns the existing durable job.

### Bounded worker and CLI
- `veridra-monitoring-worker` leases and executes a bounded number of due jobs, then exits;
- no infinite worker thread is embedded in the web application;
- failed execution is retried only within the configured attempt limit;
- the worker reloads the tenant-qualified project before assessment;
- assessments and email-attempt stores are selected beneath the durable job's tenant;
- legacy global history and email directories are not used.

### Documentation and tests
- architecture and operator runbook document lifecycle, leases, recovery, configuration and deployment boundaries;
- tests cover same-ID tenant isolation, enqueue idempotency, exclusive leases, stale-lease recovery, token ownership, bounded retries, cancellation, API capabilities, project ownership, bounded execution and real tenant-local persistence.

## Exact-head validation

Exact head `534a8770b4fecede0f430055839d304c6b0e91f9` passed CI #1128:
- Ruff;
- strict mypy;
- pytest;
- deterministic repository audit;
- Chromium browser audit;
- evidence upload.

## Explicit exclusions

- Redis, SQS, Celery or other distributed queue infrastructure;
- multi-region coordination;
- production process supervision;
- production SMTP configuration;
- billing and quota enforcement;
- deployment orchestration.

This PR provides a durable single-database worker foundation for tenant monitoring. It does not claim distributed queue infrastructure or complete SaaS deployment operations.

Closes #83.