### PR TITLE
Add finding-to-task confirmation workflow

### DIFF
--- a/src/veridra/agency_conversion_web.py
+++ b/src/veridra/agency_conversion_web.py
@@ -28,7 +28,7 @@ from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
 router = APIRouter(prefix="/agency", tags=["agency-conversion"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.actions{display:flex;gap:8px;flex-wrap:wrap}@media(max-width:700px){.row{grid-template-columns:1fr}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.actions{display:flex;gap:8px;flex-wrap:wrap}@media(max-width:700px){.row{grid-template-columns:1fr}}
 """
 
 
@@ -136,7 +136,11 @@ async def submit_conversion(request: Request) -> RedirectResponse:
 
 
 @router.get("/projects/{project_id}", response_class=HTMLResponse)
-def tenant_project_next_actions(project_id: str, request: Request) -> str:
+def tenant_project_next_actions(
+    project_id: str,
+    request: Request,
+    task_created: str | None = None,
+) -> str:
     identity = require_request_identity(request)
     projects = TenantProjectStore(_root(request))
     history = TenantHistoryStore(_root(request))
@@ -148,5 +152,15 @@ def tenant_project_next_actions(project_id: str, request: Request) -> str:
     query = urlencode({"url": project.target_url, **({"profile": project.profile_id} if project.profile_id else {})})
     latest = assessments[0] if assessments else None
     latest_text = html.escape(latest.generated_at) if latest else "Not available"
-    body = f"""<section><p><a href='/agency'>Agency workflow</a></p><h1>{html.escape(project.name)}</h1><p><strong>Client:</strong> {html.escape(project.client_label or 'Not set')}<br><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Saved assessment:</strong> {latest_text}</p><div class='actions'><a class='button' href='/?{html.escape(query, quote=True)}'>Review assessment</a><a class='button secondary' href='/report?{html.escape(query, quote=True)}'>Configure report</a><a class='button secondary' href='/tasks'>Create remediation tasks</a><a class='button secondary' href='/monitoring'>Enable monitoring</a></div></section><section><h2>Recommended next step</h2><p>Review the saved evidence, choose the client-facing report output, then convert actionable findings into assigned remediation work before enabling recurring monitoring.</p></section>"""
+    remediation = (
+        f"<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/assessments/{html.escape(latest.id, quote=True)}/findings'>Create remediation tasks</a>"
+        if latest is not None
+        else "<span class='muted'>Save an assessment before creating remediation tasks.</span>"
+    )
+    created_notice = (
+        f"<p class='notice success'><strong>Remediation task created:</strong> {html.escape(task_created)}</p>"
+        if task_created
+        else ""
+    )
+    body = f"""<section><p><a href='/agency'>Agency workflow</a></p><h1>{html.escape(project.name)}</h1>{created_notice}<p><strong>Client:</strong> {html.escape(project.client_label or 'Not set')}<br><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Saved assessment:</strong> {latest_text}</p><div class='actions'><a class='button' href='/?{html.escape(query, quote=True)}'>Review assessment</a><a class='button secondary' href='/report?{html.escape(query, quote=True)}'>Configure report</a>{remediation}<a class='button secondary' href='/monitoring'>Enable monitoring</a></div></section><section><h2>Recommended next step</h2><p>Review the saved evidence, choose the client-facing report output, then convert actionable findings into assigned remediation work before enabling recurring monitoring.</p></section>"""
     return _page(project.name, body)

--- a/src/veridra/agency_task_web.py
+++ b/src/veridra/agency_task_web.py
@@ -1,0 +1,158 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .finding_task_api import FindingTaskConversion, create_task_from_finding
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .request_security import require_request_identity
+from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+from .tenant_task_store import TenantTaskStore
+
+router = APIRouter(prefix="/agency", tags=["agency-remediation"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1080px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}table{width:100%;border-collapse:collapse}th,td{padding:12px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top;overflow-wrap:anywhere}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.pill{display:inline-block;border:1px solid #cfd4da;border-radius:999px;padding:3px 8px}.actions{display:flex;gap:8px;flex-wrap:wrap}@media(max-width:760px){table{display:block;overflow:auto}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _single(body: bytes, name: str) -> str:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
+
+
+def _load_source(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+    assessment_id: str,
+):
+    projects = TenantProjectStore(_root(request))
+    history = TenantHistoryStore(_root(request))
+    try:
+        project = projects.load(identity, projects.ref(identity, project_id))
+        assessment = history.load(
+            identity,
+            history.ref(identity, project_id, assessment_id),
+        )
+    except (TenantProjectStoreError, TenantHistoryStoreError) as exc:
+        raise HTTPException(status_code=404, detail="Finding source not found.") from exc
+    return project, assessment
+
+
+def _can_manage_tasks(identity: RequestIdentity) -> bool:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_tasks)
+    except IdentityBoundaryError:
+        return False
+    return True
+
+
+@router.get(
+    "/projects/{project_id}/assessments/{assessment_id}/findings",
+    response_class=HTMLResponse,
+)
+def saved_findings(
+    project_id: str,
+    assessment_id: str,
+    request: Request,
+) -> str:
+    identity = require_request_identity(request)
+    project, assessment = _load_source(request, identity, project_id, assessment_id)
+    tasks = TenantTaskStore(_root(request)).list(identity, project_id=project_id)
+    task_keys = {(task.source_assessment_id, task.finding_id): task_id for task_id, task in tasks}
+    can_create = _can_manage_tasks(identity)
+    rows: list[str] = []
+    for finding in assessment.findings:
+        key = (assessment_id, finding.id)
+        existing = task_keys.get(key)
+        if existing is not None:
+            action = f"<span class='pill'>Task {html.escape(existing)}</span>"
+        elif can_create:
+            query = html.escape(
+                urlencode(
+                    {
+                        "project_id": project_id,
+                        "assessment_id": assessment_id,
+                        "finding_id": finding.id,
+                    }
+                ),
+                quote=True,
+            )
+            action = f"<a class='button' href='/agency/tasks/from-finding?{query}'>Create task</a>"
+        else:
+            action = "<span class='muted'>Task permission required</span>"
+        rows.append(
+            "<tr><td><span class='pill'>{status}</span></td><td>{area}</td><td><strong>{title}</strong><br><span class='muted'>{summary}</span></td><td>{action}</td></tr>".format(
+                status=html.escape(finding.status.value),
+                area=html.escape(finding.area),
+                title=html.escape(finding.title),
+                summary=html.escape(finding.summary),
+                action=action,
+            )
+        )
+    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project</a> · <a href='/agency'>Agency workflow</a></p><h1>Saved findings for {html.escape(project.name)}</h1><p class='notice'>Tasks are created one finding at a time after explicit confirmation. Creating a task records remediation work; it does not prove the finding is fixed.</p><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Remediation</th></tr></thead><tbody>{''.join(rows)}</tbody></table></section>"""
+    return _page(f"{project.name} findings", body)
+
+
+@router.get("/tasks/from-finding", response_class=HTMLResponse)
+def confirm_finding_task(
+    project_id: str,
+    assessment_id: str,
+    finding_id: str,
+    request: Request,
+) -> str:
+    identity = require_request_identity(request)
+    if not _can_manage_tasks(identity):
+        raise HTTPException(status_code=403, detail="This action is not permitted.")
+    project, assessment = _load_source(request, identity, project_id, assessment_id)
+    finding = next((item for item in assessment.findings if item.id == finding_id), None)
+    if finding is None:
+        raise HTTPException(status_code=404, detail="Finding source not found.")
+    hidden = "".join(
+        (
+            f"<input type='hidden' name='project_id' value='{html.escape(project_id, quote=True)}'>",
+            f"<input type='hidden' name='assessment_id' value='{html.escape(assessment_id, quote=True)}'>",
+            f"<input type='hidden' name='finding_id' value='{html.escape(finding_id, quote=True)}'>",
+        )
+    )
+    recommendation = finding.recommendation or "Review the supporting evidence."
+    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}/assessments/{html.escape(assessment_id, quote=True)}/findings'>Saved findings</a></p><h1>Create remediation task</h1><p class='notice'><strong>Project:</strong> {html.escape(project.name)}<br><strong>Finding:</strong> {html.escape(finding.title)}</p><p><strong>Area:</strong> {html.escape(finding.area)}<br><strong>Severity:</strong> {html.escape(finding.severity)}<br><strong>Observation:</strong> {html.escape(finding.summary)}<br><strong>Recommended fix:</strong> {html.escape(recommendation)}</p><form method='post' action='/agency/tasks/from-finding'>{hidden}<button type='submit'>Confirm task creation</button> <a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/assessments/{html.escape(assessment_id, quote=True)}/findings'>Cancel</a></form></section>"""
+    return _page("Create remediation task", body)
+
+
+@router.post("/tasks/from-finding")
+async def submit_finding_task(request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_tasks)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    body = await request.body()
+    payload = FindingTaskConversion(
+        project_id=_single(body, "project_id"),
+        assessment_id=_single(body, "assessment_id"),
+        finding_id=_single(body, "finding_id"),
+    )
+    created = create_task_from_finding(payload, request, identity)
+    query = urlencode({"task_created": created.task_id})
+    return RedirectResponse(f"/agency/projects/{payload.project_id}?{query}", status_code=303)

--- a/src/veridra/agency_task_web.py
+++ b/src/veridra/agency_task_web.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlencode
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from .core import Assessment
 from .finding_task_api import FindingTaskConversion, create_task_from_finding
 from .identity_tenancy import (
     IdentityBoundaryError,
@@ -15,6 +16,7 @@ from .identity_tenancy import (
     TenantCapability,
     require_tenant_capability,
 )
+from .project_store import ClientProject
 from .request_security import require_request_identity
 from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
 from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
@@ -45,7 +47,7 @@ def _load_source(
     identity: RequestIdentity,
     project_id: str,
     assessment_id: str,
-):
+) -> tuple[ClientProject, Assessment]:
     projects = TenantProjectStore(_root(request))
     history = TenantHistoryStore(_root(request))
     try:

--- a/src/veridra/agency_task_web.py
+++ b/src/veridra/agency_task_web.py
@@ -104,13 +104,7 @@ def saved_findings(
         else:
             action = "<span class='muted'>Task permission required</span>"
         rows.append(
-            "<tr><td><span class='pill'>{status}</span></td><td>{area}</td><td><strong>{title}</strong><br><span class='muted'>{summary}</span></td><td>{action}</td></tr>".format(
-                status=html.escape(finding.status.value),
-                area=html.escape(finding.area),
-                title=html.escape(finding.title),
-                summary=html.escape(finding.summary),
-                action=action,
-            )
+            f"<tr><td><span class='pill'>{html.escape(finding.status.value)}</span></td><td>{html.escape(finding.area)}</td><td><strong>{html.escape(finding.title)}</strong><br><span class='muted'>{html.escape(finding.summary)}</span></td><td>{action}</td></tr>"
         )
     body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project</a> · <a href='/agency'>Agency workflow</a></p><h1>Saved findings for {html.escape(project.name)}</h1><p class='notice'>Tasks are created one finding at a time after explicit confirmation. Creating a task records remediation work; it does not prove the finding is fixed.</p><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Remediation</th></tr></thead><tbody>{''.join(rows)}</tbody></table></section>"""
     return _page(f"{project.name} findings", body)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -6,6 +6,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from . import app as app_module
 from . import public_web
 from .agency_conversion_web import router as agency_conversion_router
+from .agency_task_web import router as agency_task_router
 from .agency_workflow_web import router as agency_workflow_router
 from .app import app as app
 from .application_identity import configure_identity_middleware
@@ -116,6 +117,7 @@ app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)
 app.include_router(agency_conversion_router)
+app.include_router(agency_task_router)
 
 
 def main() -> None:

--- a/tests/test_agency_task_web.py
+++ b/tests/test_agency_task_web.py
@@ -1,9 +1,9 @@
 # ruff: noqa: E501
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Awaitable, Callable
 
 from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient

--- a/tests/test_agency_task_web.py
+++ b/tests/test_agency_task_web.py
@@ -1,0 +1,171 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Awaitable, Callable
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_conversion_web import router as project_router
+from veridra.agency_task_web import router as task_router
+from veridra.core import demo_assessment
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_history_store import TenantHistoryStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 9, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="owner-agency-task-session-001",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="viewer-agency-task-session-01",
+    authenticated_at=NOW,
+)
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, str, str, str]:
+    root = tmp_path / "tenants"
+    project = ClientProject.build(name="Example <Client>", target_url="https://example.com")
+    project_id = TenantProjectStore(root).save(OWNER, project)
+    assessment = demo_assessment().model_copy(update={"target": "https://example.com/"})
+    assessment_id = TenantHistoryStore(root).save(OWNER, project_id, assessment)
+    finding_id = assessment.findings[0].id
+
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        return await call_next(request)
+
+    app.include_router(project_router)
+    app.include_router(task_router)
+    return TestClient(app), project_id, assessment_id, finding_id
+
+
+def test_saved_findings_requires_identity(tmp_path: Path) -> None:
+    client, project_id, assessment_id, _ = _client(tmp_path)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/assessments/{assessment_id}/findings"
+    )
+
+    assert response.status_code == 401
+
+
+def test_saved_findings_get_does_not_create_tasks_and_escapes_project(tmp_path: Path) -> None:
+    client, project_id, assessment_id, _ = _client(tmp_path)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/assessments/{assessment_id}/findings",
+        headers={"x-test-role": "owner"},
+    )
+
+    assert response.status_code == 200
+    assert "Example &lt;Client&gt;" in response.text
+    assert "Example <Client>" not in response.text
+    assert "Create task" in response.text
+    assert not (tmp_path / "tenants" / OWNER.tenant_id / "tasks").exists()
+
+
+def test_viewer_can_review_but_not_open_confirmation(tmp_path: Path) -> None:
+    client, project_id, assessment_id, finding_id = _client(tmp_path)
+
+    listing = client.get(
+        f"/agency/projects/{project_id}/assessments/{assessment_id}/findings",
+        headers={"x-test-role": "viewer"},
+    )
+    confirmation = client.get(
+        "/agency/tasks/from-finding",
+        headers={"x-test-role": "viewer"},
+        params={
+            "project_id": project_id,
+            "assessment_id": assessment_id,
+            "finding_id": finding_id,
+        },
+    )
+
+    assert listing.status_code == 200
+    assert "Task permission required" in listing.text
+    assert confirmation.status_code == 403
+
+
+def test_owner_confirms_task_and_project_shows_status(tmp_path: Path) -> None:
+    client, project_id, assessment_id, finding_id = _client(tmp_path)
+
+    confirmation = client.get(
+        "/agency/tasks/from-finding",
+        headers={"x-test-role": "owner"},
+        params={
+            "project_id": project_id,
+            "assessment_id": assessment_id,
+            "finding_id": finding_id,
+        },
+    )
+    created = client.post(
+        "/agency/tasks/from-finding",
+        headers={"x-test-role": "owner"},
+        data={
+            "project_id": project_id,
+            "assessment_id": assessment_id,
+            "finding_id": finding_id,
+        },
+        follow_redirects=False,
+    )
+
+    assert confirmation.status_code == 200
+    assert "Confirm task creation" in confirmation.text
+    assert created.status_code == 303
+    assert created.headers["location"].startswith(f"/agency/projects/{project_id}?task_created=")
+    task_id = created.headers["location"].split("task_created=", 1)[1]
+    project_page = client.get(created.headers["location"], headers={"x-test-role": "owner"})
+    listing = client.get(
+        f"/agency/projects/{project_id}/assessments/{assessment_id}/findings",
+        headers={"x-test-role": "owner"},
+    )
+    assert project_page.status_code == 200
+    assert f"Remediation task created:</strong> {task_id}" in project_page.text
+    assert f"Task {task_id}" in listing.text
+
+
+def test_repeated_confirmation_is_idempotent(tmp_path: Path) -> None:
+    client, project_id, assessment_id, finding_id = _client(tmp_path)
+    data = {
+        "project_id": project_id,
+        "assessment_id": assessment_id,
+        "finding_id": finding_id,
+    }
+
+    first = client.post(
+        "/agency/tasks/from-finding",
+        headers={"x-test-role": "owner"},
+        data=data,
+        follow_redirects=False,
+    )
+    second = client.post(
+        "/agency/tasks/from-finding",
+        headers={"x-test-role": "owner"},
+        data=data,
+        follow_redirects=False,
+    )
+
+    assert first.headers["location"] == second.headers["location"]


### PR DESCRIPTION
Completes the operator-facing portion of issue #97 from current main `5b2088b989aca86861c8b5b0ea02b5e26f6df5e5`.

## What changed

- adds a tenant-qualified saved-findings page for the latest project assessment;
- resolves project, assessment and finding content only through verified request identity;
- shows existing remediation task state for each saved finding;
- exposes **Create task** only to roles with `manage_tasks`;
- adds an explicit confirmation page before persistence;
- posts only project, assessment and stable finding identifiers;
- delegates persistence to the merged canonical finding-to-task service;
- preserves idempotency for repeated confirmation;
- redirects back to the tenant project with a visible task-created status;
- replaces the project’s generic task-list jump with a link to the exact latest saved assessment;
- keeps GET routes read-only and escapes project and finding content;
- registers the agency remediation router in the composed runtime;
- adds authentication, permission, escaping, no-GET-persistence, status and idempotency tests.

## Boundaries

- no automatic task creation;
- no client-supplied finding text, recommendation, evidence or tenant ID;
- no claim that task creation proves remediation;
- no ownership, due-date or verification-state changes;
- same-origin middleware remains mandatory for authenticated mutations in the composed runtime.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Closes #97 when fully validated and merged. Related to #87.