### PR TITLE
Add explicit tenant report email delivery

### DIFF
--- a/src/veridra/agency_report_web.py
+++ b/src/veridra/agency_report_web.py
@@ -3,17 +3,23 @@ from __future__ import annotations
 
 import html
 from pathlib import Path
+from urllib.parse import parse_qs, urlencode
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, ValidationError
 
+from .email_delivery import EmailDeliveryError
 from .identity_tenancy import (
     IdentityBoundaryError,
     RequestIdentity,
     TenantCapability,
     require_tenant_capability,
 )
+from .pdf_reports import PdfRenderError, render_pdf
+from .report_delivery import ReportDeliveryStore, send_report_pdf
 from .report_profiles import DEFAULT_REPORT_PROFILE, ReportProfile
+from .reports import render_report
 from .request_security import require_request_identity
 from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
 from .tenant_profile_store import TenantProfileStore, TenantProfileStoreError
@@ -22,8 +28,16 @@ from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
 router = APIRouter(prefix="/agency", tags=["agency-reports"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button{display:inline-block;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.actions{display:flex;gap:8px;flex-wrap:wrap}.profile{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}.profile div{border:1px solid #e2e5e9;border-radius:8px;padding:12px}@media(max-width:700px){.profile{grid-template-columns:1fr}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.danger{border-left-color:#a23333;background:#fff3f3}.actions{display:flex;gap:8px;flex-wrap:wrap}.profile{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}.profile div{border:1px solid #e2e5e9;border-radius:8px;padding:12px}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:120px}@media(max-width:700px){.profile{grid-template-columns:1fr}}
 """
+
+
+class DeliveryInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    recipient: EmailStr
+    subject: str = Field(min_length=1, max_length=200)
+    message: str = Field(default="", max_length=4000)
 
 
 def _page(title: str, body: str) -> str:
@@ -33,6 +47,10 @@ def _page(title: str, body: str) -> str:
 def _root(request: Request) -> Path | None:
     value = getattr(request.app.state, "veridra_tenant_data_root", None)
     return value if isinstance(value, Path) else None
+
+
+def _single(body: bytes, name: str) -> str:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
 
 
 def _profile(
@@ -49,14 +67,7 @@ def _profile(
         raise HTTPException(status_code=404, detail="Report source not found.") from exc
 
 
-@router.get("/projects/{project_id}/reports", response_class=HTMLResponse)
-def project_report_hub(project_id: str, request: Request) -> str:
-    identity = require_request_identity(request)
-    try:
-        require_tenant_capability(identity, TenantCapability.manage_reports)
-    except IdentityBoundaryError as exc:
-        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
-
+def _context(request: Request, identity: RequestIdentity, project_id: str):
     root = _root(request)
     projects = TenantProjectStore(root)
     history = TenantHistoryStore(root)
@@ -65,8 +76,28 @@ def project_report_hub(project_id: str, request: Request) -> str:
         assessments = history.list(identity, project_id)
     except (TenantProjectStoreError, TenantHistoryStoreError) as exc:
         raise HTTPException(status_code=404, detail="Report source not found.") from exc
-
     profile, is_default = _profile(request, identity, project.profile_id)
+    return root, project, assessments, profile, is_default
+
+
+def _attempt_store(root: Path | None, tenant_id: str) -> ReportDeliveryStore:
+    base = root if root is not None else Path.home() / ".veridra" / "tenants"
+    return ReportDeliveryStore(base / tenant_id / "report-deliveries")
+
+
+@router.get("/projects/{project_id}/reports", response_class=HTMLResponse)
+def project_report_hub(
+    project_id: str,
+    request: Request,
+    delivery: str | None = None,
+) -> str:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_reports)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+
+    root, project, assessments, profile, is_default = _context(request, identity, project_id)
     latest = assessments[0] if assessments else None
     profile_state = "Default Veridra profile" if is_default else "Tenant report profile"
     section_labels = ", ".join(profile.section_order)
@@ -77,11 +108,91 @@ def project_report_hub(project_id: str, request: Request) -> str:
     )
     profile_summary = f"""<div class='profile'><div><strong>Profile</strong><br>{html.escape(profile_state)}</div><div><strong>Organisation</strong><br>{html.escape(profile.organisation_name)}</div><div><strong>Client</strong><br>{html.escape(profile.client_name or project.client_label or 'Not set')}</div><div><strong>Language</strong><br>{html.escape(profile.language)}</div><div><strong>Accent colour</strong><br>{html.escape(profile.accent_colour)}</div><div><strong>Call to action</strong><br>{html.escape(cta)}</div></div><p><strong>Enabled sections:</strong> {html.escape(section_labels)}</p>"""
 
+    status = ""
+    if delivery == "delivered":
+        status = "<p class='notice success'><strong>SMTP accepted the report delivery.</strong> This does not prove inbox placement or opening.</p>"
+    elif delivery == "failed":
+        status = "<p class='notice danger'><strong>The report delivery attempt failed.</strong> Review the recent attempt details before retrying.</p>"
+    elif delivery == "not-configured":
+        status = "<p class='notice'><strong>Email delivery is not configured.</strong> Configure the server SMTP environment before retrying.</p>"
+
     if latest is None:
-        output = "<p class='notice'>No saved assessment is available. Run or save a tenant-qualified assessment before generating a report.</p>"
+        output = "<p class='notice'>No saved assessment is available. Run or save a tenant-qualified assessment before generating or sending a report.</p>"
     else:
         base = f"/api/tenant/projects/{html.escape(project_id, quote=True)}/assessments/{html.escape(latest.id, quote=True)}"
-        output = f"""<p class='notice'><strong>Report source:</strong> assessment {html.escape(latest.id)}<br><strong>Generated:</strong> {html.escape(latest.generated_at)}</p><div class='actions'><a class='button' href='{base}/report'>Preview branded HTML</a><a class='button secondary' href='{base}/report.pdf'>Download PDF</a><a class='button secondary' href='{base}/export'>Download evidence ZIP</a></div><p class='muted'>These actions use the saved tenant assessment and the project’s selected report profile. Opening this hub does not generate or persist new assessment data.</p>"""
+        output = f"""<p class='notice'><strong>Report source:</strong> assessment {html.escape(latest.id)}<br><strong>Generated:</strong> {html.escape(latest.generated_at)}</p><div class='actions'><a class='button' href='{base}/report'>Preview branded HTML</a><a class='button secondary' href='{base}/report.pdf'>Download PDF</a><a class='button secondary' href='{base}/export'>Download evidence ZIP</a><a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports/send'>Email PDF report</a></div><p class='muted'>These actions use the saved tenant assessment and the project’s selected report profile. Opening this hub does not generate or persist new assessment data.</p>"""
 
-    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project</a> · <a href='/agency'>Agency workflow</a></p><h1>Reports for {html.escape(project.name)}</h1><p><strong>Website:</strong> {html.escape(project.target_url)}</p></section><section><h2>Branding and content profile</h2>{profile_summary}</section><section><h2>Report outputs</h2>{output}</section>"""
+    attempts = _attempt_store(root, identity.tenant_id).list_for_project(project_id)[:10]
+    attempt_rows = "".join(
+        f"<li><strong>{html.escape(attempt.status.value)}</strong> — {html.escape(attempt.attempted_at.isoformat())} — {html.escape(str(attempt.recipient))} — attempt {attempt.attempt_number}{f' — {html.escape(attempt.error)}' if attempt.error else ''}</li>"
+        for _, attempt in attempts
+    ) or "<li>No report delivery attempts recorded.</li>"
+    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project</a> · <a href='/agency'>Agency workflow</a></p><h1>Reports for {html.escape(project.name)}</h1>{status}<p><strong>Website:</strong> {html.escape(project.target_url)}</p></section><section><h2>Branding and content profile</h2>{profile_summary}</section><section><h2>Report outputs</h2>{output}</section><section><h2>Recent delivery attempts</h2><ul>{attempt_rows}</ul><p class='muted'>Delivered means the configured SMTP server accepted the message. It does not prove receipt or opening.</p></section>"""
     return _page(f"{project.name} reports", body)
+
+
+@router.get("/projects/{project_id}/reports/send", response_class=HTMLResponse)
+def report_delivery_confirmation(project_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_reports)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    _, project, assessments, profile, _ = _context(request, identity, project_id)
+    if not assessments:
+        raise HTTPException(status_code=404, detail="Report source not found.")
+    client = profile.client_name or project.client_label or project.name
+    subject = f"Website assessment report for {client}"
+    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Report hub</a></p><h1>Email branded PDF report</h1><p class='notice'>The latest saved tenant assessment will be rendered with the project’s selected report profile and attached as a PDF. No email is sent by opening this page.</p><form method='post' action='/agency/projects/{html.escape(project_id, quote=True)}/reports/send'><label for='recipient'>Recipient</label><input id='recipient' name='recipient' type='email' required><label for='subject'>Subject</label><input id='subject' name='subject' maxlength='200' value='{html.escape(subject, quote=True)}' required><label for='message'>Message</label><textarea id='message' name='message' maxlength='4000'>Please find your website assessment report attached.</textarea><p><button type='submit'>Send PDF report</button> <a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Cancel</a></p></form></section>"""
+    return _page("Email PDF report", body)
+
+
+@router.post("/projects/{project_id}/reports/send")
+async def submit_report_delivery(project_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_reports)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    root, project, assessments, profile, _ = _context(request, identity, project_id)
+    if not assessments:
+        raise HTTPException(status_code=404, detail="Report source not found.")
+    body = await request.body()
+    try:
+        payload = DeliveryInput(
+            recipient=_single(body, "recipient"),
+            subject=_single(body, "subject"),
+            message=_single(body, "message"),
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="Report delivery input is invalid.") from exc
+    latest = assessments[0]
+    history = TenantHistoryStore(root)
+    try:
+        assessment = history.load(
+            identity,
+            history.ref(identity, project_id, latest.id),
+        )
+        document = render_pdf(
+            render_report(assessment, profile),
+            target=str(assessment.target),
+        )
+        attempt = send_report_pdf(
+            project_id=project_id,
+            assessment_id=latest.id,
+            recipient=str(payload.recipient),
+            subject=payload.subject,
+            message_text=payload.message,
+            pdf_content=document.content,
+            filename=document.filename,
+            store=_attempt_store(root, identity.tenant_id),
+        )
+    except (TenantHistoryStoreError, PdfRenderError) as exc:
+        raise HTTPException(status_code=404, detail="Report source not found.") from exc
+    except EmailDeliveryError as exc:
+        raise HTTPException(status_code=503, detail="Report delivery could not be prepared.") from exc
+    delivery = "not-configured" if attempt is None else attempt.status.value
+    return RedirectResponse(
+        f"/agency/projects/{project_id}/reports?{urlencode({'delivery': delivery})}",
+        status_code=303,
+    )

--- a/src/veridra/agency_report_web.py
+++ b/src/veridra/agency_report_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import html
 from pathlib import Path
+from typing import Any
 from urllib.parse import parse_qs, urlencode
 
 from fastapi import APIRouter, HTTPException, Request
@@ -67,7 +68,11 @@ def _profile(
         raise HTTPException(status_code=404, detail="Report source not found.") from exc
 
 
-def _context(request: Request, identity: RequestIdentity, project_id: str):
+def _context(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+) -> tuple[Path | None, Any, list[Any], ReportProfile, bool]:
     root = _root(request)
     projects = TenantProjectStore(root)
     history = TenantHistoryStore(root)

--- a/src/veridra/report_delivery.py
+++ b/src/veridra/report_delivery.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import smtplib
+from collections.abc import Callable
+from datetime import UTC, datetime
+from email.message import EmailMessage
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+from .email_delivery import EmailDeliveryError, EmailStatus, SmtpConfig, _default_sender
+
+_MAX_MESSAGE_BYTES = 25_000_000
+
+
+class ReportDeliveryAttempt(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    recipient: EmailStr
+    attempted_at: datetime
+    status: EmailStatus
+    subject: str = Field(min_length=1, max_length=200)
+    message_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    attempt_number: int = Field(ge=1)
+    project_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    assessment_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    filename: str = Field(min_length=1, max_length=180)
+    error: str = Field(default="", max_length=1000)
+
+
+class ReportDeliveryStore:
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def _path(self, identifier: str) -> Path:
+        if len(identifier) != 24 or any(char not in "0123456789abcdef" for char in identifier):
+            raise EmailDeliveryError("Invalid report-delivery identifier.")
+        return self.directory / f"{identifier}.json"
+
+    def save(self, attempt: ReportDeliveryAttempt) -> str:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        content = json.dumps(
+            attempt.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        identifier = hashlib.sha256(content).hexdigest()[:24]
+        destination = self._path(identifier)
+        with NamedTemporaryFile(
+            mode="wb",
+            dir=self.directory,
+            prefix=f".{identifier}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(destination)
+        return identifier
+
+    def list_for_project(self, project_id: str) -> list[tuple[str, ReportDeliveryAttempt]]:
+        self._path(project_id)
+        if not self.directory.exists():
+            return []
+        attempts: list[tuple[str, ReportDeliveryAttempt]] = []
+        for path in self.directory.glob("*.json"):
+            try:
+                attempt = ReportDeliveryAttempt.model_validate_json(
+                    path.read_text(encoding="utf-8")
+                )
+            except (OSError, ValueError):
+                continue
+            if attempt.project_id == project_id:
+                attempts.append((path.stem, attempt))
+        return sorted(
+            attempts,
+            key=lambda item: (item[1].attempted_at, item[1].attempt_number, item[0]),
+            reverse=True,
+        )
+
+
+ReportSender = Callable[[SmtpConfig, EmailMessage], None]
+
+
+def send_report_pdf(
+    *,
+    project_id: str,
+    assessment_id: str,
+    recipient: str,
+    subject: str,
+    message_text: str,
+    pdf_content: bytes,
+    filename: str,
+    store: ReportDeliveryStore,
+    config: SmtpConfig | None = None,
+    sender: ReportSender = _default_sender,
+) -> ReportDeliveryAttempt | None:
+    active = config if config is not None else SmtpConfig.from_environment()
+    if active is None:
+        return None
+    email = EmailMessage()
+    email["From"] = f"{active.sender_name} <{active.sender_email}>"
+    email["To"] = recipient
+    email["Subject"] = subject
+    body = message_text or "Your website assessment report is attached."
+    email.set_content(body)
+    email.add_attachment(
+        pdf_content,
+        maintype="application",
+        subtype="pdf",
+        filename=filename,
+    )
+    raw = email.as_bytes()
+    if len(raw) > _MAX_MESSAGE_BYTES:
+        raise EmailDeliveryError("Generated report email exceeds the 25 MB delivery limit.")
+    digest = hashlib.sha256(raw).hexdigest()
+    prior = store.list_for_project(project_id)
+    status = EmailStatus.delivered
+    error = ""
+    try:
+        sender(active, email)
+    except (OSError, smtplib.SMTPException, EmailDeliveryError, ValueError) as exc:
+        status = EmailStatus.failed
+        error = str(exc)[:1000]
+    attempt = ReportDeliveryAttempt(
+        recipient=recipient,
+        attempted_at=datetime.now(UTC),
+        status=status,
+        subject=subject,
+        message_sha256=digest,
+        attempt_number=len(prior) + 1,
+        project_id=project_id,
+        assessment_id=assessment_id,
+        filename=filename,
+        error=error,
+    )
+    store.save(attempt)
+    return attempt

--- a/tests/test_agency_report_delivery_web.py
+++ b/tests/test_agency_report_delivery_web.py
@@ -1,0 +1,147 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra import agency_report_web
+from veridra.agency_report_web import router
+from veridra.core import demo_assessment
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.pdf_reports import PdfDocument
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_history_store import TenantHistoryStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 12, 0, tzinfo=UTC)
+MANAGER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.analyst,
+    session_id="report-delivery-manager-01",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="report-delivery-viewer-001",
+    authenticated_at=NOW,
+)
+
+
+def _client(tmp_path: Path, *, with_assessment: bool = True) -> tuple[TestClient, str]:
+    root = tmp_path / "tenants"
+    project_id = TenantProjectStore(root).save(
+        MANAGER,
+        ClientProject.build(name="Client <Report>", target_url="https://example.com"),
+    )
+    if with_assessment:
+        TenantHistoryStore(root).save(MANAGER, project_id, demo_assessment())
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "manager":
+            bind_verified_request_identity(request, MANAGER)
+        elif role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app), project_id
+
+
+def test_delivery_confirmation_requires_identity_and_permission(tmp_path: Path) -> None:
+    client, project_id = _client(tmp_path)
+
+    anonymous = client.get(f"/agency/projects/{project_id}/reports/send")
+    viewer = client.get(
+        f"/agency/projects/{project_id}/reports/send",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert anonymous.status_code == 401
+    assert viewer.status_code == 403
+
+
+def test_delivery_confirmation_is_read_only_and_escaped(tmp_path: Path) -> None:
+    client, project_id = _client(tmp_path)
+    project_path = tmp_path / "tenants" / MANAGER.tenant_id / "projects" / f"{project_id}.json"
+    before = project_path.read_bytes()
+
+    response = client.get(
+        f"/agency/projects/{project_id}/reports/send",
+        headers={"x-test-role": "manager"},
+    )
+
+    assert response.status_code == 200
+    assert "Client &lt;Report&gt;" in response.text
+    assert "Client <Report>" not in response.text
+    assert project_path.read_bytes() == before
+    assert not (tmp_path / "tenants" / MANAGER.tenant_id / "report-deliveries").exists()
+
+
+def test_submit_without_smtp_redirects_to_not_configured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, project_id = _client(tmp_path)
+    monkeypatch.delenv("VERIDRA_SMTP_HOST", raising=False)
+    monkeypatch.delenv("VERIDRA_SMTP_SENDER", raising=False)
+    monkeypatch.setattr(
+        agency_report_web,
+        "render_pdf",
+        lambda _html, *, target: PdfDocument(b"%PDF-test", "report.pdf"),
+    )
+
+    response = client.post(
+        f"/agency/projects/{project_id}/reports/send",
+        headers={"x-test-role": "manager"},
+        data={
+            "recipient": "client@example.com",
+            "subject": "Assessment",
+            "message": "Attached.",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == (
+        f"/agency/projects/{project_id}/reports?delivery=not-configured"
+    )
+
+
+def test_invalid_delivery_input_is_rejected(tmp_path: Path) -> None:
+    client, project_id = _client(tmp_path)
+
+    response = client.post(
+        f"/agency/projects/{project_id}/reports/send",
+        headers={"x-test-role": "manager"},
+        data={"recipient": "invalid", "subject": "", "message": ""},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Report delivery input is invalid."}
+
+
+def test_delivery_requires_saved_assessment(tmp_path: Path) -> None:
+    client, project_id = _client(tmp_path, with_assessment=False)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/reports/send",
+        headers={"x-test-role": "manager"},
+    )
+
+    assert response.status_code == 404

--- a/tests/test_report_delivery.py
+++ b/tests/test_report_delivery.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from email.message import EmailMessage
+from pathlib import Path
+
+import pytest
+
+from veridra.email_delivery import EmailStatus, SmtpConfig
+from veridra.report_delivery import ReportDeliveryStore, send_report_pdf
+
+
+def _config() -> SmtpConfig:
+    return SmtpConfig(
+        host="mail.test",
+        port=587,
+        sender_email="reports@example.com",
+        sender_name="Agency",
+    )
+
+
+def test_report_delivery_records_attachment_and_success(tmp_path: Path) -> None:
+    messages: list[EmailMessage] = []
+    store = ReportDeliveryStore(tmp_path)
+
+    attempt = send_report_pdf(
+        project_id="a" * 24,
+        assessment_id="b" * 24,
+        recipient="client@example.com",
+        subject="Your report",
+        message_text="Attached.",
+        pdf_content=b"%PDF-test",
+        filename="assessment.pdf",
+        store=store,
+        config=_config(),
+        sender=lambda _config, message: messages.append(message),
+    )
+
+    assert attempt is not None
+    assert attempt.status == EmailStatus.delivered
+    assert attempt.attempt_number == 1
+    attachment = next(messages[0].iter_attachments())
+    assert attachment.get_filename() == "assessment.pdf"
+    assert attachment.get_content_type() == "application/pdf"
+    assert store.list_for_project("a" * 24)[0][1] == attempt
+
+
+def test_report_delivery_records_failure_and_retry(tmp_path: Path) -> None:
+    store = ReportDeliveryStore(tmp_path)
+
+    def fail(_config: SmtpConfig, _message: EmailMessage) -> None:
+        raise OSError("delivery unavailable")
+
+    first = send_report_pdf(
+        project_id="a" * 24,
+        assessment_id="b" * 24,
+        recipient="client@example.com",
+        subject="Your report",
+        message_text="Attached.",
+        pdf_content=b"%PDF-test",
+        filename="assessment.pdf",
+        store=store,
+        config=_config(),
+        sender=fail,
+    )
+    second = send_report_pdf(
+        project_id="a" * 24,
+        assessment_id="b" * 24,
+        recipient="client@example.com",
+        subject="Your report",
+        message_text="Attached.",
+        pdf_content=b"%PDF-test",
+        filename="assessment.pdf",
+        store=store,
+        config=_config(),
+        sender=lambda _config, _message: None,
+    )
+
+    assert first is not None and first.status == EmailStatus.failed
+    assert second is not None and second.status == EmailStatus.delivered
+    assert second.attempt_number == 2
+    assert len(store.list_for_project("a" * 24)) == 2
+
+
+def test_report_delivery_returns_none_without_configuration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("VERIDRA_SMTP_HOST", raising=False)
+    monkeypatch.delenv("VERIDRA_SMTP_SENDER", raising=False)
+
+    attempt = send_report_pdf(
+        project_id="a" * 24,
+        assessment_id="b" * 24,
+        recipient="client@example.com",
+        subject="Your report",
+        message_text="Attached.",
+        pdf_content=b"%PDF-test",
+        filename="assessment.pdf",
+        store=ReportDeliveryStore(tmp_path),
+    )
+
+    assert attempt is None
+    assert list(tmp_path.glob("*.json")) == []


### PR DESCRIPTION
Implements issue #108 from current main `8f888d193ebac220591327489d5a510ee423856b`.

## What changed

- adds an explicit report-delivery confirmation flow to the project-attached report hub;
- resolves project, latest assessment and report profile through verified tenant identity;
- renders the branded PDF server-side and attaches only that generated document;
- reuses the existing SMTP configuration and sender boundary;
- records tenant-scoped immutable report-delivery attempts with recipient, subject, digest, attempt number, project ID, assessment ID, filename, status and bounded error;
- shows delivered, failed and SMTP-not-configured outcomes without claiming inbox placement or opening;
- supports explicit safe retries as new attempts;
- shows recent attempt history on the report hub;
- requires `manage_reports` and POST for sending;
- keeps GET routes read-only and escapes operator-visible content;
- adds service and route tests for success, attachment, failure, retry, missing SMTP, authentication, permissions, escaping, invalid input and missing assessment.

## Boundaries

- no open tracking or CTA analytics;
- no bulk or scheduled campaigns;
- no arbitrary attachments;
- no client-controlled tenant, project, assessment or profile identity;
- no claim that SMTP acceptance proves receipt.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Closes #108 when fully validated and merged. Related to #87.