### PR TITLE
Add commercial page-level crawl findings

### DIFF
--- a/docs/architecture/crawl-commercial-findings.md
+++ b/docs/architecture/crawl-commercial-findings.md
@@ -1,0 +1,49 @@
+# Commercial crawl findings
+
+## Purpose
+
+This milestone expands Veridra's existing bounded same-origin crawl with page-level evidence expected in professional agency audits. It does not replace or broaden the crawler's network safety boundary.
+
+## Existing foundation retained
+
+- same-origin HTTP/HTTPS pages only;
+- sequential bounded collection;
+- explicit page, depth, sitemap, response-byte and total-byte limits;
+- public-target validation and redirect revalidation for every collected page;
+- no authentication, script execution, form submission or private-network access;
+- deterministic affected-URL evidence.
+
+## New findings
+
+### Duplicate metadata
+
+Non-empty document titles and non-empty meta descriptions are normalized for comparison. A duplicate finding is emitted only when the same normalized value appears on more than one crawled page. Empty or missing values remain covered by existing missing-field findings.
+
+Evidence contains the normalized value and a bounded, sorted URL list for every duplicate group.
+
+### Missing image alternative text
+
+Every image without an `alt` attribute is counted per page. An explicit empty `alt=""` is treated as present because it may intentionally mark a decorative image. Evidence contains affected URLs and missing-alt counts.
+
+### Redirect chains
+
+A redirect-chain finding is emitted when collected page evidence contains more than one redirect hop. Evidence contains requested URL, final URL and the bounded redirect chain already produced by the collector.
+
+### Oversized HTML
+
+Page size is derived only from collected HTML body bytes. It is not described as browser transfer size, compressed size or total page weight. A deterministic threshold is used and reported in evidence.
+
+## Evidence constraints
+
+All lists and groups are sorted deterministically. Evidence remains bounded by the crawl limits and does not duplicate full HTML bodies.
+
+## Explicit exclusions
+
+- JavaScript-rendered DOM inspection;
+- image file-size collection;
+- CSS, JavaScript or total-page transfer weight;
+- cross-origin resource crawling;
+- semantic duplicate-content analysis;
+- backlink or keyword databases.
+
+Related to issue #56.

--- a/src/veridra/commercial_crawl_findings.py
+++ b/src/veridra/commercial_crawl_findings.py
@@ -80,7 +80,11 @@ def _finding(
 ) -> Finding:
     return Finding(
         id=identifier,
-        area="Search visibility" if identifier.startswith("crawl.duplicate") else "Website health",
+        area=(
+            "Search visibility"
+            if identifier.startswith("crawl.duplicate")
+            else "Website health"
+        ),
         title=title,
         status=Status.attention if affected else Status.passed,
         severity=severity if affected else "info",
@@ -123,7 +127,9 @@ def analyze_commercial_crawl_findings(result: CrawlResult) -> list[Finding]:
             )
         body_bytes = len(page.body.encode())
         if body_bytes > _OVERSIZED_HTML_BYTES:
-            oversized_pages.append({"url": page.final_url, "html_body_bytes": body_bytes})
+            oversized_pages.append(
+                {"url": page.final_url, "html_body_bytes": body_bytes}
+            )
 
     duplicate_titles = _duplicate_groups(titles)
     duplicate_descriptions = _duplicate_groups(descriptions)
@@ -136,7 +142,9 @@ def analyze_commercial_crawl_findings(result: CrawlResult) -> list[Finding]:
             identifier="crawl.duplicate-titles",
             title="Duplicate document titles",
             severity="medium",
-            attention_summary=f"{len(duplicate_titles)} duplicate title groups were observed.",
+            attention_summary=(
+                f"{len(duplicate_titles)} duplicate title groups were observed."
+            ),
             recommendation="Give each indexable page a distinct, descriptive document title.",
             affected=bool(duplicate_titles),
             evidence={"duplicate_groups": duplicate_titles},
@@ -156,7 +164,9 @@ def analyze_commercial_crawl_findings(result: CrawlResult) -> list[Finding]:
             identifier="crawl.image-alt",
             title="Images missing alt attributes",
             severity="medium",
