### PR TITLE
Add canonical tenant lead-to-project conversion backend

### DIFF
--- a/src/veridra/lead_project_conversion_api.py
+++ b/src/veridra/lead_project_conversion_api.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from .assessment_project_conversion_api import (
+    AssessmentProjectConversion,
+    AssessmentProjectCreated,
+    convert_assessment,
+)
+from .history import HistoryError, HistoryStore
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .lead_project_link_store import (
+    LeadProjectLink,
+    LeadProjectLinkError,
+    LeadProjectLinkStore,
+)
+from .lead_store import LeadStatus
+from .request_security import require_request_capability
+from .tenant_lead_form_store import TenantLeadFormStore, TenantLeadFormStoreError
+from .tenant_lead_store import TenantLeadStore, TenantLeadStoreError
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+
+LeadConverter = Annotated[
+    RequestIdentity,
+    Depends(require_request_capability(TenantCapability.manage_leads)),
+]
+
+
+class LeadProjectConversion(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    project_name: str = Field(min_length=1, max_length=120)
+    client_label: str | None = Field(default=None, max_length=120)
+
+
+class LeadProjectCreated(AssessmentProjectCreated):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    lead_id: str
+    existing: bool = False
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _links(request: Request, identity: RequestIdentity) -> LeadProjectLinkStore:
+    root = _root(request)
+    base = root if root is not None else Path.home() / ".veridra" / "tenants"
+    return LeadProjectLinkStore(base / identity.tenant_id / "lead-project-links")
+
+
+def _not_found(exc: Exception) -> HTTPException:
+    return HTTPException(status_code=404, detail="Lead conversion source not found.")
+
+
+def convert_lead_to_project(
+    lead_id: str,
+    payload: LeadProjectConversion,
+    request: Request,
+    identity: RequestIdentity,
+) -> LeadProjectCreated:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+
+    root = _root(request)
+    leads = TenantLeadStore(root)
+    projects = TenantProjectStore(root)
+    links = _links(request, identity)
+    try:
+        lead = leads.load(identity, leads.ref(identity, lead_id))
+        existing = links.load(lead_id)
+    except (TenantLeadStoreError, LeadProjectLinkError) as exc:
+        raise _not_found(exc) from exc
+
+    if existing is not None:
+        try:
+            projects.load(identity, projects.ref(identity, existing.project_id))
+        except TenantProjectStoreError as exc:
+            raise _not_found(exc) from exc
+        if lead.status != LeadStatus.won:
+            leads.replace(
+                identity,
+                leads.ref(identity, lead_id),
+                lead.model_copy(update={"status": LeadStatus.won}),
+            )
+        return LeadProjectCreated(
+            lead_id=lead_id,
+            project_id=existing.project_id,
+            assessment_id=existing.assessment_id,
+            existing=True,
+        )
+
+    try:
+        assessment = HistoryStore().load(lead.assessment_id)
+        if str(assessment.target) != str(lead.website):
+            raise HistoryError("Lead assessment target does not match the lead website.")
+        forms = TenantLeadFormStore(root)
+        form = forms.load(identity, forms.ref(identity, lead.form_id))
+    except (HistoryError, TenantLeadFormStoreError) as exc:
+        raise _not_found(exc) from exc
+
+    created = convert_assessment(
+        AssessmentProjectConversion(
+            assessment=assessment,
+            project_name=payload.project_name,
+            client_label=payload.client_label,
+            profile_id=form.profile_id,
+        ),
+        request,
+        identity,
+    )
+    try:
+        links.save(
+            LeadProjectLink(
+                lead_id=lead_id,
+                project_id=created.project_id,
+                assessment_id=created.assessment_id,
+            )
+        )
+        leads.replace(
+            identity,
+            leads.ref(identity, lead_id),
+            lead.model_copy(update={"status": LeadStatus.won}),
+        )
+    except (LeadProjectLinkError, TenantLeadStoreError) as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Lead conversion could not be completed.",
+        ) from exc
+    return LeadProjectCreated(
+        lead_id=lead_id,
+        project_id=created.project_id,
+        assessment_id=created.assessment_id,
+    )
+
+
+router = APIRouter(tags=["lead-project-conversion"])
+
+
+@router.post(
+    "/api/tenant/leads/{lead_id}/convert-project",
+    response_model=LeadProjectCreated,
+    status_code=status.HTTP_201_CREATED,
+)
+def convert_tenant_lead_to_project(
+    lead_id: str,
+    payload: LeadProjectConversion,
+    request: Request,
+    identity: LeadConverter,
+) -> LeadProjectCreated:
+    return convert_lead_to_project(lead_id, payload, request, identity)

