### PR TITLE
Add authenticated audit conversion confirmation UI

### DIFF
--- a/src/veridra/agency_conversion_web.py
+++ b/src/veridra/agency_conversion_web.py
@@ -1,0 +1,129 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .assessment_project_conversion_api import AssessmentProjectConversion, convert_assessment
+from .collector import CollectionError
+from .core import UnsafeTargetError, demo_assessment
+from .identity_tenancy import IdentityBoundaryError, RequestIdentity, TenantCapability, require_tenant_capability
+from .request_security import require_request_identity
+from .service import assess_url
+from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
+from .tenant_profile_store import TenantProfileStore
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+
+router = APIRouter(prefix="/agency", tags=["agency-conversion"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.actions{display:flex;gap:8px;flex-wrap:wrap}@media(max-width:700px){.row{grid-template-columns:1fr}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request) -> RequestIdentity | None:
+    try:
+        return require_request_identity(request)
+    except HTTPException:
+        return None
+
+
+def _can_manage_projects(identity: RequestIdentity) -> bool:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+    except IdentityBoundaryError:
+        return False
+    return True
+
+
+def _profile_options(request: Request, identity: RequestIdentity, selected: str | None) -> str:
+    entries = TenantProfileStore(_root(request)).list(identity)
+    options = ["<option value=''>Default Veridra report</option>"]
+    options.extend(
+        "<option value='{identifier}'{selected}>{label}</option>".format(
+            identifier=html.escape(entry.id, quote=True),
+            selected=" selected" if entry.id == selected else "",
+            label=html.escape(f"{entry.organisation_name} — {entry.client_name}" if entry.client_name else entry.organisation_name),
+        )
+        for entry in entries
+    )
+    return "".join(options)
+
+
+def _single(body: bytes, name: str) -> str:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
+
+
+@router.get("/convert", response_class=HTMLResponse)
+def conversion_confirmation(request: Request, url: str, profile: str | None = None, demo: bool = False) -> str:
+    identity = _identity(request)
+    if identity is None:
+        return _page(
+            "Sign in required",
+            "<section><h1>Sign in to create a client project</h1><p>This completed quick audit remains temporary. Sign in before creating tenant-qualified client work.</p><p><a class='button' href='/login'>Sign in</a> <a class='button secondary' href='/agency'>Back to agency workflow</a></p></section>",
+        )
+    if not _can_manage_projects(identity):
+        return _page(
+            "Project permission required",
+            "<section><h1>Project creation is not permitted</h1><p>Your current workspace role can review this audit but cannot create client projects.</p><p><a class='button secondary' href='/agency'>Back to agency workflow</a></p></section>",
+        )
+    target = "Demo assessment" if demo else url
+    options = _profile_options(request, identity, profile)
+    hidden = "<input type='hidden' name='demo' value='true'>" if demo else f"<input type='hidden' name='url' value='{html.escape(url, quote=True)}'>"
+    body = f"""<section><p><a href='/agency'>Agency workflow</a> · <a href='/'>Assessment</a></p><h1>Create client project</h1><p class='notice'><strong>Audited target:</strong> {html.escape(target)}<br>This confirmation revalidates the same public target before tenant persistence. No project is created by opening this page.</p><form method='post' action='/agency/convert'>{hidden}<div class='row'><div><label for='project_name'>Project name</label><input id='project_name' name='project_name' maxlength='120' required></div><div><label for='client_label'>Client label</label><input id='client_label' name='client_label' maxlength='120'></div></div><label for='profile_id'>Tenant report profile</label><select id='profile_id' name='profile_id'>{options}</select><p class='muted'>Only report profiles belonging to the authenticated workspace are available.</p><p><button type='submit'>Create client project</button> <a class='button secondary' href='/'>Cancel</a></p></form></section>"""
+    return _page("Create client project", body)
+
+
+@router.post("/convert")
+async def submit_conversion(request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    body = await request.body()
+    url = _single(body, "url")
+    demo = _single(body, "demo") == "true"
+    try:
+        assessment = demo_assessment() if demo else assess_url(url)
+        payload = AssessmentProjectConversion(
+            assessment=assessment,
+            project_name=_single(body, "project_name"),
+            client_label=_single(body, "client_label") or None,
+            profile_id=_single(body, "profile_id") or None,
+        )
+    except (UnsafeTargetError, CollectionError, ValidationError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Project conversion input is invalid.") from exc
+    created = convert_assessment(payload, request, identity)
+    return RedirectResponse(f"/agency/projects/{created.project_id}", status_code=303)
+
+
+@router.get("/projects/{project_id}", response_class=HTMLResponse)
+def tenant_project_next_actions(project_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    projects = TenantProjectStore(_root(request))
+    history = TenantHistoryStore(_root(request))
+    try:
+        project = projects.load(identity, projects.ref(identity, project_id))
+        assessments = history.list(identity, project_id)
+    except (TenantProjectStoreError, TenantHistoryStoreError) as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
+    query = urlencode({"url": project.target_url, **({"profile": project.profile_id} if project.profile_id else {})})
+    latest = assessments[0] if assessments else None
+    latest_text = html.escape(latest.generated_at) if latest else "Not available"
+    body = f"""<section><p><a href='/agency'>Agency workflow</a></p><h1>{html.escape(project.name)}</h1><p><strong>Client:</strong> {html.escape(project.client_label or 'Not set')}<br><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Saved assessment:</strong> {latest_text}</p><div class='actions'><a class='button' href='/?{html.escape(query, quote=True)}'>Review assessment</a><a class='button secondary' href='/report?{html.escape(query, quote=True)}'>Configure report</a><a class='button secondary' href='/tasks'>Create remediation tasks</a><a class='button secondary' href='/monitoring'>Enable monitoring</a></div></section><section><h2>Recommended next step</h2><p>Review the saved evidence, choose the client-facing report output, then convert actionable findings into assigned remediation work before enabling recurring monitoring.</p></section>"""
+    return _page(project.name, body)

--- a/src/veridra/agency_conversion_web.py
+++ b/src/veridra/agency_conversion_web.py
@@ -13,7 +13,12 @@ from .app import dashboard
 from .assessment_project_conversion_api import AssessmentProjectConversion, convert_assessment
 from .collector import CollectionError
 from .core import UnsafeTargetError, demo_assessment
-from .identity_tenancy import IdentityBoundaryError, RequestIdentity, TenantCapability, require_tenant_capability
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
 from .request_security import require_request_identity
 from .service import assess_url
 from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError

--- a/src/veridra/agency_conversion_web.py
+++ b/src/veridra/agency_conversion_web.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
+from .app import dashboard
 from .assessment_project_conversion_api import AssessmentProjectConversion, convert_assessment
 from .collector import CollectionError
 from .core import UnsafeTargetError, demo_assessment
@@ -66,6 +67,23 @@ def _profile_options(request: Request, identity: RequestIdentity, selected: str 
 
 def _single(body: bytes, name: str) -> str:
     return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
+
+
+@router.get("/audit", response_class=HTMLResponse)
+def completed_agency_audit(url: str) -> str:
+    try:
+        assessment = assess_url(url)
+    except (UnsafeTargetError, CollectionError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    normalized = str(assessment.target)
+    conversion_query = html.escape(urlencode({"url": normalized}), quote=True)
+    action = f"<section><h3>Continue with this audit</h3><p class='muted'>This assessment is still temporary. Create a tenant-qualified client project only after explicit confirmation.</p><a class='button' href='/agency/convert?{conversion_query}'>Create client project</a> <a class='button secondary' href='/agency'>Back to agency workflow</a></section>"
+    rendered = dashboard(
+        assessment,
+        submitted_url=normalized,
+        profile_entries=[],
+    )
+    return rendered.replace("<div class='cards'>", action + "<div class='cards'>", 1)
 
 
 @router.get("/convert", response_class=HTMLResponse)

--- a/src/veridra/agency_workflow_web.py
+++ b/src/veridra/agency_workflow_web.py
@@ -75,4 +75,4 @@ def quick_audit_handoff(
     cleaned = target.strip()
     if not cleaned:
         return RedirectResponse("/agency", status_code=303)
-    return RedirectResponse(f"/?{urlencode({'url': cleaned})}", status_code=303)
+    return RedirectResponse(f"/agency/audit?{urlencode({'url': cleaned})}", status_code=303)

--- a/src/veridra/assessment_project_conversion_api.py
+++ b/src/veridra/assessment_project_conversion_api.py
@@ -41,18 +41,10 @@ def _root(request: Request) -> Path | None:
     return value if isinstance(value, Path) else None
 
 
-router = APIRouter(tags=["assessment-project-conversion"])
-
-
-@router.post(
-    "/api/tenant/projects/from-assessment",
-    response_model=AssessmentProjectCreated,
-    status_code=status.HTTP_201_CREATED,
-)
-def convert_assessment_to_project(
+def convert_assessment(
     payload: AssessmentProjectConversion,
     request: Request,
-    identity: ProjectManager,
+    identity: RequestIdentity,
 ) -> AssessmentProjectCreated:
     root = _root(request)
     projects = TenantProjectStore(root)
@@ -80,3 +72,19 @@ def convert_assessment_to_project(
         project_id=project_id,
         assessment_id=assessment_id,
     )
+
+
+router = APIRouter(tags=["assessment-project-conversion"])
+
+
+@router.post(
+    "/api/tenant/projects/from-assessment",
+    response_model=AssessmentProjectCreated,
+    status_code=status.HTTP_201_CREATED,
+)
+def convert_assessment_to_project(
+    payload: AssessmentProjectConversion,
+    request: Request,
+    identity: ProjectManager,
+) -> AssessmentProjectCreated:
+    return convert_assessment(payload, request, identity)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -5,6 +5,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from . import app as app_module
 from . import public_web
+from .agency_conversion_web import router as agency_conversion_router
 from .agency_workflow_web import router as agency_workflow_router
 from .app import app as app
 from .application_identity import configure_identity_middleware
@@ -112,6 +113,7 @@ app.include_router(workspace_router)
 app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)
+app.include_router(agency_conversion_router)
 
 
 def main() -> None:

--- a/tests/test_agency_conversion_web.py
+++ b/tests/test_agency_conversion_web.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -140,7 +141,7 @@ def test_owner_get_does_not_persist_and_escapes_target(tmp_path: Path) -> None:
 
 def test_owner_confirms_conversion_and_reaches_tenant_next_actions(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client, owner_tenant, _ = _client(tmp_path)
     client.cookies.set("veridra_session", OWNER_CREDENTIAL)
@@ -176,7 +177,7 @@ def test_owner_confirms_conversion_and_reaches_tenant_next_actions(
 
 def test_completed_agency_audit_adds_conversion_only_after_success(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client, _, _ = _client(tmp_path)
     assessment = demo_assessment().model_copy(update={"target": "https://example.com/"})

--- a/tests/test_agency_conversion_web.py
+++ b/tests/test_agency_conversion_web.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E501
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta

--- a/tests/test_agency_conversion_web.py
+++ b/tests/test_agency_conversion_web.py
@@ -77,7 +77,7 @@ def _client(tmp_path: Path) -> tuple[TestClient, Tenant, Tenant]:
         user=_active_user("owner@example.com"),
         role=TenantRole.owner,
         credential=OWNER_CREDENTIAL,
-        session_id="agency-conversion-owner",
+        session_id="agency-conversion-owner-01",
     )
     _save_identity(
         store,
@@ -85,7 +85,7 @@ def _client(tmp_path: Path) -> tuple[TestClient, Tenant, Tenant]:
         user=_active_user("viewer@example.com"),
         role=TenantRole.viewer,
         credential=VIEWER_CREDENTIAL,
-        session_id="agency-conversion-viewer",
+        session_id="agency-conversion-viewer-1",
     )
     app = FastAPI()
     app.state.veridra_tenant_data_root = tmp_path / "tenants"

--- a/tests/test_agency_conversion_web.py
+++ b/tests/test_agency_conversion_web.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra import agency_conversion_web
+from veridra.agency_conversion_web import router
+from veridra.core import demo_assessment
+from veridra.identity_middleware import VerifiedIdentityMiddleware
+from veridra.identity_tenancy import (
+    AccountStatus,
+    AuthenticatedUser,
+    AuthSession,
+    Tenant,
+    TenantMembership,
+    TenantRole,
+)
+from veridra.session_cookie import SecureSessionCookieExtractor
+from veridra.session_identity_adapter import ServerSideSessionIdentityAdapter
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+
+NOW = datetime(2026, 7, 27, 3, 0, tzinfo=UTC)
+OWNER_CREDENTIAL = "owner-session-credential-value-00000001"
+VIEWER_CREDENTIAL = "viewer-session-credential-value-0000001"
+
+
+def _active_user(email: str) -> AuthenticatedUser:
+    return AuthenticatedUser.build(email=email, display_name=email, now=NOW).model_copy(
+        update={"status": AccountStatus.active, "email_verified_at": NOW}
+    )
+
+
+def _save_identity(
+    store: SQLiteIdentityRecordStore,
+    *,
+    tenant: Tenant,
+    user: AuthenticatedUser,
+    role: TenantRole,
+    credential: str,
+    session_id: str,
+) -> None:
+    store.save_tenant(tenant)
+    store.save_user(user)
+    store.save_membership(
+        TenantMembership(
+            tenant_id=tenant.id,
+            user_id=user.id,
+            role=role,
+            created_at=NOW,
+        )
+    )
+    store.save_session(
+        credential=credential,
+        tenant_id=tenant.id,
+        session=AuthSession(
+            id=session_id,
+            user_id=user.id,
+            issued_at=NOW,
+            expires_at=NOW + timedelta(hours=8),
+        ),
+    )
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Tenant, Tenant]:
+    store = SQLiteIdentityRecordStore(tmp_path / "identity.sqlite3")
+    store.initialize()
+    owner_tenant = Tenant.build(slug="owner-tenant", display_name="Owner", now=NOW)
+    viewer_tenant = Tenant.build(slug="viewer-tenant", display_name="Viewer", now=NOW)
+    _save_identity(
+        store,
+        tenant=owner_tenant,
+        user=_active_user("owner@example.com"),
+        role=TenantRole.owner,
+        credential=OWNER_CREDENTIAL,
+        session_id="agency-conversion-owner",
+    )
+    _save_identity(
+        store,
+        tenant=viewer_tenant,
+        user=_active_user("viewer@example.com"),
+        role=TenantRole.viewer,
+        credential=VIEWER_CREDENTIAL,
+        session_id="agency-conversion-viewer",
+    )
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path / "tenants"
+    adapter = ServerSideSessionIdentityAdapter(
+        extractor=SecureSessionCookieExtractor(),
+        store=store,
+        clock=lambda: NOW + timedelta(minutes=1),
+    )
+    app.add_middleware(VerifiedIdentityMiddleware, adapter=adapter)
+    app.include_router(router)
+    return TestClient(app), owner_tenant, viewer_tenant
+
+
+def test_anonymous_confirmation_shows_sign_in_without_persistence(tmp_path: Path) -> None:
+    client, _, _ = _client(tmp_path)
+
+    response = client.get("/agency/convert", params={"url": "https://example.com"})
+
+    assert response.status_code == 200
+    assert "Sign in to create a client project" in response.text
+    assert not (tmp_path / "tenants").exists()
+
+
+def test_viewer_sees_permission_message_and_cannot_submit(tmp_path: Path) -> None:
+    client, _, viewer_tenant = _client(tmp_path)
+    client.cookies.set("veridra_session", VIEWER_CREDENTIAL)
+
+    page = client.get("/agency/convert", params={"url": "https://example.com"})
+    submitted = client.post(
+        "/agency/convert",
+        data={"url": "https://example.com", "project_name": "Forbidden"},
+    )
+
+    assert "Project creation is not permitted" in page.text
+    assert submitted.status_code == 403
+    assert not (tmp_path / "tenants" / viewer_tenant.id).exists()
+
+
+def test_owner_get_does_not_persist_and_escapes_target(tmp_path: Path) -> None:
+    client, owner_tenant, _ = _client(tmp_path)
+    client.cookies.set("veridra_session", OWNER_CREDENTIAL)
+
+    response = client.get(
+        "/agency/convert",
+        params={"url": "https://example.com/?q=<script>alert(1)</script>"},
+    )
+
+    assert response.status_code == 200
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in response.text
+    assert "<script>alert(1)</script>" not in response.text
+    assert not (tmp_path / "tenants" / owner_tenant.id / "projects").exists()
+
+
+def test_owner_confirms_conversion_and_reaches_tenant_next_actions(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    client, owner_tenant, _ = _client(tmp_path)
+    client.cookies.set("veridra_session", OWNER_CREDENTIAL)
+    assessment = demo_assessment().model_copy(update={"target": "https://example.com/"})
+    monkeypatch.setattr(agency_conversion_web, "assess_url", lambda _url: assessment)
+
+    response = client.post(
+        "/agency/convert",
+        data={
+            "url": "https://example.com",
+            "project_name": "<b>Example project</b>",
+            "client_label": "Example & Co",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    location = response.headers["location"]
+    assert location.startswith("/agency/projects/")
+    project_id = location.rsplit("/", 1)[-1]
+    project_path = (
+        tmp_path / "tenants" / owner_tenant.id / "projects" / f"{project_id}.json"
+    )
+    assert project_path.exists()
+
+    detail = client.get(location)
+    assert detail.status_code == 200
+    assert "&lt;b&gt;Example project&lt;/b&gt;" in detail.text
+    assert "<b>Example project</b>" not in detail.text
+    assert "Create remediation tasks" in detail.text
+    assert "Enable monitoring" in detail.text
+
+
+def test_completed_agency_audit_adds_conversion_only_after_success(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    client, _, _ = _client(tmp_path)
+    assessment = demo_assessment().model_copy(update={"target": "https://example.com/"})
+    monkeypatch.setattr(agency_conversion_web, "assess_url", lambda _url: assessment)
+
+    response = client.get("/agency/audit", params={"url": "https://example.com"})
+
+    assert response.status_code == 200
+    assert "Create client project" in response.text
+    assert "/agency/convert?url=https%3A%2F%2Fexample.com%2F" in response.text

--- a/tests/test_agency_workflow_web.py
+++ b/tests/test_agency_workflow_web.py
@@ -25,7 +25,7 @@ def test_agency_home_explains_quick_and_persistent_workflows() -> None:
     assert "href='/monitoring'" in response.text
 
 
-def test_quick_audit_handoff_redirects_to_existing_console_without_persistence() -> None:
+def test_quick_audit_handoff_redirects_to_completed_agency_result() -> None:
     response = _client().get(
         "/agency/quick-audit",
         params={"target": "  https://example.com/path?a=1&b=2  "},
@@ -33,7 +33,7 @@ def test_quick_audit_handoff_redirects_to_existing_console_without_persistence()
     )
 
     assert response.status_code == 303
-    assert response.headers["location"] == "/?url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1%26b%3D2"
+    assert response.headers["location"] == "/agency/audit?url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1%26b%3D2"
 
 
 def test_quick_audit_handoff_rejects_missing_target() -> None:
@@ -52,4 +52,4 @@ def test_quick_audit_handoff_does_not_reflect_target_in_response_body() -> None:
 
     assert response.status_code == 303
     assert marker not in response.text
-    assert response.headers["location"].startswith("/?url=")
+    assert response.headers["location"].startswith("/agency/audit?url=")

--- a/tests/test_agency_workflow_web.py
+++ b/tests/test_agency_workflow_web.py
@@ -33,7 +33,9 @@ def test_quick_audit_handoff_redirects_to_completed_agency_result() -> None:
     )
 
     assert response.status_code == 303
-    assert response.headers["location"] == "/agency/audit?url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1%26b%3D2"
+    assert response.headers["location"] == (
+        "/agency/audit?url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1%26b%3D2"
+    )
 
 
 def test_quick_audit_handoff_rejects_missing_target() -> None:


### PR DESCRIPTION
Implements issue #95 from current main `5b8840b3fd683bef452f6da3d2a3f4ca86ed6d2a`.

## What changed

- routes agency quick audits through a completed-result surface;
- shows **Create client project** only after a successful agency audit;
- keeps the generic anonymous assessment console unchanged;
- shows a clear sign-in requirement to unauthenticated operators;
- shows a role-specific denial message when project creation is not permitted;
- renders a tenant-aware confirmation form with explicit project name, optional client label and tenant report profiles;
- never accepts a tenant identifier in query or form data;
- revalidates the same public target at confirmed conversion rather than automatically persisting quick-audit data or embedding the complete assessment in HTML;
- reuses the merged assessment-to-project conversion service rather than duplicating persistence logic;
- redirects to a tenant-qualified project next-actions page;
- exposes next actions for assessment review, report configuration, remediation tasks and monitoring;
- routes tenant project loading through verified request identity;
- adds anonymous, permission, no-GET-persistence, escaping, successful conversion and completed-result tests.

## Boundaries

- GET requests do not persist projects or assessments;
- anonymous quick audits remain usable and temporary;
- same-origin middleware remains responsible for authenticated mutation protection in the composed runtime;
- no client-controlled tenant identity;
- no redirect into legacy project persistence;
- no claim that lead conversion or the complete agency workflow is finished.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Closes #95 when fully validated and merged. Related to #87.