-            attention_summary=f"{len(missing_alt)} crawled pages contain images without alt attributes.",
+            attention_summary=(
+                f"{len(missing_alt)} crawled pages contain images without alt attributes."
+            ),
             recommendation=(
                 "Add useful alt text to informative images and explicit empty alt attributes "
                 "to decorative images."
@@ -171,8 +181,12 @@ def analyze_commercial_crawl_findings(result: CrawlResult) -> list[Finding]:
             identifier="crawl.redirect-chains",
             title="Multi-hop redirect chains",
             severity="medium",
-            attention_summary=f"{len(redirect_chains)} crawled pages used multi-hop redirects.",
-            recommendation="Link directly to the final canonical URL and remove avoidable redirect hops.",
+            attention_summary=(
+                f"{len(redirect_chains)} crawled pages used multi-hop redirects."
+            ),
+            recommendation=(
+                "Link directly to the final canonical URL and remove avoidable redirect hops."
+            ),
             affected=bool(redirect_chains),
             evidence={"redirect_chains": redirect_chains},
         ),
@@ -183,7 +197,9 @@ def analyze_commercial_crawl_findings(result: CrawlResult) -> list[Finding]:
             attention_summary=(
                 f"{len(oversized_pages)} crawled pages exceeded the collected HTML threshold."
             ),
