### PR TITLE
Harden production runtime and deployment boundaries

### DIFF
--- a/docs/architecture/production-runtime-hardening.md
+++ b/docs/architecture/production-runtime-hardening.md
@@ -1,0 +1,58 @@
+# Production runtime hardening
+
+## Purpose
+
+This milestone defines the fail-closed runtime boundary required to deploy Veridra's authenticated web application and durable monitoring worker without trusting implicit development defaults.
+
+## Runtime environments
+
+Veridra distinguishes `development`, `test` and `production` explicitly.
+
+Development and test may use loopback binding and temporary local storage. Production must provide durable absolute paths, an HTTPS trusted origin and explicit host/proxy configuration.
+
+## Startup contract
+
+Production startup must refuse to continue when mandatory configuration is absent, malformed or unsafe. Validation covers at least:
+
+- identity database path;
+- tenant data root;
+- trusted HTTPS application origin;
+- allowed request hosts;
+- bind host and port;
+- reverse-proxy trust configuration;
+- writable durable storage and database parent directories.
+
+Configuration errors must identify the setting category without printing secrets or token values.
+
+## Request boundary
+
+The application rejects untrusted `Host` values before route handling. Forwarded headers are not trusted merely because they are present. Proxy-derived scheme, host or client information may be accepted only when the immediate peer matches an explicitly configured trusted proxy boundary.
+
+Authenticated unsafe requests retain the existing trusted-origin validation. Public embedded audit routes retain their independent allowed-origin policy.
+
+Request bodies are bounded before application parsing. Limits may differ between authenticated JSON mutations and public lead-capture submissions, but neither surface may accept an unbounded body.
+
+## Health and readiness
+
+`/health` reports only that the process can serve requests. It must not reveal filesystem paths, database names, environment values, versions of sensitive dependencies or tenant information.
+
+`/ready` verifies the configured durable dependencies needed by this process. A failed dependency returns a generic unavailable result while detailed diagnostics remain in protected operator logs.
+
+## Process model
+
+The web process and monitoring worker remain separate bounded processes. The web application does not start an infinite worker thread. Deployment tooling is responsible for restart policy, scheduling, concurrency and log collection.
+
+## Logging and secrets
+
+Secrets, session credentials, invitation/reset tokens, SMTP passwords and authorization headers must never be logged. Identifiers may be logged only when operationally necessary and should not be combined with personal data unnecessarily.
+
+## Explicit exclusions
+
+- cloud-provider-specific infrastructure;
+- Kubernetes or Terraform implementation;
+- distributed rate limiting;
+- billing and subscription enforcement;
+- production SMTP-provider selection;
+- penetration-test certification.
+
+Related to issue #85.

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -1,0 +1,121 @@
+# Production deployment operations
+
+## Process model
+
+Run the web application and durable monitoring worker as separate supervised processes.
+
+Web process:
+
+```text
+veridra-api
+```
+
+Worker invocation:
+
+```text
+veridra-monitoring-worker --limit 10
+```
+
+The worker is intentionally bounded and exits. Use an operating-system scheduler or process supervisor to invoke it repeatedly. Do not embed an infinite worker loop inside the web process.
+
+## Required production configuration
+
+Set these values explicitly:
+
+```text
+VERIDRA_ENV=production
+VERIDRA_IDENTITY_DB=/absolute/durable/path/identity.sqlite3
+VERIDRA_TENANT_DATA_ROOT=/absolute/durable/path/tenants
+VERIDRA_TRUSTED_ORIGIN=https://app.example.com
+VERIDRA_ALLOWED_HOSTS=app.example.com
+VERIDRA_BIND_HOST=127.0.0.1
+VERIDRA_BIND_PORT=8000
+VERIDRA_MAX_REQUEST_BODY_BYTES=1000000
+```
+
+Set `VERIDRA_TRUSTED_PROXY_IPS` only when a reverse proxy connects directly to the application. List only immediate proxy IP addresses. Forwarded headers from every other peer are rejected, and Uvicorn proxy-header interpretation remains disabled.
+
+## Reverse proxy boundary
+
+Terminate public TLS at a controlled reverse proxy. The proxy should:
+
+- connect to Veridra over a private or loopback interface;
+- set the public `Host` consistently;
+- enforce its own request and connection limits;
+- replace, rather than append blindly to, forwarded headers;
+- prevent direct public access to the application bind port.
+
+The application does not use forwarded headers to redefine the ASGI scheme, host or client identity. Trusting a proxy IP permits those headers to pass the boundary for controlled upstream use; it does not make arbitrary client-supplied values authoritative.
+
+## Filesystem permissions
+
+Use a dedicated service account. Grant it:
+
+- read/write access to the identity database and its parent directory;
+- read/write access to the tenant-data root;
+- no write access to application source or package files;
+- no interactive login unless operationally required.
+
+Do not place durable data inside an ephemeral container layer or temporary checkout.
+
+## Startup and migration order
+
+1. Stop web and worker processes before restoring or manually migrating data.
+2. Back up the identity database and tenant-data root together.
+3. Start one web process to apply versioned identity migrations.
+4. Confirm `/health` returns `200` and `/ready` returns `200`.
+5. Start the remaining web processes.
+6. Resume scheduled worker invocations.
+
+A `503` readiness response means a configured durable dependency is unavailable. It intentionally does not disclose paths or database details.
+
+## Backup and recovery
+
+Back up these assets as one consistency set:
+
+- identity SQLite database;
+- tenant project, lead, assessment, report-profile and delivery data;
+- durable monitoring-job SQLite database.
+
+Test restoration in an isolated environment. A backup that has not been restored successfully is not considered verified.
+
+During recovery, prevent workers from leasing jobs until the identity and tenant-data snapshots are both restored.
+
+## Logging and secrets
+
+Never log:
+
+- session cookie values;
+- password-reset or invitation tokens;
+- `Authorization` headers;
+- SMTP passwords;
+- raw request bodies containing personal data;
+- environment-variable dumps.
+
+Operational logs may include bounded internal identifiers and generic error categories where needed, but should avoid combining tenant identifiers with unnecessary personal data.
+
+## Supervision expectations
+
+Configure the service manager to:
+
+- restart the web process after unexpected exit with bounded backoff;
+- run the monitoring worker on a fixed schedule;
+- prevent overlapping worker starts unless intentional concurrency has been tested;
+- capture stdout and stderr in protected logs;
+- alert on repeated web restarts, readiness failures and terminal monitoring-job failures.
+
+This repository does not prescribe systemd, Windows Services, Docker Compose, Kubernetes or a cloud-specific supervisor. Deployment tooling must preserve the same process and trust boundaries.
+
+## Pre-release checklist
+
+- production configuration validates without fallback defaults;
+- public TLS and allowed host match `VERIDRA_TRUSTED_ORIGIN`;
+- the application port is not directly internet-accessible;
+- trusted proxy IPs contain only immediate proxies;
+- `/health` and `/ready` are monitored separately;
+- filesystem permissions use least privilege;
+- backup and restore have been tested;
+- identity migrations complete before worker scheduling resumes;
+- secrets are supplied outside source control;
+- log access is restricted;
+- exact deployed commit and validation evidence are recorded.

