### PR TITLE
Align current product strategy and agency workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,53 @@
 # Veridra
 
-Automated website assessment for visibility, AI discoverability, trust signals, technical health, and public security posture.
+Veridra helps agencies find website risks and growth opportunities, turn them into branded client reports and remediation work, and prove improvements through recurring monitoring.
 
-## Current vertical slice
+It audits technical SEO, AI technical readiness, AI crawler policy, trust, accessibility and passive public security; captures audit leads; produces evidence-backed white-label reports; converts findings into work; and monitors the results.
 
-- bounded live public-website assessment with DNS/IP validation and pinned connections;
-- redirect revalidation, response-size limits, and loopback-only operation;
-- deterministic demo assessment for testing and review;
-- evidence-backed findings for page structure, search readiness, AI crawler access, trust signals, and passive public security headers;
-- homepage and `robots.txt` evidence collection without authentication or active scanning;
-- bounded NS, MX, SPF, and DMARC posture checks with deterministic resolver fixtures;
-- responsive operator dashboard with assessment-area summaries and a five-item priority-action queue;
-- server-side finding filters and dedicated Website health, Search visibility, AI discoverability, Trust signals, and Security posture views;
-- JSON API plus printable HTML reports with metadata, prioritised actions, per-area summaries, full evidence, and recommendations;
-- deterministic ZIP evidence packages containing JSON, HTML, and a SHA-256 manifest;
-- explicit local assessment history with deterministic identifiers, atomic writes, comparisons, retention, and deletion controls;
-- Ruff, strict mypy, pytest, deterministic repository audit, and Chromium browser acceptance checks in GitHub Actions;
-- desktop and mobile screenshots plus machine-readable audit artifacts retained by CI.
+## Product boundary
+
+Veridra is an agency website-audit, evidence, lead-generation, remediation and monitoring platform. It is not:
+
+- a full Semrush alternative;
+- a proprietary keyword, backlink, traffic-estimation or global rank-tracking database;
+- a penetration-testing tool;
+- proof of universal AI visibility;
+- a replacement for licensed SEO-market data.
+
+The core evidence model is:
+
+> Observation → evidence → affected URLs → business impact → recommended fix → task → rescan verification.
+
+## Implemented
+
+- bounded public website assessment with DNS/IP validation, pinned connections, redirect revalidation and response-size limits;
+- configurable multi-page crawl profiles with same-origin controls, sitemap discovery and page-level evidence;
+- findings covering technical SEO fundamentals, AI crawler policy, AI technical readiness, trust, accessibility heuristics, domain/email posture and passive public security;
+- authenticated users, tenants, memberships, roles, invitations, password recovery and server-side sessions;
+- tenant-qualified projects, leads, lead forms, remediation tasks, monitoring configuration, report profiles, assessments and report artifacts;
+- white-label HTML, PDF and evidence-ZIP generation from tenant-qualified project data;
+- durable monitoring jobs with idempotent enqueueing, worker leases, stale-lease recovery, bounded retries and a separate worker CLI;
+- health/readiness endpoints, trusted hosts, explicit proxy boundaries, bounded request bodies and fail-closed production runtime validation;
+- an agency workflow home that separates temporary quick audits from persistent client projects;
+- deterministic comparisons, history, evidence packages and CI validation.
+
+## Verification status
+
+The repository quality gate includes Ruff, strict mypy, pytest, a deterministic repository audit and a Chromium browser audit. These checks verify repository behavior; they do not replace deployment-specific acceptance testing or an independent security assessment.
+
+## Production foundation and remaining deployment work
+
+The application provides explicit development, test and production modes; mandatory durable paths and trusted origins in production; trusted-host and proxy boundaries; bounded request bodies; health/readiness endpoints; and separate web and monitoring-worker processes.
+
+A concrete hosted environment still requires infrastructure provisioning, TLS termination, process supervision, backups, monitoring, SMTP configuration, secrets management and deployment-specific validation. Billing collection and subscription lifecycle management are not complete.
+
+## Important AI terminology
+
+- **AI technical readiness:** whether content is accessible, structured, identifiable and technically understandable.
+- **AI crawler policy:** whether named crawlers are allowed or blocked.
+- **Sampled AI visibility:** whether selected AI providers mention or cite a business for a controlled prompt set.
+
+Robots.txt checks, structured data and extractability do not prove actual AI visibility.
 
 ## Run locally
 
