### PR TITLE
Convert completed assessments into tenant projects

### DIFF
--- a/src/veridra/assessment_project_conversion_api.py
+++ b/src/veridra/assessment_project_conversion_api.py
@@ -60,7 +60,7 @@ def convert_assessment_to_project(
     require_project_capacity(len(projects.list(identity)))
     project = ClientProject.build(
         name=payload.project_name,
-        target_url=payload.assessment.target,
+        target_url=str(payload.assessment.target),
         client_label=payload.client_label,
         profile_id=payload.profile_id,
     )

--- a/src/veridra/assessment_project_conversion_api.py
+++ b/src/veridra/assessment_project_conversion_api.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from .core import Assessment
+from .identity_tenancy import RequestIdentity, TenantCapability
+from .project_store import ClientProject
+from .request_security import require_request_capability
+from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+from .workspace_web import require_project_capacity
+
+ProjectManager = Annotated[
+    RequestIdentity,
+    Depends(require_request_capability(TenantCapability.manage_projects)),
+]
+
+
+class AssessmentProjectConversion(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    assessment: Assessment
+    project_name: str = Field(min_length=1, max_length=120)
+    client_label: str | None = Field(default=None, max_length=120)
+    profile_id: str | None = Field(default=None, min_length=24, max_length=24)
+
+
+class AssessmentProjectCreated(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    project_id: str
+    assessment_id: str
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+router = APIRouter(tags=["assessment-project-conversion"])
+
+
+@router.post(
+    "/api/tenant/projects/from-assessment",
+    response_model=AssessmentProjectCreated,
+    status_code=status.HTTP_201_CREATED,
+)
+def convert_assessment_to_project(
+    payload: AssessmentProjectConversion,
+    request: Request,
+    identity: ProjectManager,
+) -> AssessmentProjectCreated:
+    root = _root(request)
+    projects = TenantProjectStore(root)
+    history = TenantHistoryStore(root)
+    require_project_capacity(len(projects.list(identity)))
+    project = ClientProject.build(
+        name=payload.project_name,
+        target_url=payload.assessment.target,
+        client_label=payload.client_label,
+        profile_id=payload.profile_id,
+    )
+    try:
+        project_id = projects.save(identity, project)
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Report profile not found.") from exc
+    try:
+        assessment_id = history.save(identity, project_id, payload.assessment)
+    except TenantHistoryStoreError as exc:
+        projects.delete(identity, projects.ref(identity, project_id))
+        raise HTTPException(
+            status_code=500,
+            detail="Project conversion could not be completed.",
+        ) from exc
+    return AssessmentProjectCreated(
+        project_id=project_id,
+        assessment_id=assessment_id,
+    )

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -8,6 +8,7 @@ from . import public_web
 from .agency_workflow_web import router as agency_workflow_router
 from .app import app as app
 from .application_identity import configure_identity_middleware
+from .assessment_project_conversion_api import router as assessment_project_conversion_router
 from .auth_api import router as auth_router
 from .commercial_web import router as commercial_router
 from .crawl_profile_web import router as crawl_profile_router
@@ -90,6 +91,7 @@ app.include_router(session_router)
 app.include_router(invitation_router)
 app.include_router(existing_user_invitation_router)
 app.include_router(tenant_project_router)
+app.include_router(assessment_project_conversion_router)
 app.include_router(tenant_history_router)
 app.include_router(tenant_report_router)
 app.include_router(tenant_lead_router)

--- a/tests/test_assessment_project_conversion_api.py
+++ b/tests/test_assessment_project_conversion_api.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.assessment_project_conversion_api import router
+from veridra.core import demo_assessment
+from veridra.identity_middleware import VerifiedIdentityMiddleware
+from veridra.identity_tenancy import (
+    AccountStatus,
+    AuthenticatedUser,
+    AuthSession,
+    Tenant,
+    TenantMembership,
+    TenantRole,
+)
+from veridra.session_cookie import SecureSessionCookieExtractor
+from veridra.session_identity_adapter import ServerSideSessionIdentityAdapter
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+
+NOW = datetime(2026, 7, 27, 1, 0, tzinfo=UTC)
+OWNER_CREDENTIAL = "owner-session-credential-value-00000001"
+VIEWER_CREDENTIAL = "viewer-session-credential-value-0000001"
+
+
+def _active_user(email: str) -> AuthenticatedUser:
+    return AuthenticatedUser.build(email=email, display_name=email, now=NOW).model_copy(
+        update={"status": AccountStatus.active, "email_verified_at": NOW}
+    )
+
+
+def _save_identity(
+    store: SQLiteIdentityRecordStore,
+    *,
+    tenant: Tenant,
+    user: AuthenticatedUser,
+    role: TenantRole,
+    credential: str,
+    session_id: str,
+) -> None:
+    store.save_tenant(tenant)
+    store.save_user(user)
+    store.save_membership(
+        TenantMembership(
+            tenant_id=tenant.id,
+            user_id=user.id,
+            role=role,
+            created_at=NOW,
+        )
+    )
+    store.save_session(
+        credential=credential,
+        tenant_id=tenant.id,
+        session=AuthSession(
+            id=session_id,
+            user_id=user.id,
+            issued_at=NOW,
+            expires_at=NOW + timedelta(hours=8),
+        ),
+    )
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Tenant, Tenant]:
+    store = SQLiteIdentityRecordStore(tmp_path / "identity.sqlite3")
+    store.initialize()
+    owner_tenant = Tenant.build(slug="owner-tenant", display_name="Owner", now=NOW)
+    viewer_tenant = Tenant.build(slug="viewer-tenant", display_name="Viewer", now=NOW)
+    _save_identity(
+        store,
+        tenant=owner_tenant,
+        user=_active_user("owner@example.com"),
+        role=TenantRole.owner,
+        credential=OWNER_CREDENTIAL,
+        session_id="conversion-owner-session",
+    )
+    _save_identity(
+        store,
+        tenant=viewer_tenant,
+        user=_active_user("viewer@example.com"),
+        role=TenantRole.viewer,
+        credential=VIEWER_CREDENTIAL,
+        session_id="conversion-viewer-session",
+    )
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path / "tenants"
+    adapter = ServerSideSessionIdentityAdapter(
+        extractor=SecureSessionCookieExtractor(),
+        store=store,
+        clock=lambda: NOW + timedelta(minutes=1),
+    )
+    app.add_middleware(VerifiedIdentityMiddleware, adapter=adapter)
+    app.include_router(router)
+    return TestClient(app), owner_tenant, viewer_tenant
+
+
+def _payload() -> dict[str, object]:
+    assessment = demo_assessment().model_copy(update={"target": "https://example.com/"})
+    return {
+        "assessment": assessment.model_dump(mode="json"),
+        "project_name": "Example client",
+        "client_label": "Example Ltd",
+    }
+
+
+def test_conversion_requires_verified_identity(tmp_path: Path) -> None:
+    client, _, _ = _client(tmp_path)
+
+    response = client.post("/api/tenant/projects/from-assessment", json=_payload())
+
+    assert response.status_code == 401
+
+
+def test_owner_converts_assessment_into_project_and_history(tmp_path: Path) -> None:
+    client, owner_tenant, _ = _client(tmp_path)
+    client.cookies.set("veridra_session", OWNER_CREDENTIAL)
+
+    response = client.post("/api/tenant/projects/from-assessment", json=_payload())
+
+    assert response.status_code == 201
+    body = response.json()
+    project_path = (
+        tmp_path
+        / "tenants"
+        / owner_tenant.id
+        / "projects"
+        / f"{body['project_id']}.json"
+    )
+    assessment_path = (
+        tmp_path
+        / "tenants"
+        / owner_tenant.id
+        / "projects"
+        / body["project_id"]
+        / "history"
+        / f"{body['assessment_id']}.json"
+    )
+    assert project_path.exists()
+    assert assessment_path.exists()
+    assert "https://example.com/" in project_path.read_text(encoding="utf-8")
+
+
+def test_viewer_cannot_convert_and_has_no_tenant_files(tmp_path: Path) -> None:
+    client, _, viewer_tenant = _client(tmp_path)
+    client.cookies.set("veridra_session", VIEWER_CREDENTIAL)
+
+    response = client.post("/api/tenant/projects/from-assessment", json=_payload())
+
+    assert response.status_code == 403
+    assert not (tmp_path / "tenants" / viewer_tenant.id).exists()
+
+
+def test_target_is_derived_from_assessment_and_extra_target_is_rejected(tmp_path: Path) -> None:
+    client, _, _ = _client(tmp_path)
+    client.cookies.set("veridra_session", OWNER_CREDENTIAL)
+    payload = _payload()
+    payload["target_url"] = "https://attacker.example"
+
+    response = client.post("/api/tenant/projects/from-assessment", json=payload)
+
+    assert response.status_code == 422
+
+
+def test_missing_tenant_profile_is_generically_concealed(tmp_path: Path) -> None:
+    client, _, _ = _client(tmp_path)
+    client.cookies.set("veridra_session", OWNER_CREDENTIAL)
+    payload = _payload()
+    payload["profile_id"] = "0" * 24
+
+    response = client.post("/api/tenant/projects/from-assessment", json=payload)
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Report profile not found."}

--- a/tests/test_assessment_project_conversion_api.py
+++ b/tests/test_assessment_project_conversion_api.py
@@ -134,7 +134,7 @@ def test_owner_converts_assessment_into_project_and_history(tmp_path: Path) -> N
         / owner_tenant.id
         / "projects"
         / body["project_id"]
-        / "history"
+        / "assessments"
         / f"{body['assessment_id']}.json"
     )
     assert project_path.exists()


### PR DESCRIPTION
Implements the first coherent slice of issue #93 from current main `e90df54bd1efa79e4e899d7e7ea857a60093bfe1`.

## What changed

- adds an authenticated tenant API for explicit assessment-to-project conversion;
- derives the project target only from the validated completed assessment payload;
- requires explicit project name and optional client label;
- derives tenant and user identity only from verified server-side request identity;
- enforces `manage_projects` capability and active project capacity;
- validates report profiles inside the current tenant boundary;
- creates the tenant-qualified project and saves the completed assessment into its tenant history;
- rolls back the project when assessment persistence fails;
- rejects extra client-controlled target fields;
- registers the route in the composed runtime;
- adds authentication, authorization, tenant persistence, validation and profile-concealment tests.

## Boundaries

- no project creation on GET or audit navigation;
- no client-controlled tenant identifier;
- no arbitrary request body or HTML copied into project storage;
- no lead-to-project conversion;
- existing same-origin, identity, entitlement and crawler boundaries remain unchanged.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Closes #93 when fully validated and merged. Related to #87.