--- a/src/veridra/operations_api.py
+++ b/src/veridra/operations_api.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from fastapi import APIRouter, Request, Response, status
+from pydantic import BaseModel, ConfigDict
+
+router = APIRouter(tags=["operations"])
+
+
+class OperationalStatus(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: str
+
+
+def _database_ready(database: Path | None) -> bool:
+    if database is None:
+        return True
+    try:
+        with sqlite3.connect(database) as connection:
+            connection.execute("SELECT 1").fetchone()
+    except (OSError, sqlite3.Error):
+        return False
+    return True
+
+
+def _tenant_root_ready(root: Path | None) -> bool:
+    if root is None:
+        return True
+    return root.exists() and root.is_dir()
+
+
+@router.get("/health", response_model=OperationalStatus)
+def health() -> OperationalStatus:
+    return OperationalStatus(status="ok")
+
+
+@router.get("/ready", response_model=OperationalStatus)
+def ready(request: Request, response: Response) -> OperationalStatus:
+    database = getattr(request.app.state, "veridra_identity_database", None)
+    tenant_root = getattr(request.app.state, "veridra_tenant_data_root", None)
+    if not isinstance(database, Path):
+        database = None
+    if not isinstance(tenant_root, Path):
+        tenant_root = None
+    if not _database_ready(database) or not _tenant_root_ready(tenant_root):
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return OperationalStatus(status="unavailable")
+    return OperationalStatus(status="ready")

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi.routing import APIRoute
+from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from . import app as app_module
 from . import public_web
@@ -16,9 +17,11 @@ from .lead_web import router as lead_router
 from .member_assignments_web import router as member_assignments_router
 from .monitoring_job_api import router as monitoring_job_router
 from .monitoring_web import router as monitoring_router
+from .operations_api import router as operations_router
 from .password_recovery_api import router as password_recovery_router
 from .pdf_web import router as pdf_router
 from .public_web import ToolDefinition
+from .runtime_config import RuntimeConfig
 from .session_api import router as session_router
 from .task_web import router as task_router
 from .tenant_bound_lead_capture import router as tenant_bound_lead_capture_router
@@ -33,6 +36,14 @@ from .tenant_task_api import router as tenant_task_router
 from .workspace_enforcement import enforce_workspace_policy
 from .workspace_members_web import router as workspace_members_router
 from .workspace_web import router as workspace_router
+
+runtime_config = RuntimeConfig.from_environment()
+runtime_config.configure_directories()
+app.state.veridra_runtime_config = runtime_config
+if runtime_config.tenant_data_root is not None:
+    app.state.veridra_tenant_data_root = runtime_config.tenant_data_root
+if runtime_config.allowed_hosts:
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(runtime_config.allowed_hosts))
 
 if "Accessibility" not in app_module._AREAS:
     vars(app_module)["_AREAS"] = (*app_module._AREAS, "Accessibility")