@@ -27,18 +58,18 @@ python -m venv .venv
 .\.venv\Scripts\veridra-api.exe
 ```
 
-Open `http://127.0.0.1:8000`.
+Development defaults bind to `http://127.0.0.1:8000`.
 
-## Local history
-
-Veridra does not save assessments automatically. The operator must select **Save locally** for an assessment to be written to the local data directory. Saved data is limited to the existing assessment model; Veridra does not store credentials, cookies, form submissions, or request bodies.
-
-Set `VERIDRA_DATA_DIR` to choose the parent data directory. When it is not set, Veridra uses `~/.veridra/history`.
+Production configuration is documented in `docs/operations/production-deployment.md` and `docs/architecture/production-runtime-hardening.md`.
 
 ## Safety boundary
 
-Veridra is limited to bounded public evidence collection. It is not a penetration test, does not authenticate, does not submit forms, and must reject private or non-public targets before any website request. DNS posture checks are passive and do not connect to mail servers, transfer zones, enumerate subdomains, or guess DKIM selectors.
+Veridra collects bounded public evidence. It rejects private or non-public targets before website requests and does not perform active exploitation, credential attacks, subdomain brute force, mail-server probing or penetration testing.
 
-## Development status
+Passive security findings describe observable public posture only. Accessibility findings are heuristics, not conformance certification. AI-readiness and crawler-policy findings are not claims of universal AI visibility.
 
-Veridra 1.0.0 is a verified loopback-local product. Public deployment controls, multi-tenant operation, accounts, billing, external backlink providers, and sampled LLM visibility checks remain deferred until their operational and commercial requirements are justified.
+## Current product priority
+
+The first agency workflow shell is implemented. The next coherent milestone is explicit conversion from a completed quick audit into a tenant-qualified client project, followed by project-attached finding-to-task and report-delivery workflows.
+
+See issue #87 and `docs/product/agency-operator-workflow-audit.md`.

