### PR TITLE
Create remediation tasks from saved findings

### DIFF
--- a/src/veridra/finding_task_api.py
+++ b/src/veridra/finding_task_api.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from .core import Finding
+from .identity_tenancy import RequestIdentity, TenantCapability
+from .request_security import require_request_capability
+from .task_store import RemediationTask
+from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
+from .tenant_task_store import TenantTaskStore
+
+TaskManager = Annotated[
+    RequestIdentity,
+    Depends(require_request_capability(TenantCapability.manage_tasks)),
+]
+
+
+class FindingTaskConversion(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    project_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    assessment_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    finding_id: str = Field(min_length=1, max_length=160)
+
+
+class FindingTaskCreated(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    task_id: str
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _finding_notes(finding: Finding) -> str:
+    evidence = json.dumps(
+        finding.evidence,
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    if len(evidence) > 1800:
+        evidence = f"{evidence[:1797]}..."
+    recommendation = finding.recommendation or "Review the supporting evidence."
+    notes = (
+        f"Area: {finding.area}\n"
+        f"Severity: {finding.severity}\n"
+        f"Observation: {finding.summary}\n"
+        f"Recommended fix: {recommendation}\n"
+        f"Evidence: {evidence}"
+    )
+    return notes[:5000]
+
+
+def create_task_from_finding(
+    payload: FindingTaskConversion,
+    request: Request,
+    identity: RequestIdentity,
+) -> FindingTaskCreated:
+    history = TenantHistoryStore(_root(request))
+    try:
+        assessment = history.load(
+            identity,
+            history.ref(identity, payload.project_id, payload.assessment_id),
+        )
+    except TenantHistoryStoreError as exc:
+        raise HTTPException(status_code=404, detail="Finding source not found.") from exc
+    finding = next(
+        (item for item in assessment.findings if item.id == payload.finding_id),
+        None,
+    )
+    if finding is None:
+        raise HTTPException(status_code=404, detail="Finding source not found.")
+    task = RemediationTask(
+        project_id=payload.project_id,
+        finding_id=finding.id,
+        title=finding.title,
+        notes=_finding_notes(finding),
+        source_assessment_id=payload.assessment_id,
+    )
+    task_id = TenantTaskStore(_root(request)).save(identity, task)
+    return FindingTaskCreated(task_id=task_id)
+
+
+router = APIRouter(tags=["finding-remediation-tasks"])
+
+
+@router.post(
+    "/api/tenant/tasks/from-finding",
+    response_model=FindingTaskCreated,
+    status_code=status.HTTP_201_CREATED,
+)
+def convert_finding_to_task(
+    payload: FindingTaskConversion,
+    request: Request,
+    identity: TaskManager,
+) -> FindingTaskCreated:
+    return create_task_from_finding(payload, request, identity)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -14,6 +14,7 @@ from .auth_api import router as auth_router
 from .commercial_web import router as commercial_router
 from .crawl_profile_web import router as crawl_profile_router
 from .existing_user_invitation_api import router as existing_user_invitation_router
+from .finding_task_api import router as finding_task_router
 from .invitation_api import router as invitation_router
 from .lead_form_tenant_binding_api import router as lead_form_tenant_binding_router
 from .lead_web import router as lead_router
@@ -98,6 +99,7 @@ app.include_router(tenant_report_router)
 app.include_router(tenant_lead_router)
 app.include_router(tenant_lead_form_router)
 app.include_router(tenant_task_router)
+app.include_router(finding_task_router)
 app.include_router(tenant_monitoring_router)
 app.include_router(monitoring_job_router)
 app.include_router(tenant_profile_router)

--- a/tests/test_finding_task_api.py
+++ b/tests/test_finding_task_api.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient
 
 from veridra.core import demo_assessment
@@ -43,7 +44,10 @@ def _client(tmp_path: Path) -> tuple[TestClient, str, str, str]:
     app.state.veridra_tenant_data_root = root
 
     @app.middleware("http")
-    async def identity(request: Request, call_next):
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
         role = request.headers.get("x-test-role")
         if role == "owner":
             bind_verified_request_identity(request, OWNER)

--- a/tests/test_finding_task_api.py
+++ b/tests/test_finding_task_api.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from veridra.core import demo_assessment
+from veridra.finding_task_api import router
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_history_store import TenantHistoryStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 8, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="owner-finding-task-session-01",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="viewer-finding-task-session-1",
+    authenticated_at=NOW,
+)
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, str, str, str]:
+    root = tmp_path / "tenants"
+    project = ClientProject.build(name="Client", target_url="https://example.com")
+    project_id = TenantProjectStore(root).save(OWNER, project)
+    assessment = demo_assessment().model_copy(update={"target": "https://example.com/"})
+    assessment_id = TenantHistoryStore(root).save(OWNER, project_id, assessment)
+    finding_id = assessment.findings[0].id
+
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(request: Request, call_next):
+        role = request.headers.get("x-test-role")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app), project_id, assessment_id, finding_id
+
+
+def _payload(project_id: str, assessment_id: str, finding_id: str) -> dict[str, str]:
+    return {
+        "project_id": project_id,
+        "assessment_id": assessment_id,
+        "finding_id": finding_id,
+    }
+
+
+def test_finding_task_conversion_requires_identity(tmp_path: Path) -> None:
+    client, project_id, assessment_id, finding_id = _client(tmp_path)
+
+    response = client.post(
+        "/api/tenant/tasks/from-finding",
+        json=_payload(project_id, assessment_id, finding_id),
+    )
+
+    assert response.status_code == 401
+
+
+def test_viewer_cannot_create_finding_task(tmp_path: Path) -> None:
+    client, project_id, assessment_id, finding_id = _client(tmp_path)
+
+    response = client.post(
+        "/api/tenant/tasks/from-finding",
+        headers={"x-test-role": "viewer"},
+        json=_payload(project_id, assessment_id, finding_id),
+    )
+
+    assert response.status_code == 403
+
+
+def test_owner_creates_canonical_idempotent_task_from_saved_finding(tmp_path: Path) -> None:
+    client, project_id, assessment_id, finding_id = _client(tmp_path)
+    payload = _payload(project_id, assessment_id, finding_id)
+
+    first = client.post(
+        "/api/tenant/tasks/from-finding",
+        headers={"x-test-role": "owner"},
+        json=payload,
+    )
+    second = client.post(
+        "/api/tenant/tasks/from-finding",
+        headers={"x-test-role": "owner"},
+        json=payload,
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert first.json() == second.json()
+    task_id = first.json()["task_id"]
+    task_path = tmp_path / "tenants" / OWNER.tenant_id / "tasks" / f"{task_id}.json"
+    text = task_path.read_text(encoding="utf-8")
+    assert finding_id in text
+    assert assessment_id in text
+    assert "Observation:" in text
+    assert "Recommended fix:" in text
+
+
+def test_missing_finding_is_generically_concealed(tmp_path: Path) -> None:
+    client, project_id, assessment_id, _ = _client(tmp_path)
+
+    response = client.post(
+        "/api/tenant/tasks/from-finding",
+        headers={"x-test-role": "owner"},
+        json=_payload(project_id, assessment_id, "missing-finding"),
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Finding source not found."}
+
+
+def test_cross_tenant_project_reference_is_concealed(tmp_path: Path) -> None:
+    client, project_id, assessment_id, finding_id = _client(tmp_path)
+
+    response = client.post(
+        "/api/tenant/tasks/from-finding",
+        headers={"x-test-role": "viewer"},
+        json=_payload(project_id, assessment_id, finding_id),
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
Implements the first bounded slice of issue #97 from current main `0c25a55cb06523b9f168bbf595c80d38ce8018f5`.

## What changed

- adds an authenticated tenant endpoint for converting one saved assessment finding into a remediation task;
- loads the assessment through the verified tenant boundary;
- selects source content only by the stable finding ID from the saved assessment;
- requires the existing `manage_tasks` capability;
- preserves project ID, finding ID and source assessment ID in the existing task model;
- derives the task title from the saved finding;
- builds bounded notes from area, severity, observation, recommendation and deterministic JSON evidence;
- truncates evidence and final notes to existing storage limits;
- uses canonical task persistence, so repeated identical conversion returns the same task identifier;
- conceals missing assessment and finding references through a generic source-not-found response;
- registers the route in the composed runtime;
- adds identity, permission, idempotency, source-linkage and missing-finding tests.

## Boundaries

- no automatic task creation;
- no client-supplied title, recommendation, evidence or tenant identity;
- no change to ownership, due dates or verification states;
- task creation is not proof that a finding has been fixed;
- operator-facing confirmation UI remains a follow-up slice if this backend boundary validates.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Related to #87. Closes the backend portion of #97 when validated and merged.