### PR TITLE
Preserve tenant project identity on updates

### DIFF
--- a/src/veridra/project_store.py
+++ b/src/veridra/project_store.py
@@ -130,9 +130,8 @@ class ProjectStore:
             raise ProjectStoreError("Invalid project identifier.")
         return self.directory / f"{entry_id}.json"
 
-    def save(self, project: ClientProject) -> str:
+    def _write(self, entry_id: str, project: ClientProject) -> None:
         self.directory.mkdir(parents=True, exist_ok=True)
-        entry_id = project_id(project)
         destination = self._path(entry_id)
         with NamedTemporaryFile(
             mode="wb",
@@ -146,6 +145,17 @@ class ProjectStore:
             os.fsync(temporary.fileno())
             temporary_path = Path(temporary.name)
         temporary_path.replace(destination)
+
+    def save(self, project: ClientProject) -> str:
+        entry_id = project_id(project)
+        self._write(entry_id, project)
+        return entry_id
+
+    def overwrite(self, entry_id: str, project: ClientProject) -> str:
+        current = self._path(entry_id)
+        if not current.exists():
+            raise ProjectStoreError("Saved project was not found.")
+        self._write(entry_id, project)
         return entry_id
 
     def replace(self, entry_id: str, project: ClientProject) -> str:

--- a/src/veridra/tenant_project_store.py
+++ b/src/veridra/tenant_project_store.py
@@ -30,7 +30,9 @@ class TenantProjectStore:
 
     This is a migration-compatible local persistence step, not a production database.
     Every public operation requires a verified request identity and resolves storage
-    beneath that identity's tenant directory.
+    beneath that identity's tenant directory. Tenant project identifiers remain stable
+    across mutable configuration updates so child assessments and tasks keep their
+    project relationship.
     """
 
     def __init__(self, root: Path | None = None) -> None:
@@ -87,7 +89,7 @@ class TenantProjectStore:
             raise TenantProjectStoreError("Tenant object is not a project reference.")
         self._require_profile(identity, project)
         try:
-            return self._store(identity).replace(target.object_id, project)
+            return self._store(identity).overwrite(target.object_id, project)
         except ProjectStoreError as exc:
             raise TenantProjectStoreError("Saved project was not found.") from exc
 

--- a/tests/test_project_store.py
+++ b/tests/test_project_store.py
@@ -32,6 +32,20 @@ def test_project_store_round_trip_and_delete(tmp_path: Path) -> None:
     assert store.list() == []
 
 
+def test_project_overwrite_preserves_identifier(tmp_path: Path) -> None:
+    store = ProjectStore(tmp_path)
+    original = ClientProject.build(name="Original", target_url="example.com")
+    entry_id = store.save(original)
+    replacement = ClientProject.build(name="Updated", target_url="example.org")
+
+    overwritten_id = store.overwrite(entry_id, replacement)
+
+    assert overwritten_id == entry_id
+    assert store.load(entry_id) == replacement
+    assert not (tmp_path / f"{project_id(replacement)}.json").exists()
+    assert not list(tmp_path.glob("*.tmp"))
+
+
 def test_project_replace_changes_identifier_and_removes_old_file(tmp_path: Path) -> None:
     store = ProjectStore(tmp_path)
     original = ClientProject.build(name="Original", target_url="example.com")

--- a/tests/test_tenant_monitoring.py
+++ b/tests/test_tenant_monitoring.py
@@ -15,7 +15,7 @@ from veridra.tenant_monitoring_api import (
     get_monitoring_configuration,
     replace_monitoring_configuration,
 )
-from veridra.tenant_project_store import TenantProjectStore, TenantProjectStoreError
+from veridra.tenant_project_store import TenantProjectStore
 
 NOW = datetime(2026, 7, 25, 21, 0, tzinfo=UTC)
 
@@ -44,7 +44,7 @@ def _request(root: Path) -> Request:
     )
 
 
-def test_monitoring_update_rotates_only_the_tenant_project(tmp_path: Path) -> None:
+def test_monitoring_update_preserves_tenant_project_identity(tmp_path: Path) -> None:
     root = tmp_path / "tenants"
     analyst = _identity("1" * 24, TenantRole.analyst)
     store = TenantProjectStore(root)
@@ -70,12 +70,10 @@ def test_monitoring_update_rotates_only_the_tenant_project(tmp_path: Path) -> No
         analyst,
     )
 
-    assert response.project_id != project_id
+    assert response.project_id == project_id
     assert response.schedule == payload.schedule
     assert str(response.recipient) == "monitoring@example.com"
-    with pytest.raises(TenantProjectStoreError):
-        store.load(analyst, store.ref(analyst, project_id))
-    replacement = store.load(analyst, store.ref(analyst, response.project_id))
+    replacement = store.load(analyst, store.ref(analyst, project_id))
     assert replacement.monitoring_schedule == payload.schedule
     assert str(replacement.monitoring_email) == "monitoring@example.com"
 

--- a/tests/test_tenant_project_store.py
+++ b/tests/test_tenant_project_store.py
@@ -75,19 +75,21 @@ def test_viewer_can_list_and_load_but_cannot_write(tmp_path: Path) -> None:
         store.save(viewer, _project("Forbidden"))
 
 
-def test_replace_and_delete_require_tenant_scoped_project_reference(tmp_path: Path) -> None:
+def test_replace_preserves_tenant_project_identifier(tmp_path: Path) -> None:
     store = TenantProjectStore(tmp_path)
     identity = _identity("b" * 24)
     project_id = store.save(identity, _project("Original"))
     target = store.ref(identity, project_id)
 
     replacement_id = store.replace(identity, target, _project("Replacement"))
-    assert replacement_id != project_id
-    assert store.load(identity, store.ref(identity, replacement_id)).name == "Replacement"
 
-    store.delete(identity, store.ref(identity, replacement_id))
+    assert replacement_id == project_id
+    assert store.load(identity, target).name == "Replacement"
+    assert [entry.id for entry in store.list(identity)] == [project_id]
+
+    store.delete(identity, target)
     with pytest.raises(TenantProjectStoreError, match="not found"):
-        store.load(identity, store.ref(identity, replacement_id))
+        store.load(identity, target)
 
 
 def test_non_project_reference_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
Implements issue #101 from current main `b5e8bbe974d61bf1a3f2a249ae742c04e250a214`.

## What changed

- adds an atomic `ProjectStore.overwrite()` primitive that writes new project content at an existing validated ID;
- keeps legacy standalone `ProjectStore.replace()` content-addressed behavior unchanged;
- changes `TenantProjectStore.replace()` to preserve the tenant project ID;
- documents tenant project IDs as stable object identities across mutable configuration changes;
- retains tenant capability, tenant scope and tenant report-profile validation;
- preserves existing project assessment directories and task references without migration or copying;
- adds project-store overwrite tests;
- updates tenant project replacement tests to require stable identity.

## Why

Mutable monitoring, profile, contact or crawl configuration previously produced a new project ID, deleted the old project document and left assessments and remediation tasks attached to the old ID. Stable tenant identity is required before issue #100 can safely expose monitoring configuration updates.

## Boundaries

- initial tenant project creation remains deterministic;
- legacy standalone local project replacement behavior is unchanged;
- no cross-tenant reference handling changes;
- no child object rewrite or copy is performed because the parent ID now remains stable.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Closes #101 when validated and merged. Blocks #100.