@@ -65,6 +76,7 @@ lead_router.routes[:] = [
 
 app.middleware("http")(enforce_workspace_policy)
 configure_identity_middleware(app)
+app.include_router(operations_router)
 app.include_router(auth_router)
 app.include_router(password_recovery_router)
 app.include_router(session_router)
@@ -95,4 +107,9 @@ app.include_router(member_assignments_router)
 def main() -> None:
     import uvicorn
 
-    uvicorn.run(app, host="127.0.0.1", port=8000)
+    uvicorn.run(
+        app,
+        host=runtime_config.bind_host,
+        port=runtime_config.bind_port,
+        proxy_headers=False,
+    )

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -21,6 +21,7 @@ from .operations_api import router as operations_router
 from .password_recovery_api import router as password_recovery_router
 from .pdf_web import router as pdf_router
 from .public_web import ToolDefinition
+from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
 from .session_api import router as session_router
 from .task_web import router as task_router
@@ -42,6 +43,11 @@ runtime_config.configure_directories()
 app.state.veridra_runtime_config = runtime_config
 if runtime_config.tenant_data_root is not None:
     app.state.veridra_tenant_data_root = runtime_config.tenant_data_root
+app.add_middleware(
+    RuntimeBoundaryMiddleware,
+    max_body_bytes=runtime_config.max_request_body_bytes,
+    trusted_proxy_ips=runtime_config.trusted_proxy_ips,
+)
 if runtime_config.allowed_hosts:
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(runtime_config.allowed_hosts))
 

--- a/src/veridra/runtime_boundary.py
+++ b/src/veridra/runtime_boundary.py
@@ -32,7 +32,8 @@ class RuntimeBoundaryMiddleware:
         headers = dict(scope.get("headers", []))
         client = scope.get("client")
         peer = client[0] if client is not None else ""
-        if any(name in headers for name in _FORWARDED_HEADERS) and peer not in self.trusted_proxy_ips:
+        forwarded_present = any(name in headers for name in _FORWARDED_HEADERS)
+        if forwarded_present and peer not in self.trusted_proxy_ips:
             await self._reject(scope, receive, send, 400, "Untrusted forwarded headers.")
             return
         if scope.get("method") not in _UNSAFE_METHODS:

--- a/src/veridra/runtime_boundary.py
+++ b/src/veridra/runtime_boundary.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -35,11 +33,7 @@ class RuntimeBoundaryMiddleware:
         client = scope.get("client")
         peer = client[0] if client is not None else ""
         if any(name in headers for name in _FORWARDED_HEADERS) and peer not in self.trusted_proxy_ips:
-            response = JSONResponse(
-                {"detail": "Untrusted forwarded headers."},
-                status_code=400,
-            )
-            await response(scope, receive, send)
+            await self._reject(scope, receive, send, 400, "Untrusted forwarded headers.")
             return
         if scope.get("method") not in _UNSAFE_METHODS:
             await self.app(scope, receive, send)