-            recommendation="Reduce generated HTML where practical and verify the delivered document size.",
+            recommendation=(
+                "Reduce generated HTML where practical and verify the delivered document size."
+            ),
             affected=bool(oversized_pages),
             evidence={
                 "threshold_bytes": _OVERSIZED_HTML_BYTES,

--- a/src/veridra/commercial_crawl_findings.py
+++ b/src/veridra/commercial_crawl_findings.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from html.parser import HTMLParser
+
+from .core import Finding, Status
+from .crawl import CrawlResult
+
+_OVERSIZED_HTML_BYTES = 500_000
+
+
+class _CommercialPageSignals(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._inside_title = False
+        self._title_parts: list[str] = []
+        self.description = ""
+        self.missing_alt_count = 0
+
+    @property
+    def title(self) -> str:
+        return " ".join(" ".join(self._title_parts).split())
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        lowered_tag = tag.lower()
+        data = {key.lower(): (value or "") for key, value in attrs}
+        if lowered_tag == "title":
+            self._inside_title = True
+        elif lowered_tag == "meta" and data.get("name", "").casefold() == "description":
+            self.description = " ".join(data.get("content", "").split())
+        elif lowered_tag == "img" and "alt" not in data:
+            self.missing_alt_count += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "title":
+            self._inside_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._inside_title:
+            self._title_parts.append(data)
+
+
+def _normalized(value: str) -> str:
+    return " ".join(value.split()).casefold()
+
+
+def _duplicate_groups(values: dict[str, str]) -> list[dict[str, object]]:
+    grouped: defaultdict[str, list[str]] = defaultdict(list)
+    display_values: dict[str, str] = {}
+    for url, value in values.items():
+        normalized = _normalized(value)
+        if not normalized:
+            continue
+        grouped[normalized].append(url)
+        display_values.setdefault(normalized, " ".join(value.split()))
+    return [
+        {
+            "value": display_values[normalized],
+            "normalized_value": normalized,
+            "urls": sorted(urls),
+        }
+        for normalized, urls in sorted(grouped.items())
+        if len(urls) > 1
+    ]
+
+
+def _finding(
+    *,
+    identifier: str,
+    title: str,
+    severity: str,
+    attention_summary: str,
+    recommendation: str,
+    affected: bool,
+    evidence: dict[str, object],
+) -> Finding:
+    return Finding(
+        id=identifier,
+        area="Search visibility" if identifier.startswith("crawl.duplicate") else "Website health",
+        title=title,
+        status=Status.attention if affected else Status.passed,
+        severity=severity if affected else "info",
+        summary=(
+            attention_summary
+            if affected
+            else f"No {title.lower()} issues were observed in the bounded crawl."
+        ),
+        recommendation=recommendation if affected else None,
+        evidence=evidence,
+    )
+
+
+def analyze_commercial_crawl_findings(result: CrawlResult) -> list[Finding]:
+    titles: dict[str, str] = {}
+    descriptions: dict[str, str] = {}
+    missing_alt: list[dict[str, object]] = []
+    redirect_chains: list[dict[str, object]] = []
+    oversized_pages: list[dict[str, object]] = []
+
+    for crawled in result.pages:
+        page = crawled.evidence
+        parser = _CommercialPageSignals()
+        parser.feed(page.body)
+        if parser.title:
+            titles[page.final_url] = parser.title
+        if parser.description:
+            descriptions[page.final_url] = parser.description
+        if parser.missing_alt_count:
+            missing_alt.append(
+                {"url": page.final_url, "missing_alt_count": parser.missing_alt_count}
+            )
+        if len(page.redirect_chain) > 1:
+            redirect_chains.append(
+                {
+                    "requested_url": page.requested_url,
+                    "final_url": page.final_url,
+                    "redirect_chain": list(page.redirect_chain),
+                }
+            )
+        body_bytes = len(page.body.encode())
+        if body_bytes > _OVERSIZED_HTML_BYTES:
+            oversized_pages.append({"url": page.final_url, "html_body_bytes": body_bytes})
+
+    duplicate_titles = _duplicate_groups(titles)
+    duplicate_descriptions = _duplicate_groups(descriptions)
+    missing_alt.sort(key=lambda item: str(item["url"]))
+    redirect_chains.sort(key=lambda item: str(item["requested_url"]))
+    oversized_pages.sort(key=lambda item: str(item["url"]))
+
+    return [
+        _finding(
+            identifier="crawl.duplicate-titles",
+            title="Duplicate document titles",
+            severity="medium",
+            attention_summary=f"{len(duplicate_titles)} duplicate title groups were observed.",
+            recommendation="Give each indexable page a distinct, descriptive document title.",
+            affected=bool(duplicate_titles),
+            evidence={"duplicate_groups": duplicate_titles},
+        ),
+        _finding(
+            identifier="crawl.duplicate-descriptions",
+            title="Duplicate meta descriptions",
+            severity="medium",
+            attention_summary=(
+                f"{len(duplicate_descriptions)} duplicate meta-description groups were observed."
+            ),
+            recommendation="Write a distinct meta description for each important page.",
+            affected=bool(duplicate_descriptions),
+            evidence={"duplicate_groups": duplicate_descriptions},
+        ),
+        _finding(
+            identifier="crawl.image-alt",
+            title="Images missing alt attributes",
+            severity="medium",
+            attention_summary=f"{len(missing_alt)} crawled pages contain images without alt attributes.",
+            recommendation=(
+                "Add useful alt text to informative images and explicit empty alt attributes "
+                "to decorative images."
+            ),
+            affected=bool(missing_alt),
+            evidence={
+                "affected_pages": missing_alt,
+                "affected_urls": [item["url"] for item in missing_alt],
+            },
+        ),
+        _finding(
+            identifier="crawl.redirect-chains",
+            title="Multi-hop redirect chains",
+            severity="medium",
+            attention_summary=f"{len(redirect_chains)} crawled pages used multi-hop redirects.",
+            recommendation="Link directly to the final canonical URL and remove avoidable redirect hops.",
+            affected=bool(redirect_chains),
+            evidence={"redirect_chains": redirect_chains},
+        ),
+        _finding(
+            identifier="crawl.oversized-html",
+            title="Oversized HTML responses",
+            severity="medium",
+            attention_summary=(
+                f"{len(oversized_pages)} crawled pages exceeded the collected HTML threshold."
+            ),
+            recommendation="Reduce generated HTML where practical and verify the delivered document size.",
+            affected=bool(oversized_pages),
+            evidence={
+                "threshold_bytes": _OVERSIZED_HTML_BYTES,
+                "measurement": "decoded collected HTML body bytes",
+                "affected_pages": oversized_pages,
+                "affected_urls": [item["url"] for item in oversized_pages],
+            },
+        ),
+    ]

--- a/src/veridra/service.py
+++ b/src/veridra/service.py
@@ -12,6 +12,7 @@ from .collector import (
     collect_page,
     collect_site,
 )
+from .commercial_crawl_findings import analyze_commercial_crawl_findings
 from .core import Assessment, Finding, Status, analyze_document
 from .crawl import CrawlLimits, analyze_crawl, crawl_site
 from .crawl_profiles import CrawlProfile, anonymous_crawl_profile
@@ -132,6 +133,7 @@ def assess_url(
         robots_text=robots_text,
     )
     findings.extend(analyze_crawl(crawl))
+    findings.extend(analyze_commercial_crawl_findings(crawl))
     findings.extend(analyze_page_quality(crawl))
     findings.extend(analyze_accessibility(crawl))
     findings.extend(analyze_passive_security(crawl))

--- a/tests/test_commercial_crawl_findings.py
+++ b/tests/test_commercial_crawl_findings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from veridra.collector import PageEvidence
 from veridra.commercial_crawl_findings import analyze_commercial_crawl_findings
-from veridra.core import Status
+from veridra.core import Finding, Status
 from veridra.crawl import CrawlResult, CrawledPage
 
 
@@ -37,7 +37,7 @@ def _result(*pages: CrawledPage) -> CrawlResult:
     )
 
 
-def _findings(result: CrawlResult) -> dict[str, object]:
+def _findings(result: CrawlResult) -> dict[str, Finding]:
     return {finding.id: finding for finding in analyze_commercial_crawl_findings(result)}
 
 

--- a/tests/test_commercial_crawl_findings.py
+++ b/tests/test_commercial_crawl_findings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from veridra.collector import PageEvidence
 from veridra.commercial_crawl_findings import analyze_commercial_crawl_findings
 from veridra.core import Finding, Status
-from veridra.crawl import CrawlResult, CrawledPage
+from veridra.crawl import CrawledPage, CrawlResult
 
 
 def _page(

--- a/tests/test_commercial_crawl_findings.py
+++ b/tests/test_commercial_crawl_findings.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from veridra.collector import PageEvidence
+from veridra.commercial_crawl_findings import analyze_commercial_crawl_findings
+from veridra.core import Status
+from veridra.crawl import CrawlResult, CrawledPage
+
+
+def _page(
+    url: str,
+    body: str,
+    *,
+    requested_url: str | None = None,
+    redirect_chain: tuple[str, ...] = (),
+) -> CrawledPage:
+    return CrawledPage(
+        evidence=PageEvidence(
+            requested_url=requested_url or url,
+            final_url=url,
+            status_code=200,
+            headers={"content-type": "text/html"},
+            body=body,
+            redirect_chain=redirect_chain,
+            connected_ip="93.184.216.34",
+            validated_ips=("93.184.216.34",),
+        ),
+        depth=0,
+    )
+
+
+def _result(*pages: CrawledPage) -> CrawlResult:
+    return CrawlResult(
+        pages=pages,
+        skipped_urls=(),
+        exhausted_page_limit=False,
+        exhausted_byte_limit=False,
+    )
+
+
+def _findings(result: CrawlResult) -> dict[str, object]:
+    return {finding.id: finding for finding in analyze_commercial_crawl_findings(result)}
+
+
+def test_duplicate_metadata_is_normalized_and_empty_values_are_ignored() -> None:
+    result = _result(
+        _page(
+            "https://example.com/a",
+            "<title>  Shared   Title </title>"
+            "<meta name='description' content=' Shared description '>",
+        ),
+        _page(
+            "https://example.com/b",
+            "<title>shared title</title>"
+            "<meta name='description' content='shared   description'>",
+        ),
+        _page(
+            "https://example.com/c",
+            "<title>Unique</title><meta name='description' content=''>",
+        ),
+    )
+    findings = _findings(result)
+    titles = findings["crawl.duplicate-titles"]
+    descriptions = findings["crawl.duplicate-descriptions"]
+
+    assert titles.status is Status.attention
+    assert titles.evidence["duplicate_groups"] == [
+        {
+            "value": "Shared Title",
+            "normalized_value": "shared title",
+            "urls": ["https://example.com/a", "https://example.com/b"],
+        }
+    ]
+    assert descriptions.status is Status.attention
+    assert descriptions.evidence["duplicate_groups"] == [
+        {
+            "value": "Shared description",
+            "normalized_value": "shared description",
+            "urls": ["https://example.com/a", "https://example.com/b"],
+        }
+    ]
+
+
+def test_missing_alt_counts_only_images_without_the_attribute() -> None:
+    result = _result(
+        _page(
+            "https://example.com/gallery",
+            "<img src='one.jpg'><img src='two.jpg' alt=''>"
+            "<img src='three.jpg' alt='Description'><img src='four.jpg'>",
+        )
+    )
+    finding = _findings(result)["crawl.image-alt"]
+
+    assert finding.status is Status.attention
+    assert finding.evidence["affected_pages"] == [
+        {"url": "https://example.com/gallery", "missing_alt_count": 2}
+    ]
+    assert finding.evidence["affected_urls"] == ["https://example.com/gallery"]
+
+
+def test_redirect_chain_and_oversized_html_evidence_is_bounded_and_explicit() -> None:
+    oversized_body = "x" * 500_001
+    result = _result(
+        _page(
+            "https://example.com/final",
+            oversized_body,
+            requested_url="https://example.com/start",
+            redirect_chain=(
+                "https://example.com/middle",
+                "https://example.com/final",
+            ),
+        ),
+        _page(
+            "https://example.com/one-hop",
+            "ok",
+            requested_url="https://example.com/old",
+            redirect_chain=("https://example.com/one-hop",),
+        ),
+    )
+    findings = _findings(result)
+    redirects = findings["crawl.redirect-chains"]
+    oversized = findings["crawl.oversized-html"]
+
+    assert redirects.status is Status.attention
+    assert redirects.evidence["redirect_chains"] == [
+        {
+            "requested_url": "https://example.com/start",
+            "final_url": "https://example.com/final",
+            "redirect_chain": [
+                "https://example.com/middle",
+                "https://example.com/final",
+            ],
+        }
+    ]
+    assert oversized.status is Status.attention
+    assert oversized.evidence["threshold_bytes"] == 500_000
+    assert oversized.evidence["measurement"] == "decoded collected HTML body bytes"
+    assert oversized.evidence["affected_pages"] == [
+        {"url": "https://example.com/final", "html_body_bytes": 500_001}
+    ]
+
+
+def test_clean_pages_produce_passed_findings() -> None:
+    result = _result(
+        _page(
+            "https://example.com/a",
+            "<title>A</title><meta name='description' content='A page'>"
+            "<img src='decorative.jpg' alt=''>",
+        ),
+        _page(
+            "https://example.com/b",
+            "<title>B</title><meta name='description' content='B page'>"
+            "<img src='useful.jpg' alt='Useful'>",
+        ),
+    )
+
+    assert all(
+        finding.status is Status.passed
+        for finding in analyze_commercial_crawl_findings(result)
+    )


### PR DESCRIPTION
Implements issue #56 from merged production-runtime foundation `22f3e2e2a0672c5e4ea9257681eef5fbb799bc5c`.

## Implemented and proven

### Duplicate metadata
- detects duplicate non-empty document titles across crawled pages;
- detects duplicate non-empty meta descriptions;
- normalizes whitespace and case for comparison;
- preserves a representative display value;
- excludes empty or missing values so existing missing-field findings remain authoritative;
- returns deterministic sorted URL groups.

### Image alternative text
- counts images without an `alt` attribute per crawled page;
- treats explicit `alt=""` as present for decorative-image semantics;
- reports affected URLs and per-page counts.

### Redirect and size evidence
- reports only redirect chains with more than one hop;
- includes requested URL, final URL and the collector's bounded chain;
- reports HTML documents exceeding 500.000 collected body bytes;
- labels the measurement as decoded collected HTML body bytes, not browser transfer size or total page weight.

### Integration and safety
- integrated into the existing assessment service;
- retains same-origin, sequential and bounded crawling;
- does not alter target validation, redirect revalidation, page limits, sitemap limits or byte limits;
- adds no JavaScript execution, authentication or cross-origin crawling.

### Tests
- duplicate normalization and empty-value exclusion;
- missing-alt counts and decorative empty-alt handling;
- multi-hop versus single-hop redirects;
- deterministic HTML-size threshold evidence;
- clean-pass behavior.

## Exact-head validation

Exact head `da4a47951c35f88bc5814acc9dadbead87489a73` passed CI #1176:
- Ruff;
- strict mypy;
- pytest;
- deterministic repository audit;
- Chromium browser audit;
- evidence upload.

## Explicit exclusions

- JavaScript-rendered DOM inspection;
- total browser page weight;
- cross-origin resource crawling;
- semantic duplicate-content analysis;
- backlink or keyword datasets.

Closes #56.