### PR TITLE
Add agency assessment comparison workflow

### DIFF
--- a/src/veridra/agency_monitoring_web.py
+++ b/src/veridra/agency_monitoring_web.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
+from .history import Comparison
 from .identity_tenancy import (
     IdentityBoundaryError,
     RequestIdentity,
@@ -29,7 +30,7 @@ from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
 router = APIRouter(prefix="/agency", tags=["agency-monitoring"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.row{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.actions{display:flex;gap:8px;flex-wrap:wrap}@media(max-width:700px){.row{grid-template-columns:1fr}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.row{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.actions{display:flex;gap:8px;flex-wrap:wrap}.comparison{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.comparison article{border:1px solid #dfe3e8;border-radius:8px;padding:16px}.comparison ul{padding-left:20px}@media(max-width:700px){.row,.comparison{grid-template-columns:1fr}}
 """
 
 
@@ -69,6 +70,31 @@ def _project(
 def _option(value: str, selected: str, label: str) -> str:
     marker = " selected" if value == selected else ""
     return f"<option value='{html.escape(value, quote=True)}'{marker}>{html.escape(label)}</option>"
+
+
+def _comparison_items(
+    project_id: str,
+    assessment_id: str,
+    values: tuple[str, ...],
+) -> str:
+    if not values:
+        return "<p class='muted'>None</p>"
+    findings_url = (
+        f"/agency/projects/{html.escape(project_id, quote=True)}"
+        f"/assessments/{html.escape(assessment_id, quote=True)}/findings"
+    )
+    return "<ul>" + "".join(
+        f"<li><a href='{findings_url}'>{html.escape(value)}</a></li>" for value in values
+    ) + "</ul>"
+
+
+def _comparison_card(
+    title: str,
+    project_id: str,
+    assessment_id: str,
+    values: tuple[str, ...],
+) -> str:
+    return f"<article><h2>{html.escape(title)} <span class='muted'>({len(values)})</span></h2>{_comparison_items(project_id, assessment_id, values)}</article>"
 
 
 @router.get("/projects/{project_id}/monitoring", response_class=HTMLResponse)
@@ -112,14 +138,51 @@ def project_monitoring(
     history_summary = (
         f"<p><strong>Latest assessment:</strong> {html.escape(latest.generated_at) if latest else 'Not available'}<br><strong>Previous assessment:</strong> {html.escape(previous.generated_at) if previous else 'Not available'}</p>"
     )
+    if latest is not None and previous is not None:
+        compare_query = html.escape(
+            urlencode({"before": previous.id, "after": latest.id}),
+            quote=True,
+        )
+        comparison_action = f"<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/monitoring/compare?{compare_query}'>Compare latest assessments</a>"
+    else:
+        comparison_action = "<span class='muted'>At least two saved assessments are required for comparison.</span>"
     if can_manage:
         form = f"""<form method='post' action='/agency/projects/{html.escape(project_id, quote=True)}/monitoring'><div class='row'><div><label for='cadence'>Cadence</label><select id='cadence' name='cadence'>{cadence_options}</select></div><div><label for='timezone'>Timezone</label><input id='timezone' name='timezone' maxlength='64' value='{html.escape(schedule.timezone, quote=True)}' required></div></div><div class='row'><div><label for='hour'>Hour</label><input id='hour' name='hour' type='number' min='0' max='23' value='{schedule.hour}' required></div><div><label for='minute'>Minute</label><input id='minute' name='minute' type='number' min='0' max='59' value='{schedule.minute}' required></div></div><div class='row'><div><label for='weekday'>Weekday (0 Monday–6 Sunday)</label><input id='weekday' name='weekday' type='number' min='0' max='6' value='{html.escape(weekday, quote=True)}'></div><div><label for='day_of_month'>Day of month (1–28)</label><input id='day_of_month' name='day_of_month' type='number' min='1' max='28' value='{html.escape(day_of_month, quote=True)}'></div></div><label for='recipient'>Notification email</label><input id='recipient' name='recipient' type='email' value='{recipient}'><p class='muted'>Saving this form explicitly replaces the project monitoring configuration. It does not run an assessment.</p><button type='submit'>Save monitoring configuration</button></form>"""
         run_action = f"<form method='post' action='/agency/projects/{html.escape(project_id, quote=True)}/monitoring/run'><button type='submit'>Run monitoring now</button></form>"
     else:
         form = "<p class='notice'>Your current workspace role can inspect this configuration but cannot change it.</p>"
         run_action = ""
-    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project</a> · <a href='/agency'>Agency workflow</a></p><h1>Monitoring for {html.escape(project.name)}</h1>{status_panel}<p><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Current cadence:</strong> {html.escape(schedule.cadence.value)}<br><strong>Timezone:</strong> {html.escape(schedule.timezone)}<br><strong>Notification:</strong> {html.escape(str(project.monitoring_email or 'Not configured'))}</p>{history_summary}</section><section><h2>Configuration</h2>{form}</section><section><h2>Manual verification</h2><p class='muted'>A manual run performs the existing bounded assessment, saves it to this tenant project and attempts the configured summary email. Email delivery status is evidence of the attempt, not a guarantee of receipt.</p>{run_action}</section>"""
+    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project</a> · <a href='/agency'>Agency workflow</a></p><h1>Monitoring for {html.escape(project.name)}</h1>{status_panel}<p><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Current cadence:</strong> {html.escape(schedule.cadence.value)}<br><strong>Timezone:</strong> {html.escape(schedule.timezone)}<br><strong>Notification:</strong> {html.escape(str(project.monitoring_email or 'Not configured'))}</p>{history_summary}<div class='actions'>{comparison_action}</div></section><section><h2>Configuration</h2>{form}</section><section><h2>Manual verification</h2><p class='muted'>A manual run performs the existing bounded assessment, saves it to this tenant project and attempts the configured summary email. Email delivery status is evidence of the attempt, not a guarantee of receipt.</p>{run_action}</section>"""
     return _page(f"{project.name} monitoring", body)
+
+
+@router.get(
+    "/projects/{project_id}/monitoring/compare",
+    response_class=HTMLResponse,
+)
+def compare_project_assessments(
+    project_id: str,
+    before: str,
+    after: str,
+    request: Request,
+) -> str:
+    identity = require_request_identity(request)
+    project = _project(request, identity, project_id)
+    history = TenantHistoryStore(_root(request))
+    try:
+        comparison: Comparison = history.compare(identity, project_id, before, after)
+    except TenantHistoryStoreError as exc:
+        raise HTTPException(status_code=404, detail="Assessment comparison not found.") from exc
+    cards = "".join(
+        (
+            _comparison_card("Added", project_id, after, comparison.added),
+            _comparison_card("Resolved", project_id, before, comparison.resolved),
+            _comparison_card("Changed", project_id, after, comparison.changed),
+            _comparison_card("Unchanged", project_id, after, comparison.unchanged),
+        )
+    )
+    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}/monitoring'>Monitoring</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project</a></p><h1>Assessment comparison for {html.escape(project.name)}</h1><p class='notice'><strong>Before:</strong> {html.escape(before)}<br><strong>After:</strong> {html.escape(after)}</p><p>This view reports stored finding changes only. A resolved identifier is not client-facing proof of remediation without reviewing the underlying evidence.</p></section><section class='comparison'>{cards}</section>"""
+    return _page(f"{project.name} assessment comparison", body)
 
 
 @router.post("/projects/{project_id}/monitoring")

--- a/tests/test_agency_assessment_comparison_web.py
+++ b/tests/test_agency_assessment_comparison_web.py
@@ -1,0 +1,142 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_monitoring_web import router
+from veridra.core import demo_assessment
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_history_store import TenantHistoryStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 11, 0, tzinfo=UTC)
+ANALYST = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.analyst,
+    session_id="analyst-comparison-session-01",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="viewer-comparison-session-001",
+    authenticated_at=NOW,
+)
+OTHER_VIEWER = RequestIdentity(
+    user_id="3" * 24,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="other-comparison-session-0001",
+    authenticated_at=NOW,
+)
+
+
+def _app(root: Path) -> TestClient:
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        elif role == "other":
+            bind_verified_request_identity(request, OTHER_VIEWER)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _project_with_history(tmp_path: Path, *, count: int) -> tuple[TestClient, str, list[str]]:
+    root = tmp_path / "tenants"
+    project = ClientProject.build(
+        name="Comparison <Client>",
+        target_url="https://example.com",
+    )
+    project_id = TenantProjectStore(root).save(ANALYST, project)
+    history = TenantHistoryStore(root)
+    identifiers: list[str] = []
+    for offset in range(count):
+        assessment = demo_assessment().model_copy(
+            update={
+                "target": "https://example.com/",
+                "generated_at": NOW + timedelta(minutes=offset),
+            }
+        )
+        identifiers.append(history.save(ANALYST, project_id, assessment))
+    return _app(root), project_id, identifiers
+
+
+def test_monitoring_page_links_latest_and_previous_assessments(tmp_path: Path) -> None:
+    client, project_id, identifiers = _project_with_history(tmp_path, count=2)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/monitoring",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert response.status_code == 200
+    assert "Comparison &lt;Client&gt;" in response.text
+    assert "Compare latest assessments" in response.text
+    assert f"before={identifiers[0]}" in response.text
+    assert f"after={identifiers[1]}" in response.text
+
+
+def test_viewer_opens_read_only_comparison(tmp_path: Path) -> None:
+    client, project_id, identifiers = _project_with_history(tmp_path, count=2)
+    root = tmp_path / "tenants" / ANALYST.tenant_id / "projects" / project_id / "assessments"
+    before_files = {path.name: path.read_bytes() for path in root.glob("*.json")}
+
+    response = client.get(
+        f"/agency/projects/{project_id}/monitoring/compare",
+        headers={"x-test-role": "viewer"},
+        params={"before": identifiers[0], "after": identifiers[1]},
+    )
+
+    assert response.status_code == 200
+    assert "Assessment comparison for Comparison &lt;Client&gt;" in response.text
+    assert "Added" in response.text
+    assert "Resolved" in response.text
+    assert "Changed" in response.text
+    assert "Unchanged" in response.text
+    assert "not client-facing proof of remediation" in response.text
+    assert {path.name: path.read_bytes() for path in root.glob("*.json")} == before_files
+
+
+def test_monitoring_page_shows_insufficient_history_state(tmp_path: Path) -> None:
+    client, project_id, _ = _project_with_history(tmp_path, count=1)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/monitoring",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert response.status_code == 200
+    assert "At least two saved assessments are required for comparison." in response.text
+    assert "Compare latest assessments" not in response.text
+
+
+def test_cross_tenant_comparison_is_concealed(tmp_path: Path) -> None:
+    client, project_id, identifiers = _project_with_history(tmp_path, count=2)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/monitoring/compare",
+        headers={"x-test-role": "other"},
+        params={"before": identifiers[0], "after": identifiers[1]},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Project not found."}


### PR DESCRIPTION
Implements issue #104 from current main `98429f463b4df11210f9929c66648063fafcb0f0`.

## What changed

- adds a **Compare latest assessments** action when a tenant project has at least two saved assessments;
- selects the immediately previous assessment as `before` and latest as `after`;
- adds a tenant-qualified read-only comparison page;
- delegates comparison semantics to the existing `TenantHistoryStore.compare()` boundary;
- renders added, resolved, changed and unchanged identifiers with explicit counts;
- links identifiers back to the relevant saved findings surface;
- preserves a clear insufficient-history state;
- avoids claiming that a resolved identifier alone proves remediation;
- conceals cross-tenant and missing project references through generic not-found responses;
- escapes project and comparison content;
- adds viewer, read-only, insufficient-history and cross-tenant tests.

## Boundaries

- no comparison semantic changes;
- no charts or trend analytics;
- no cross-project or cross-tenant comparisons;
- no persistence mutations on GET;
- no client-facing proof claims without evidence review.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Closes #104 when fully validated and merged. Related to #87.