@@ -51,33 +45,43 @@ class RuntimeBoundaryMiddleware:
             except ValueError:
                 declared_length = self.max_body_bytes + 1
             if declared_length > self.max_body_bytes:
-                await self._reject_large_body(scope, receive, send)
+                await self._reject(scope, receive, send, 413, "Request body too large.")
                 return
 
+        messages: list[Message] = []
         received = 0
-
-        async def limited_receive() -> Message:
-            nonlocal received
+        while True:
             message = await receive()
+            messages.append(message)
             if message["type"] == "http.request":
                 received += len(message.get("body", b""))
                 if received > self.max_body_bytes:
-                    raise _RequestBodyTooLarge
-            return message
+                    await self._reject(scope, receive, send, 413, "Request body too large.")
+                    return
+                if not message.get("more_body", False):
+                    break
+            elif message["type"] == "http.disconnect":
+                break
 
-        try:
-            await self.app(scope, limited_receive, send)
-        except _RequestBodyTooLarge:
-            await self._reject_large_body(scope, receive, send)
+        index = 0
+
+        async def replay_receive() -> Message:
+            nonlocal index
+            if index < len(messages):
+                message = messages[index]
+                index += 1
+                return message
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        await self.app(scope, replay_receive, send)
 
     @staticmethod
-    async def _reject_large_body(scope: Scope, receive: Receive, send: Send) -> None:
-        response = JSONResponse(
-            {"detail": "Request body too large."},
-            status_code=413,
-        )
+    async def _reject(
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        status_code: int,
+        detail: str,
+    ) -> None:
+        response = JSONResponse({"detail": detail}, status_code=status_code)
         await response(scope, receive, send)
-
-
-class _RequestBodyTooLarge(Exception):
-    pass

--- a/src/veridra/runtime_boundary.py
+++ b/src/veridra/runtime_boundary.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+_FORWARDED_HEADERS = {
+    b"forwarded",
+    b"x-forwarded-for",
+    b"x-forwarded-host",
+    b"x-forwarded-port",
+    b"x-forwarded-proto",
+}
+
+
+class RuntimeBoundaryMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        max_body_bytes: int,
+        trusted_proxy_ips: tuple[str, ...] = (),
+    ) -> None:
+        self.app = app
+        self.max_body_bytes = max_body_bytes
+        self.trusted_proxy_ips = frozenset(trusted_proxy_ips)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers", []))
+        client = scope.get("client")
+        peer = client[0] if client is not None else ""
+        if any(name in headers for name in _FORWARDED_HEADERS) and peer not in self.trusted_proxy_ips:
+            response = JSONResponse(
+                {"detail": "Untrusted forwarded headers."},
+                status_code=400,
+            )
+            await response(scope, receive, send)
+            return
+        if scope.get("method") not in _UNSAFE_METHODS:
+            await self.app(scope, receive, send)
+            return
+        content_length = headers.get(b"content-length")
+        if content_length is not None:
+            try:
+                declared_length = int(content_length)
+            except ValueError:
+                declared_length = self.max_body_bytes + 1
+            if declared_length > self.max_body_bytes:
+                await self._reject_large_body(scope, receive, send)
+                return
+
+        received = 0
+
+        async def limited_receive() -> Message:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_body_bytes:
+                    raise _RequestBodyTooLarge
+            return message
+
+        try:
+            await self.app(scope, limited_receive, send)
+        except _RequestBodyTooLarge:
+            await self._reject_large_body(scope, receive, send)
+
+    @staticmethod
+    async def _reject_large_body(scope: Scope, receive: Receive, send: Send) -> None:
+        response = JSONResponse(
+            {"detail": "Request body too large."},
+            status_code=413,
+        )
+        await response(scope, receive, send)
+
+
+class _RequestBodyTooLarge(Exception):
+    pass

