### PR TITLE
Add agency workflow shell

### DIFF
--- a/src/veridra/agency_workflow_web.py
+++ b/src/veridra/agency_workflow_web.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E501
 from __future__ import annotations
 
 import html

--- a/src/veridra/agency_workflow_web.py
+++ b/src/veridra/agency_workflow_web.py
@@ -1,7 +1,6 @@
 # ruff: noqa: E501
 from __future__ import annotations
 
-import html
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Query

--- a/src/veridra/agency_workflow_web.py
+++ b/src/veridra/agency_workflow_web.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import html
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Query
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+router = APIRouter(tags=["agency-workflow"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;font:14px Arial,sans-serif;background:#f7f8fa;color:#17191c}
+main{max-width:1240px;margin:0 auto;padding:36px 22px}.top{display:flex;justify-content:space-between;gap:20px;align-items:flex-start;margin-bottom:22px}
+.eyebrow{font-size:12px;text-transform:uppercase;color:#68707a}.muted{color:#68707a}.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:16px}
+section,.card{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:22px}.steps{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:10px;margin:18px 0}
+.step{background:#fff;border:1px solid #dfe3e8;border-radius:8px;padding:14px}.step strong{display:block;margin-bottom:6px}.actions{display:flex;gap:8px;flex-wrap:wrap}
+.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}
+input{width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px;margin:6px 0 10px}.links{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px;margin-top:12px}
+.links a{display:block;border:1px solid #dfe3e8;border-radius:7px;padding:12px;text-decoration:none;color:#22272d;background:#fff}.notice{border-left:4px solid #68707a;padding:12px 14px;background:#f4f6f8}
+@media(max-width:900px){.steps{grid-template-columns:1fr 1fr}.links{grid-template-columns:1fr 1fr}}
+@media(max-width:680px){.top,.grid{display:block}.card,section{margin-bottom:14px}.steps,.links{grid-template-columns:1fr}}
+"""
+
+
+def _page(body: str) -> str:
+    return (
+        "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        f"<title>Agency workflow · Veridra</title><style>{_STYLE}</style></head>"
+        f"<body><main>{body}</main></body></html>"
+    )
+
+
+@router.get("/agency", response_class=HTMLResponse)
+def agency_workflow_home() -> str:
+    body = """
+    <div class='top'><div><p class='eyebrow'>Agency workspace</p><h1>Turn website evidence into client work</h1>
+    <p class='muted'>Run an audit, produce a branded report, organise remediation and prove improvement through monitoring.</p></div>
+    <div class='actions'><a class='button secondary' href='/workspace'>Plan and usage</a><a class='button secondary' href='/workspace/members'>Team</a></div></div>
+    <div class='steps'>
+      <div class='step'><strong>1. Audit</strong><span class='muted'>Collect bounded public evidence.</span></div>
+      <div class='step'><strong>2. Explain</strong><span class='muted'>Review findings and priorities.</span></div>
+      <div class='step'><strong>3. Report</strong><span class='muted'>Create branded client output.</span></div>
+      <div class='step'><strong>4. Remediate</strong><span class='muted'>Convert findings into tasks.</span></div>
+      <div class='step'><strong>5. Prove</strong><span class='muted'>Rescan and compare changes.</span></div>
+    </div>
+    <div class='grid'>
+      <section><p class='eyebrow'>One-off opportunity</p><h2>Quick audit</h2>
+      <p>Use this for a prospect or an initial review. The handoff starts the existing bounded assessment and does not create a project or save data automatically.</p>
+      <form method='get' action='/agency/quick-audit'><label for='target'><strong>Public website</strong></label>
+      <input id='target' name='target' maxlength='2048' placeholder='example.com' required>
+      <button type='submit'>Start quick audit</button></form></section>
+      <section><p class='eyebrow'>Ongoing client work</p><h2>Client projects</h2>
+      <p>Create a persistent project when the website needs reports, remediation tasks, recurring monitoring and change comparison.</p>
+      <div class='actions'><a class='button' href='/projects'>Open projects</a><a class='button secondary' href='/monitoring'>Monitoring operations</a></div></section>
+    </div>
+    <section><h2>Agency operations</h2><p class='muted'>Existing capabilities remain separate security and persistence boundaries; this page provides one understandable entry point.</p>
+    <div class='links'>
+      <a href='/profiles'><strong>Report profiles</strong><br><span class='muted'>Brand and configure reports.</span></a>
+      <a href='/leads'><strong>Leads</strong><br><span class='muted'>Review captured prospects.</span></a>
+      <a href='/lead-forms'><strong>Lead forms</strong><br><span class='muted'>Configure embedded capture.</span></a>
+      <a href='/tasks'><strong>Remediation tasks</strong><br><span class='muted'>Track implementation work.</span></a>
+      <a href='/commercial'><strong>Commercial operations</strong><br><span class='muted'>Follow-up and engagement evidence.</span></a>
+      <a href='/history'><strong>Assessment history</strong><br><span class='muted'>Review saved evidence and comparisons.</span></a>
+    </div></section>
+    <p class='notice'><strong>Boundary:</strong> A quick audit is temporary until an operator explicitly saves it or creates a client project. Veridra does not infer a tenant, client or project from a submitted URL.</p>
+    """
+    return _page(body)
+
+
+@router.get("/agency/quick-audit")
+def quick_audit_handoff(
+    target: str = Query(min_length=1, max_length=2048),
+) -> RedirectResponse:
+    cleaned = target.strip()
+    if not cleaned:
+        return RedirectResponse("/agency", status_code=303)
+    return RedirectResponse(f"/?{urlencode({'url': cleaned})}", status_code=303)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -5,6 +5,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from . import app as app_module
 from . import public_web
+from .agency_workflow_web import router as agency_workflow_router
 from .app import app as app
 from .application_identity import configure_identity_middleware
 from .auth_api import router as auth_router
@@ -108,6 +109,7 @@ app.include_router(commercial_router)
 app.include_router(workspace_router)
 app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
+app.include_router(agency_workflow_router)
 
 
 def main() -> None:

--- a/tests/test_agency_workflow_web.py
+++ b/tests/test_agency_workflow_web.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.agency_workflow_web import router
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_agency_home_explains_quick_and_persistent_workflows() -> None:
+    response = _client().get("/agency")
+
+    assert response.status_code == 200
+    assert "Turn website evidence into client work" in response.text
+    assert "Quick audit" in response.text
+    assert "Client projects" in response.text
+    assert "does not create a project or save data automatically" in response.text
+    assert "Veridra does not infer a tenant, client or project" in response.text
+    assert "href='/profiles'" in response.text
+    assert "href='/monitoring'" in response.text
+
+
+def test_quick_audit_handoff_redirects_to_existing_console_without_persistence() -> None:
+    response = _client().get(
+        "/agency/quick-audit",
+        params={"target": "  https://example.com/path?a=1&b=2  "},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/?url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1%26b%3D2"
+
+
+def test_quick_audit_handoff_rejects_missing_target() -> None:
+    response = _client().get("/agency/quick-audit", follow_redirects=False)
+
+    assert response.status_code == 422
+
+
+def test_quick_audit_handoff_does_not_reflect_target_in_response_body() -> None:
+    marker = "<script>alert(1)</script>"
+    response = _client().get(
+        "/agency/quick-audit",
+        params={"target": marker},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert marker not in response.text
+    assert response.headers["location"].startswith("/?url=")


### PR DESCRIPTION
Implements the first bounded slice of issue #90 from current main `2618b5561e3cfce30a1321b20bc6249fbfa7f3f8`.

## What changed

- adds `/agency` as one coherent entry point for the existing agency workflow;
- distinguishes temporary Quick audits from persistent Client projects;
- explains the audit → report → remediation → monitoring evidence chain;
- links existing workspace, team, project, monitoring, profile, lead, task, commercial and history operations;
- adds `/agency/quick-audit` as a bounded handoff to the existing assessment console;
- preserves only the submitted public target in the redirect;
- does not create a project, save an assessment or accept a tenant identifier;
- registers the router in the composed runtime;
- adds deterministic route and safety assertions.

## Security and persistence boundaries

- no client-controlled tenant identity;
- no cross-tenant object lookup;
- no automatic persistence;
- existing server-side identity, same-origin enforcement, workspace policy and crawler controls remain unchanged;
- no new hosted-production, billing or security claim.

## Validation

The branch requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before it can be marked ready or merged.

Related to #87. Closes #90 when fully validated and merged.