--- a/docs/product/agency-operator-workflow-audit.md
+++ b/docs/product/agency-operator-workflow-audit.md
@@ -1,0 +1,87 @@
+# Agency operator workflow audit
+
+## Purpose
+
+This document reviews Veridra as an end-to-end commercial workflow for a non-technical agency operator. It is based on the composed runtime and visible application entry points, not only on module existence.
+
+## Intended commercial loop
+
+1. onboard an agency tenant;
+2. configure workspace and team;
+3. run a quick audit or create a client project;
+4. choose a bounded crawl profile;
+5. review findings and affected URLs;
+6. configure a white-label report;
+7. deliver the report;
+8. capture and qualify leads;
+9. convert findings into remediation tasks;
+10. schedule monitoring;
+11. rescan and prove improvements.
+
+## Verified implementation inventory
+
+The runtime includes authenticated identity, tenant-qualified projects, history, reports, leads, lead forms, tasks, monitoring, monitoring jobs, report profiles, workspace plans, members and assignments. The merged agency workflow shell now provides explicit Quick audit and Client projects entry points.
+
+The principal remaining commercial risk is not missing modules. It is continuity between those modules: operators must understand prerequisites, next actions and the difference between temporary and persistent work.
+
+## Current workflow assessment
+
+### Onboarding and workspace
+
+Authentication, memberships, roles, invitations, password recovery and tenant boundaries exist. A complete first-run checklist and persistent visibility of tenant, role, plan and usage remain incomplete.
+
+### Quick audits and client projects
+
+The agency shell now clearly separates one-off audits from persistent projects. The next missing action is explicit conversion of a completed quick audit into a tenant-qualified project without accepting a client-controlled tenant identifier or persisting automatically.
+
+### Finding review and remediation
+
+Findings include deterministic evidence and affected URLs. Project findings should directly expose task creation, existing task state, first-seen/last-seen evidence and rescan verification status.
+
+### Reporting
+
+Reusable report profiles and HTML, PDF and evidence ZIP outputs exist. The project workflow still needs a guided report sequence: choose profile, select assessment, preview sections, generate, deliver and review delivery/engagement state.
+
+### Leads and commercial operations
+
+Lead forms, captured leads, report-open and CTA events, outbound delivery attempts, ownership, follow-up, retention and analytics exist. They should be presented as one sales workflow with a visible convert-to-project action.
+
+### Monitoring
+
+Schedules, durable tenant monitoring jobs, bounded worker leases, history and comparisons exist. Project pages still need a simple status view showing next run, latest job, latest assessment, changed findings, verification candidates and delivery outcome.
+
+## Commercial-severity ranking
+
+### Critical
+
+1. No explicit quick-audit-to-project conversion.
+2. Finding review does not yet make task creation and later verification the obvious path.
+3. Lead capture, report delivery, engagement and project conversion remain fragmented.
+
+### High
+
+4. Workspace plan, quota, tenant and role context are not persistently visible.
+5. Monitoring infrastructure is stronger than the project-level monitoring UX.
+6. Report configuration, generation and delivery need a project-attached workflow.
+
+### Medium
+
+7. Legacy local and tenant-qualified concepts need clearer retirement boundaries.
+8. Hosted email, billing and deployment operations remain environment-dependent rather than complete SaaS operations.
+
+## Next coherent milestone
+
+Implement quick-audit-to-project conversion:
+
+- offer conversion only after a completed audit;
+- preserve the normalized public target and selected report profile;
+- require explicit project name/client confirmation;
+- derive tenant identity exclusively from verified server-side identity;
+- enforce project capacity and permissions before persistence;
+- create no project on GET or audit execution alone;
+- redirect to the created project overview;
+- add route, permission, tenant-isolation and Chromium tests.
+
+## Explicit nonclaims
+
+This audit does not claim that hosted SaaS onboarding, payment collection, SMTP delivery or deployment orchestration are complete. Accessibility findings are not WCAG certification, passive security is not penetration testing, and AI readiness does not prove model visibility.