--- a/src/veridra/runtime_config.py
+++ b/src/veridra/runtime_config.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import ipaddress
+import os
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Mapping
+from urllib.parse import urlparse
+
+
+class RuntimeConfigurationError(RuntimeError):
+    pass
+
+
+class RuntimeEnvironment(StrEnum):
+    development = "development"
+    test = "test"
+    production = "production"
+
+
+def _absolute_path(value: str, *, name: str) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise RuntimeConfigurationError(f"{name} must be an absolute path.")
+    return path.resolve()
+
+
+def _split_hosts(value: str) -> tuple[str, ...]:
+    hosts = tuple(part.strip().lower() for part in value.split(",") if part.strip())
+    if any(host == "*" for host in hosts):
+        raise RuntimeConfigurationError("VERIDRA_ALLOWED_HOSTS cannot contain a wildcard.")
+    return hosts
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    environment: RuntimeEnvironment
+    identity_database: Path | None
+    tenant_data_root: Path | None
+    trusted_origin: str | None
+    allowed_hosts: tuple[str, ...]
+    bind_host: str
+    bind_port: int
+
+    @classmethod
+    def from_environment(cls, env: Mapping[str, str] | None = None) -> RuntimeConfig:
+        values = os.environ if env is None else env
+        try:
+            environment = RuntimeEnvironment(values.get("VERIDRA_ENV", "development").strip())
+        except ValueError as exc:
+            raise RuntimeConfigurationError("VERIDRA_ENV is invalid.") from exc
+
+        identity_value = values.get("VERIDRA_IDENTITY_DB", "").strip()
+        tenant_value = values.get("VERIDRA_TENANT_DATA_ROOT", "").strip()
+        origin = values.get("VERIDRA_TRUSTED_ORIGIN", "").strip() or None
+        hosts = _split_hosts(values.get("VERIDRA_ALLOWED_HOSTS", ""))
+        bind_host = values.get("VERIDRA_BIND_HOST", "127.0.0.1").strip()
+        try:
+            bind_port = int(values.get("VERIDRA_BIND_PORT", "8000"))
+        except ValueError as exc:
+            raise RuntimeConfigurationError("VERIDRA_BIND_PORT is invalid.") from exc
+        if not 1 <= bind_port <= 65535:
+            raise RuntimeConfigurationError("VERIDRA_BIND_PORT must be between 1 and 65535.")
+        try:
+            ipaddress.ip_address(bind_host)
+        except ValueError as exc:
+            raise RuntimeConfigurationError("VERIDRA_BIND_HOST must be an IP address.") from exc
+
+        identity = _absolute_path(identity_value, name="VERIDRA_IDENTITY_DB") if identity_value else None
+        tenant_root = (
+            _absolute_path(tenant_value, name="VERIDRA_TENANT_DATA_ROOT")
+            if tenant_value
+            else None
+        )
+        config = cls(
+            environment=environment,
+            identity_database=identity,
+            tenant_data_root=tenant_root,
+            trusted_origin=origin,
+            allowed_hosts=hosts,
+            bind_host=bind_host,
+            bind_port=bind_port,
+        )
+        config.validate()
+        return config
+
+    def validate(self) -> None:
+        if self.environment is not RuntimeEnvironment.production:
+            return
+        if self.identity_database is None:
+            raise RuntimeConfigurationError("VERIDRA_IDENTITY_DB is required in production.")
+        if self.tenant_data_root is None:
+            raise RuntimeConfigurationError(
+                "VERIDRA_TENANT_DATA_ROOT is required in production."
+            )
+        if self.trusted_origin is None:
+            raise RuntimeConfigurationError("VERIDRA_TRUSTED_ORIGIN is required in production.")
+        parsed = urlparse(self.trusted_origin)
+        if parsed.scheme != "https" or not parsed.hostname or parsed.path not in {"", "/"}:
+            raise RuntimeConfigurationError(
+                "VERIDRA_TRUSTED_ORIGIN must be an HTTPS origin without a path."
+            )
+        if not self.allowed_hosts:
+            raise RuntimeConfigurationError("VERIDRA_ALLOWED_HOSTS is required in production.")
+        if parsed.hostname.lower() not in self.allowed_hosts:
+            raise RuntimeConfigurationError(
+                "VERIDRA_ALLOWED_HOSTS must include the trusted-origin host."
+            )
+
+    def configure_directories(self) -> None:
+        if self.identity_database is not None:
+            self.identity_database.parent.mkdir(parents=True, exist_ok=True)
+        if self.tenant_data_root is not None:
+            self.tenant_data_root.mkdir(parents=True, exist_ok=True)

--- a/src/veridra/runtime_config.py
+++ b/src/veridra/runtime_config.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import ipaddress
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Mapping
 from urllib.parse import urlparse
 
 