--- a/src/veridra/lead_project_link_store.py
+++ b/src/veridra/lead_project_link_store.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LeadProjectLinkError(RuntimeError):
+    pass
+
+
+class LeadProjectLink(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    lead_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    project_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    assessment_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+
+
+class LeadProjectLinkStore:
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def _path(self, lead_id: str) -> Path:
+        if len(lead_id) != 24 or any(char not in "0123456789abcdef" for char in lead_id):
+            raise LeadProjectLinkError("Invalid lead identifier.")
+        return self.directory / f"{lead_id}.json"
+
+    def load(self, lead_id: str) -> LeadProjectLink | None:
+        try:
+            return LeadProjectLink.model_validate_json(
+                self._path(lead_id).read_text(encoding="utf-8")
+            )
+        except FileNotFoundError:
+            return None
+        except (OSError, ValueError) as exc:
+            raise LeadProjectLinkError("Lead project link could not be read safely.") from exc
+
+    def save(self, link: LeadProjectLink) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        destination = self._path(link.lead_id)
+        content = json.dumps(
+            link.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        with NamedTemporaryFile(
+            mode="wb",
+            dir=self.directory,
+            prefix=f".{link.lead_id}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(destination)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -20,6 +20,7 @@ from .existing_user_invitation_api import router as existing_user_invitation_rou
 from .finding_task_api import router as finding_task_router
 from .invitation_api import router as invitation_router
 from .lead_form_tenant_binding_api import router as lead_form_tenant_binding_router
+from .lead_project_conversion_api import router as lead_project_conversion_router
 from .lead_web import router as lead_router
 from .member_assignments_web import router as member_assignments_router
 from .monitoring_job_api import router as monitoring_job_router
@@ -100,6 +101,7 @@ app.include_router(assessment_project_conversion_router)
 app.include_router(tenant_history_router)
 app.include_router(tenant_report_router)
 app.include_router(tenant_lead_router)
+app.include_router(lead_project_conversion_router)
 app.include_router(tenant_lead_form_router)
 app.include_router(tenant_task_router)
 app.include_router(finding_task_router)

--- a/tests/test_lead_project_conversion_api.py
+++ b/tests/test_lead_project_conversion_api.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from fastapi import FastAPI, HTTPException
+from pydantic import HttpUrl
 from starlette.requests import Request
 
 from veridra.core import demo_assessment
@@ -66,7 +67,7 @@ def _lead_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path
     )
     lead = AuditLead(
         form_id=form_id,
-        website="https://example.com/",
+        website=HttpUrl("https://example.com/"),
         name="Alex Client",
         email="alex@example.com",
         company="Client Co",

--- a/tests/test_lead_project_conversion_api.py
+++ b/tests/test_lead_project_conversion_api.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from starlette.requests import Request
+
+from veridra.core import demo_assessment
+from veridra.history import HistoryStore
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.lead_project_conversion_api import (
+    LeadProjectConversion,
+    convert_lead_to_project,
+)
+from veridra.lead_project_link_store import LeadProjectLinkStore
+from veridra.lead_store import AuditLead, LeadFormConfig, LeadStatus
+from veridra.tenant_history_store import TenantHistoryStore
+from veridra.tenant_lead_form_store import TenantLeadFormStore
+from veridra.tenant_lead_store import TenantLeadStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 13, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="lead-project-conversion-01",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="lead-project-viewer-0001",
+    authenticated_at=NOW,
+)
+
+
+def _request(root: Path) -> Request:
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/tenant/leads/test/convert-project",
+            "headers": [],
+            "app": app,
+        }
+    )
+
+
+def _lead_fixture(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, str, str]:
+    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))
+    root = tmp_path / "tenants"
+    assessment = demo_assessment().model_copy(update={"target": "https://example.com/"})
+    assessment_id = HistoryStore().save(assessment)
+    form_id = TenantLeadFormStore(root).save(
+        OWNER,
+        LeadFormConfig(
+            organisation_label="Agency",
+            consent_text="I agree to be contacted.",
+        ),
+    )
+    lead = AuditLead(
+        form_id=form_id,
+        website="https://example.com/",
+        name="Alex Client",
+        email="alex@example.com",
+        company="Client Co",
+        consent_text="I agree to be contacted.",
+        consented_at=NOW,
+        assessment_id=assessment_id,
+    )
+    lead_id = TenantLeadStore(root).save(OWNER, lead)
+    return root, lead_id, assessment_id
+
+
+def test_lead_conversion_creates_project_and_marks_lead_won(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, lead_id, source_assessment_id = _lead_fixture(tmp_path, monkeypatch)
+
+    created = convert_lead_to_project(
+        lead_id,
+        LeadProjectConversion(project_name="Client website", client_label="Client Co"),
+        _request(root),
+        OWNER,
+    )
+
+    assert created.lead_id == lead_id
+    assert created.existing is False
+    project = TenantProjectStore(root).load(
+        OWNER,
+        TenantProjectStore(root).ref(OWNER, created.project_id),
+    )
+    assert project.target_url == "https://example.com/"
+    saved = TenantHistoryStore(root).load(
+        OWNER,
+        TenantHistoryStore(root).ref(OWNER, created.project_id, created.assessment_id),
+    )
+    assert str(saved.target) == "https://example.com/"
+    assert source_assessment_id == created.assessment_id
+    lead = TenantLeadStore(root).load(
+        OWNER,
+        TenantLeadStore(root).ref(OWNER, lead_id),
+    )
+    assert lead.status == LeadStatus.won
+
+
+def test_lead_conversion_is_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, lead_id, _ = _lead_fixture(tmp_path, monkeypatch)
+    payload = LeadProjectConversion(project_name="Client website", client_label="Client Co")
+
+    first = convert_lead_to_project(lead_id, payload, _request(root), OWNER)
+    second = convert_lead_to_project(lead_id, payload, _request(root), OWNER)
+
+    assert second.existing is True
+    assert second.project_id == first.project_id
+    assert second.assessment_id == first.assessment_id
+    links = LeadProjectLinkStore(root / OWNER.tenant_id / "lead-project-links")
+    assert links.load(lead_id) is not None
+    assert len(TenantProjectStore(root).list(OWNER)) == 1
+
+
+def test_viewer_cannot_convert_lead(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, lead_id, _ = _lead_fixture(tmp_path, monkeypatch)
+
+    with pytest.raises(HTTPException) as captured:
+        convert_lead_to_project(
+            lead_id,
+            LeadProjectConversion(project_name="Forbidden"),
+            _request(root),
+            VIEWER,
+        )
+
+    assert captured.value.status_code == 403
+
+
+def test_missing_source_assessment_is_concealed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, lead_id, assessment_id = _lead_fixture(tmp_path, monkeypatch)
+    HistoryStore().delete(assessment_id)
+
+    with pytest.raises(HTTPException) as captured:
+        convert_lead_to_project(
+            lead_id,
+            LeadProjectConversion(project_name="Client website"),
+            _request(root),
+            OWNER,
+        )
+
+    assert captured.value.status_code == 404
+    assert captured.value.detail == "Lead conversion source not found."


### PR DESCRIPTION
Implements the backend boundary for issue #110 from current main `a49cae229de8801d3dd3dcd07ec9b7b5ac6079f8`.

## What changed

- adds a tenant lead-to-project conversion API;
- requires tenant lead ownership plus `manage_projects` capability;
- loads the lead’s referenced legacy assessment server-side;
- verifies the assessment target exactly matches the lead website;
- loads the originating tenant lead form and preserves its selected report profile;
- delegates project creation, capacity checks, profile concealment and assessment persistence to the existing assessment conversion service;
- persists a tenant-local lead-to-project link;
- returns the linked project idempotently on repeated conversion;
- marks the lead `won` only after project, assessment and link persistence;
- repairs the lead status on a repeated request if the durable link already exists;
- registers the API in the composed runtime;
- adds tests for successful conversion, saved tenant assessment, lead status, idempotency, viewer denial and missing source concealment.

## Boundaries

- backend only; the explicit operator confirmation UI remains in issue #110;
- no automatic conversion during public lead capture;
- no arbitrary assessment selection;
- no deletion of source lead or legacy assessment;
- no client-controlled tenant, project, assessment or profile identity.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Part of #110. Related to #87.