--- a/docs/product/strategy-and-roadmap.md
+++ b/docs/product/strategy-and-roadmap.md
@@ -1,0 +1,125 @@
+# Veridra product strategy and roadmap
+
+## Working position
+
+> Veridra helps agencies find website risks and growth opportunities, turn them into branded client reports and remediation work, and prove improvements through recurring monitoring.
+
+Veridra audits technical SEO, AI technical readiness, AI crawler policy, trust, accessibility and passive public security; captures audit leads; produces evidence-backed white-label reports; converts findings into work; and monitors the results.
+
+## Strategic category
+
+Veridra is a website-audit, evidence, lead-generation, remediation and monitoring platform for web agencies, technical consultants, MSPs, website-maintenance providers, hosting providers and digital-service businesses.
+
+## Core commercial loop
+
+1. capture a prospect or create a client project;
+2. run a bounded multi-page website assessment;
+3. produce an evidence-backed white-label report;
+4. convert findings into prioritized remediation work;
+5. assign, track and verify tasks;
+6. rescan the website;
+7. demonstrate improvement;
+8. convert the work into recurring monitoring or maintenance.
+
+## Evidence model
+
+Every actionable conclusion should follow:
+
+> Observation → evidence → affected URLs → business impact → recommended fix → task → rescan verification.
+
+Scores are acceptable only when every component is explicit, explainable and traceable to findings.
+
+## Differentiation
+
+Veridra should strengthen transparent first-party evidence in:
+
+- technical SEO fundamentals;
+- indexability and crawlability;
+- AI crawler policy and technical readiness;
+- entity and business clarity;
+- structured data;
+- passive public security and email-domain posture;
+- accessibility heuristics;
+- trust and legal signals;
+- contact and conversion routes;
+- per-page evidence and affected URL lists;
+- remediation tasks;
+- monitoring and before/after proof.
+
+## Internal-build exclusions
+
+Do not build internally:
+
+- proprietary keyword databases or search-volume estimation;
+- backlink crawlers or backlink indexes;
+- competitor traffic estimation;
+- global rank-tracking infrastructure;
+- paid-search intelligence;
+- generic AI article writing;
+- market-scale AI-prompt databases;
+- opaque universal authority, credibility or AI-visibility scores.
+
+External data may later enrich reports, but every metric must retain provider, timestamp, geography/database, device where applicable, freshness, limitations, usage cost and attribution.
+
+## AI terminology boundary
+
+Keep separate:
+
+- **AI technical readiness:** whether content is accessible, structured, identifiable and technically understandable;
+- **AI crawler policy:** whether named crawlers are allowed or blocked;
+- **sampled AI visibility:** whether selected providers mention or cite a business for a controlled prompt set.
+
+Any future sampled visibility feature must store provider, model, prompt, response and timestamp and present results as bounded observations.
+
+## Roadmap sequence
+
+### Completed foundations
+
+- authentication and tenant isolation;
+- tenant-qualified projects and operational data;
+- white-label report profiles and report artifacts;
+- durable monitoring jobs and bounded worker execution;
+- production runtime hardening and deployment guidance;
+- bounded commercial page-level crawl findings;
+- first agency workflow shell separating quick audits from persistent projects.
+
+### Current priority
+
+Complete the workflow continuity identified in issue #87:
+
+1. quick-audit-to-project conversion;
+2. finding-to-task creation and verification state;
+3. project-attached report generation and delivery;
+4. lead-to-project conversion;
+5. visible workspace, role, plan and usage context;
+6. project-level monitoring status and next actions.
+
+### Later product feature
+
+Technical competitor comparison based only on observable website evidence. It must not make traffic, keyword, authority, backlink or ranking claims unless supplied by an explicitly named external provider.
+
+### External integrations
+
+Prioritize customer-owned first-party data through provider-neutral adapters:
+
+1. Google Search Console;
+2. Google Analytics 4;
+3. PageSpeed Insights or CrUX;
+4. Bing Webmaster Tools;
+5. Google Business Profile when commercially justified.
+
+## Documentation status vocabulary
+
+Documentation should distinguish:
+
+- **implemented:** present in the repository;
+- **locally verified:** covered by repository tests and audits;
+- **production-ready foundation:** has fail-closed application boundaries but still requires deployment infrastructure and environment validation;
+- **experimental:** available for evaluation without a production-support claim;
+- **intentionally deferred:** excluded by strategy or awaiting a provider/business decision.
+
+## Commercial completion measure
+
+Do not use route count or module count as the primary measure of readiness. Measure whether an agency operator can complete:
+
+> prospect/client → audit → evidence → branded report → remediation work → rescan proof → recurring monitoring.


### PR DESCRIPTION
Ports and updates the useful documentation from stale PR #88 onto current main after merged agency workflow PR #91.

## Changes

- replaces the obsolete 1.0 loopback-only README;
- documents the actual implemented tenant, reporting, lead, task, monitoring and production-runtime foundations;
- records the merged agency workflow shell;
- adds a current agency operator workflow audit;
- ranks the remaining commercial workflow gaps;
- defines quick-audit-to-project conversion as the next coherent milestone;
- preserves explicit nonclaims around hosted deployment, billing, accessibility, passive security and AI visibility;
- records strategic exclusions for proprietary keyword, backlink, traffic and rank datasets.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before merge.

Supersedes PR #88. Related to issue #87.