@@ -67,7 +67,11 @@ class RuntimeConfig:
         except ValueError as exc:
             raise RuntimeConfigurationError("VERIDRA_BIND_HOST must be an IP address.") from exc
 
-        identity = _absolute_path(identity_value, name="VERIDRA_IDENTITY_DB") if identity_value else None
+        identity = (
+            _absolute_path(identity_value, name="VERIDRA_IDENTITY_DB")
+            if identity_value
+            else None
+        )
         tenant_root = (
             _absolute_path(tenant_value, name="VERIDRA_TENANT_DATA_ROOT")
             if tenant_value

--- a/src/veridra/runtime_config.py
+++ b/src/veridra/runtime_config.py
@@ -33,6 +33,19 @@ def _split_hosts(value: str) -> tuple[str, ...]:
     return hosts
 
 
+def _split_proxy_ips(value: str) -> tuple[str, ...]:
+    proxies: list[str] = []
+    for part in value.split(","):
+        candidate = part.strip()
+        if not candidate:
+            continue
+        try:
+            proxies.append(str(ipaddress.ip_address(candidate)))
+        except ValueError as exc:
+            raise RuntimeConfigurationError("VERIDRA_TRUSTED_PROXY_IPS is invalid.") from exc
+    return tuple(proxies)
+
+
 @dataclass(frozen=True)
 class RuntimeConfig:
     environment: RuntimeEnvironment
@@ -40,6 +53,8 @@ class RuntimeConfig:
     tenant_data_root: Path | None
     trusted_origin: str | None
     allowed_hosts: tuple[str, ...]
+    trusted_proxy_ips: tuple[str, ...]
+    max_request_body_bytes: int
     bind_host: str
     bind_port: int
 
@@ -55,13 +70,21 @@ class RuntimeConfig:
         tenant_value = values.get("VERIDRA_TENANT_DATA_ROOT", "").strip()
         origin = values.get("VERIDRA_TRUSTED_ORIGIN", "").strip() or None
         hosts = _split_hosts(values.get("VERIDRA_ALLOWED_HOSTS", ""))
+        trusted_proxy_ips = _split_proxy_ips(values.get("VERIDRA_TRUSTED_PROXY_IPS", ""))
         bind_host = values.get("VERIDRA_BIND_HOST", "127.0.0.1").strip()
         try:
             bind_port = int(values.get("VERIDRA_BIND_PORT", "8000"))
+            max_request_body_bytes = int(
+                values.get("VERIDRA_MAX_REQUEST_BODY_BYTES", "1000000")
+            )
         except ValueError as exc:
-            raise RuntimeConfigurationError("VERIDRA_BIND_PORT is invalid.") from exc
+            raise RuntimeConfigurationError("Runtime numeric configuration is invalid.") from exc
         if not 1 <= bind_port <= 65535:
             raise RuntimeConfigurationError("VERIDRA_BIND_PORT must be between 1 and 65535.")
+        if not 1_024 <= max_request_body_bytes <= 10_000_000:
+            raise RuntimeConfigurationError(
+                "VERIDRA_MAX_REQUEST_BODY_BYTES must be between 1024 and 10000000."
+            )
         try:
             ipaddress.ip_address(bind_host)
         except ValueError as exc:
@@ -83,6 +106,8 @@ class RuntimeConfig:
             tenant_data_root=tenant_root,
             trusted_origin=origin,
             allowed_hosts=hosts,
+            trusted_proxy_ips=trusted_proxy_ips,
+            max_request_body_bytes=max_request_body_bytes,
             bind_host=bind_host,
             bind_port=bind_port,
         )

--- a/tests/test_runtime_hardening.py
+++ b/tests/test_runtime_hardening.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from veridra.operations_api import router as operations_router
+from veridra.runtime_boundary import RuntimeBoundaryMiddleware
 from veridra.runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
 
 
@@ -19,6 +20,8 @@ def test_development_defaults_remain_local() -> None:
     assert config.tenant_data_root is None
     assert config.bind_host == "127.0.0.1"
     assert config.bind_port == 8000
+    assert config.trusted_proxy_ips == ()
+    assert config.max_request_body_bytes == 1_000_000
 
 
 def test_production_requires_complete_safe_configuration(tmp_path: Path) -> None:
@@ -45,6 +48,8 @@ def test_valid_production_configuration_is_explicit(tmp_path: Path) -> None:
             "VERIDRA_TENANT_DATA_ROOT": str(tmp_path / "tenants"),
             "VERIDRA_TRUSTED_ORIGIN": "https://app.example.com",
             "VERIDRA_ALLOWED_HOSTS": "app.example.com",
+            "VERIDRA_TRUSTED_PROXY_IPS": "127.0.0.1,10.0.0.8",
+            "VERIDRA_MAX_REQUEST_BODY_BYTES": "2000000",
             "VERIDRA_BIND_HOST": "0.0.0.0",
             "VERIDRA_BIND_PORT": "8443",
         }
@@ -52,6 +57,8 @@ def test_valid_production_configuration_is_explicit(tmp_path: Path) -> None:
 
     assert config.environment is RuntimeEnvironment.production
     assert config.allowed_hosts == ("app.example.com",)
+    assert config.trusted_proxy_ips == ("127.0.0.1", "10.0.0.8")
+    assert config.max_request_body_bytes == 2_000_000
     assert config.bind_host == "0.0.0.0"
     assert config.bind_port == 8443
 
@@ -83,3 +90,59 @@ def test_trusted_host_rejects_unconfigured_host() -> None:
 
     assert client.get("/health").status_code == 200
     assert client.get("/health", headers={"host": "evil.example"}).status_code == 400
+
+
+def _boundary_client(*, trusted_proxy_ips: tuple[str, ...] = ()) -> TestClient:
+    app = FastAPI()
+    app.add_middleware(
+        RuntimeBoundaryMiddleware,
+        max_body_bytes=32,
+        trusted_proxy_ips=trusted_proxy_ips,
+    )
+
+    @app.post("/echo")
+    async def echo(request: Request) -> dict[str, str]:
+        return {"body": (await request.body()).decode()}
+
+    return TestClient(app)
+
+
+def test_oversized_mutation_body_is_rejected_before_route_parsing() -> None:
+    client = _boundary_client()
+
+    accepted = client.post("/echo", content="a" * 32)
+    rejected = client.post("/echo", content="a" * 33)
+
+    assert accepted.status_code == 200
+    assert rejected.status_code == 413
+    assert rejected.json() == {"detail": "Request body too large."}
+
+
+def test_untrusted_forwarded_headers_are_rejected() -> None:
+    client = _boundary_client()
+
+    response = client.post(
+        "/echo",
+        content="ok",
+        headers={"x-forwarded-host": "evil.example"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Untrusted forwarded headers."}
+
+
+def test_trusted_proxy_headers_do_not_redefine_request_identity() -> None:
+    client = _boundary_client(trusted_proxy_ips=("testclient",))
+
+    response = client.post(
+        "/echo",
+        content="ok",
+        headers={
+            "x-forwarded-host": "public.example",
+            "x-forwarded-proto": "https",
+            "x-forwarded-for": "203.0.113.7",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"body": "ok"}

--- a/tests/test_runtime_hardening.py
+++ b/tests/test_runtime_hardening.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.trustedhost import TrustedHostMiddleware
+
+from veridra.operations_api import router as operations_router
+from veridra.runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
+
+
+def test_development_defaults_remain_local() -> None:
+    config = RuntimeConfig.from_environment({})
+
+    assert config.environment is RuntimeEnvironment.development
+    assert config.identity_database is None
+    assert config.tenant_data_root is None
+    assert config.bind_host == "127.0.0.1"
+    assert config.bind_port == 8000
+
+
+def test_production_requires_complete_safe_configuration(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeConfigurationError, match="IDENTITY_DB"):
+        RuntimeConfig.from_environment({"VERIDRA_ENV": "production"})
+
+    with pytest.raises(RuntimeConfigurationError, match="HTTPS origin"):
+        RuntimeConfig.from_environment(
+            {
+                "VERIDRA_ENV": "production",
+                "VERIDRA_IDENTITY_DB": str(tmp_path / "identity.sqlite3"),
+                "VERIDRA_TENANT_DATA_ROOT": str(tmp_path / "tenants"),
+                "VERIDRA_TRUSTED_ORIGIN": "http://app.example.com",
+                "VERIDRA_ALLOWED_HOSTS": "app.example.com",
+            }
+        )
+
+
+def test_valid_production_configuration_is_explicit(tmp_path: Path) -> None:
+    config = RuntimeConfig.from_environment(
+        {
+            "VERIDRA_ENV": "production",
+            "VERIDRA_IDENTITY_DB": str(tmp_path / "identity.sqlite3"),
+            "VERIDRA_TENANT_DATA_ROOT": str(tmp_path / "tenants"),
+            "VERIDRA_TRUSTED_ORIGIN": "https://app.example.com",
+            "VERIDRA_ALLOWED_HOSTS": "app.example.com",
+            "VERIDRA_BIND_HOST": "0.0.0.0",
+            "VERIDRA_BIND_PORT": "8443",
+        }
+    )
+
+    assert config.environment is RuntimeEnvironment.production
+    assert config.allowed_hosts == ("app.example.com",)
+    assert config.bind_host == "0.0.0.0"
+    assert config.bind_port == 8443
+
+
+def test_health_is_non_disclosing_and_readiness_checks_dependencies(tmp_path: Path) -> None:
+    app = FastAPI()
+    app.include_router(operations_router)
+    app.state.veridra_tenant_data_root = tmp_path / "missing"
+    client = TestClient(app)
+
+    health = client.get("/health")
+    unavailable = client.get("/ready")
+    app.state.veridra_tenant_data_root.mkdir()
+    ready = client.get("/ready")
+
+    assert health.status_code == 200
+    assert health.json() == {"status": "ok"}
+    assert unavailable.status_code == 503
+    assert unavailable.json() == {"status": "unavailable"}
+    assert ready.status_code == 200
+    assert ready.json() == {"status": "ready"}
+
+
+def test_trusted_host_rejects_unconfigured_host() -> None:
+    app = FastAPI()
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=["app.example.com"])
+    app.include_router(operations_router)
+    client = TestClient(app, base_url="https://app.example.com")
+
+    assert client.get("/health").status_code == 200
+    assert client.get("/health", headers={"host": "evil.example"}).status_code == 400


### PR DESCRIPTION
Implements issue #85 from merged durable-monitoring foundation `d21aabb01c659a36a3f7ef039af38d523dcc3313`.

## Implemented and proven

### Runtime configuration
- explicit `development`, `test` and `production` environments;
- fail-closed production validation for durable absolute paths, HTTPS trusted origin, allowed hosts and bind settings;
- configurable bind host/port, request-body limit and trusted immediate proxy IPs;
- production startup cannot rely on partial development defaults.

### Health and readiness
- `GET /health` returns only `{"status":"ok"}`;
- `GET /ready` checks configured durable dependencies and returns a generic `503` unavailable response without disclosing paths, database names, tenant data or secrets.

### Host, proxy and request boundaries
- explicit `TrustedHostMiddleware` enforcement;
- Uvicorn proxy-header interpretation remains disabled;
- forwarded headers from untrusted immediate peers are rejected;
- trusted proxy configuration accepts only validated IP addresses;
- forwarded headers do not redefine ASGI scheme, host or client identity inside the application;
- authenticated and public unsafe request bodies are bounded by both declared and actual received bytes before route parsing;
- malformed or oversized bodies fail before downstream route execution.

### Deployment operations
- separate supervised web and bounded monitoring-worker process model;
- production configuration reference;
- reverse-proxy and direct-access boundary;
- filesystem least privilege;
- backup, restore and migration order;
- readiness monitoring;
- secret and token redaction rules;
- supervisor expectations and pre-release checklist.

### Tests
- development defaults remain local;
- incomplete or unsafe production configuration fails;
- valid production configuration is explicit;
- health is non-disclosing and readiness reflects dependency availability;
- untrusted Host values fail;
- oversized mutation bodies fail with `413`;
- untrusted forwarded headers fail;
- configured proxy headers do not redefine application request identity.

## Exact-head validation

Exact head `96104f08f75d20ee5949ea1d3df2dd6606ea87fc` passed CI #1156:
- Ruff;
- strict mypy;
- pytest;
- deterministic repository audit;
- Chromium browser audit;
- evidence upload.

## Explicit exclusions

- provider-specific infrastructure;
- Kubernetes or Terraform implementation;
- distributed rate limiting;
- production SMTP-provider selection;
- billing and subscription enforcement;
- external penetration-test certification.

This PR establishes a fail-closed single-region production runtime boundary. It does not claim a completed cloud deployment or external certification.

Closes #85.