### PR TITLE
Complete tenant lead-to-project operator workflow

### DIFF
--- a/src/veridra/agency_lead_web.py
+++ b/src/veridra/agency_lead_web.py
@@ -88,7 +88,11 @@ def agency_leads(request: Request) -> str:
     return _page("Audit leads", body)
 
 
-@router.get("/leads/{lead_id}/convert", response_class=HTMLResponse)
+@router.get(
+    "/leads/{lead_id}/convert",
+    response_class=HTMLResponse,
+    response_model=None,
+)
 def lead_conversion_confirmation(
     lead_id: str,
     request: Request,

--- a/src/veridra/agency_lead_web.py
+++ b/src/veridra/agency_lead_web.py
@@ -89,7 +89,10 @@ def agency_leads(request: Request) -> str:
 
 
 @router.get("/leads/{lead_id}/convert", response_class=HTMLResponse)
-def lead_conversion_confirmation(lead_id: str, request: Request) -> str:
+def lead_conversion_confirmation(
+    lead_id: str,
+    request: Request,
+) -> str | RedirectResponse:
     identity = require_request_identity(request)
     _require_conversion_capabilities(identity)
     leads = TenantLeadStore(_root(request))

--- a/src/veridra/agency_lead_web.py
+++ b/src/veridra/agency_lead_web.py
@@ -1,0 +1,122 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .lead_project_conversion_api import LeadProjectConversion, convert_lead_to_project
+from .lead_project_link_store import LeadProjectLinkError, LeadProjectLinkStore
+from .request_security import require_request_identity
+from .tenant_lead_store import TenantLeadStore, TenantLeadStoreError
+
+router = APIRouter(prefix="/agency", tags=["agency-leads"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1050px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}label{display:block;font-weight:700;margin:12px 0 5px}input{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}@media(max-width:700px){.row{grid-template-columns:1fr}table{display:block;overflow:auto}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _links(request: Request, identity: RequestIdentity) -> LeadProjectLinkStore:
+    root = _root(request)
+    base = root if root is not None else Path.home() / ".veridra" / "tenants"
+    return LeadProjectLinkStore(base / identity.tenant_id / "lead-project-links")
+
+
+def _single(body: bytes, name: str) -> str:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
+
+
+def _require_conversion_capabilities(identity: RequestIdentity) -> None:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+
+
+@router.get("/leads", response_class=HTMLResponse)
+def agency_leads(request: Request) -> str:
+    identity = require_request_identity(request)
+    leads = TenantLeadStore(_root(request))
+    try:
+        entries = leads.list(identity)
+    except TenantLeadStoreError as exc:
+        raise HTTPException(status_code=404, detail="Lead data not found.") from exc
+    link_store = _links(request, identity)
+    rows: list[str] = []
+    for lead_id, lead in entries:
+        try:
+            link = link_store.load(lead_id)
+        except LeadProjectLinkError as exc:
+            raise HTTPException(status_code=404, detail="Lead data not found.") from exc
+        action = (
+            f"<a class='button secondary' href='/agency/projects/{html.escape(link.project_id, quote=True)}'>Open project</a>"
+            if link is not None
+            else f"<a class='button' href='/agency/leads/{html.escape(lead_id, quote=True)}/convert'>Convert to client project</a>"
+        )
+        rows.append(
+            f"<tr><td>{html.escape(lead.name)}<br><span class='muted'>{html.escape(lead.company or 'No company')}</span></td><td>{html.escape(str(lead.website))}</td><td>{html.escape(str(lead.email))}</td><td>{html.escape(lead.status.value)}</td><td>{action}</td></tr>"
+        )
+    table = (
+        "<table><thead><tr><th>Prospect</th><th>Website</th><th>Email</th><th>Status</th><th>Next action</th></tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+        if rows
+        else "<p class='notice'>No tenant audit leads are available yet.</p>"
+    )
+    body = f"<section><p><a href='/agency'>Agency workflow</a></p><h1>Audit leads</h1><p class='muted'>Convert a qualified captured audit into persistent client work without re-entering its website or assessment.</p>{table}</section>"
+    return _page("Audit leads", body)
+
+
+@router.get("/leads/{lead_id}/convert", response_class=HTMLResponse)
+def lead_conversion_confirmation(lead_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    _require_conversion_capabilities(identity)
+    leads = TenantLeadStore(_root(request))
+    try:
+        lead = leads.load(identity, leads.ref(identity, lead_id))
+        link = _links(request, identity).load(lead_id)
+    except (TenantLeadStoreError, LeadProjectLinkError) as exc:
+        raise HTTPException(status_code=404, detail="Lead conversion source not found.") from exc
+    if link is not None:
+        return RedirectResponse(f"/agency/projects/{link.project_id}", status_code=303)
+    project_name = lead.company or f"{lead.name} website"
+    client_label = lead.company or lead.name
+    body = f"""<section><p><a href='/agency/leads'>Audit leads</a></p><h1>Convert lead to client project</h1><p class='notice'><strong>Prospect:</strong> {html.escape(lead.name)}<br><strong>Website:</strong> {html.escape(str(lead.website))}<br><strong>Assessment:</strong> {html.escape(lead.assessment_id)}</p><p>The website, assessment and tenant report profile are resolved server-side from this tenant-owned lead. Opening this page creates nothing.</p><form method='post' action='/agency/leads/{html.escape(lead_id, quote=True)}/convert'><div class='row'><div><label for='project_name'>Project name</label><input id='project_name' name='project_name' maxlength='120' value='{html.escape(project_name, quote=True)}' required></div><div><label for='client_label'>Client label</label><input id='client_label' name='client_label' maxlength='120' value='{html.escape(client_label, quote=True)}'></div></div><p><button type='submit'>Create client project</button> <a class='button secondary' href='/agency/leads'>Cancel</a></p></form></section>"""
+    return _page("Convert lead", body)
+
+
+@router.post("/leads/{lead_id}/convert")
+async def submit_lead_conversion(lead_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    _require_conversion_capabilities(identity)
+    body = await request.body()
+    try:
+        payload = LeadProjectConversion(
+            project_name=_single(body, "project_name"),
+            client_label=_single(body, "client_label") or None,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="Lead conversion input is invalid.") from exc
+    created = convert_lead_to_project(lead_id, payload, request, identity)
+    return RedirectResponse(f"/agency/projects/{created.project_id}", status_code=303)

--- a/src/veridra/agency_workflow_web.py
+++ b/src/veridra/agency_workflow_web.py
@@ -57,7 +57,7 @@ def agency_workflow_home() -> str:
     <section><h2>Agency operations</h2><p class='muted'>Existing capabilities remain separate security and persistence boundaries; this page provides one understandable entry point.</p>
     <div class='links'>
       <a href='/profiles'><strong>Report profiles</strong><br><span class='muted'>Brand and configure reports.</span></a>
-      <a href='/leads'><strong>Leads</strong><br><span class='muted'>Review captured prospects.</span></a>
+      <a href='/agency/leads'><strong>Leads</strong><br><span class='muted'>Review captured prospects and convert qualified audits into client projects.</span></a>
       <a href='/lead-forms'><strong>Lead forms</strong><br><span class='muted'>Configure embedded capture.</span></a>
       <a href='/tasks'><strong>Remediation tasks</strong><br><span class='muted'>Track implementation work.</span></a>
       <a href='/commercial'><strong>Commercial operations</strong><br><span class='muted'>Follow-up and engagement evidence.</span></a>

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -6,6 +6,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from . import app as app_module
 from . import public_web
 from .agency_conversion_web import router as agency_conversion_router
+from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
 from .agency_report_web import router as agency_report_router
 from .agency_task_web import router as agency_task_router
@@ -121,6 +122,7 @@ app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)
 app.include_router(agency_conversion_router)
+app.include_router(agency_lead_router)
 app.include_router(agency_task_router)
 app.include_router(agency_monitoring_router)
 app.include_router(agency_report_router)

--- a/tests/test_agency_lead_web.py
+++ b/tests/test_agency_lead_web.py
@@ -1,0 +1,167 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+from pydantic import HttpUrl
+
+from veridra.agency_lead_web import router
+from veridra.core import demo_assessment
+from veridra.history import HistoryStore
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.lead_project_link_store import LeadProjectLink, LeadProjectLinkStore
+from veridra.lead_store import AuditLead, LeadFormConfig
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_lead_form_store import TenantLeadFormStore
+from veridra.tenant_lead_store import TenantLeadStore
+
+NOW = datetime(2026, 7, 27, 14, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="agency-lead-owner-000001",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="agency-lead-viewer-0001",
+    authenticated_at=NOW,
+)
+
+
+def _client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient, str]:
+    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))
+    root = tmp_path / "tenants"
+    assessment = demo_assessment().model_copy(update={"target": "https://example.com/"})
+    assessment_id = HistoryStore().save(assessment)
+    form_id = TenantLeadFormStore(root).save(
+        OWNER,
+        LeadFormConfig(organisation_label="Agency", consent_text="Consent"),
+    )
+    lead_id = TenantLeadStore(root).save(
+        OWNER,
+        AuditLead(
+            form_id=form_id,
+            website=HttpUrl("https://example.com/"),
+            name="Alex <Client>",
+            email="alex@example.com",
+            company="Client Co",
+            consent_text="Consent",
+            consented_at=NOW,
+            assessment_id=assessment_id,
+        ),
+    )
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app), lead_id
+
+
+def test_lead_inbox_requires_identity_and_escapes_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, lead_id = _client(tmp_path, monkeypatch)
+
+    anonymous = client.get("/agency/leads")
+    response = client.get("/agency/leads", headers={"x-test-role": "owner"})
+
+    assert anonymous.status_code == 401
+    assert response.status_code == 200
+    assert "Alex &lt;Client&gt;" in response.text
+    assert "Alex <Client>" not in response.text
+    assert f"/agency/leads/{lead_id}/convert" in response.text
+
+
+def test_confirmation_is_read_only_and_viewer_is_denied(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, lead_id = _client(tmp_path, monkeypatch)
+    root = tmp_path / "tenants"
+    lead_path = root / OWNER.tenant_id / "leads" / f"{lead_id}.json"
+    before = lead_path.read_bytes()
+
+    viewer = client.get(
+        f"/agency/leads/{lead_id}/convert",
+        headers={"x-test-role": "viewer"},
+    )
+    owner = client.get(
+        f"/agency/leads/{lead_id}/convert",
+        headers={"x-test-role": "owner"},
+    )
+
+    assert viewer.status_code == 403
+    assert owner.status_code == 200
+    assert lead_path.read_bytes() == before
+    assert not (root / OWNER.tenant_id / "lead-project-links").exists()
+
+
+def test_submit_converts_and_redirects_to_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, lead_id = _client(tmp_path, monkeypatch)
+
+    response = client.post(
+        f"/agency/leads/{lead_id}/convert",
+        headers={"x-test-role": "owner"},
+        data={"project_name": "Client website", "client_label": "Client Co"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/agency/projects/")
+    link = LeadProjectLinkStore(
+        tmp_path / "tenants" / OWNER.tenant_id / "lead-project-links"
+    ).load(lead_id)
+    assert link is not None
+
+
+def test_existing_conversion_opens_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, lead_id = _client(tmp_path, monkeypatch)
+    store = LeadProjectLinkStore(
+        tmp_path / "tenants" / OWNER.tenant_id / "lead-project-links"
+    )
+    store.save(
+        LeadProjectLink(
+            lead_id=lead_id,
+            project_id="b" * 24,
+            assessment_id="c" * 24,
+        )
+    )
+
+    inbox = client.get("/agency/leads", headers={"x-test-role": "owner"})
+    confirmation = client.get(
+        f"/agency/leads/{lead_id}/convert",
+        headers={"x-test-role": "owner"},
+        follow_redirects=False,
+    )
+
+    assert f"/agency/projects/{'b' * 24}" in inbox.text
+    assert confirmation.status_code == 303
+    assert confirmation.headers["location"] == f"/agency/projects/{'b' * 24}"

--- a/tests/test_agency_lead_web.py
+++ b/tests/test_agency_lead_web.py
@@ -32,7 +32,7 @@ VIEWER = RequestIdentity(
     user_id="2" * 24,
     tenant_id="a" * 24,
     membership_role=TenantRole.viewer,
-    session_id="agency-lead-viewer-0001",
+    session_id="agency-lead-viewer-000001",
     authenticated_at=NOW,
 )
 


### PR DESCRIPTION
Completes issue #110 from current main `4ebbc5720d6c629c667782a1f5758dc15c0cefa8`.

## What changed

- adds a tenant-qualified agency lead inbox at `/agency/leads`;
- lists captured prospect, website, email, status and next action;
- shows **Convert to client project** only when no durable lead-project link exists;
- shows **Open project** when conversion already exists;
- adds an explicit read-only conversion confirmation page prefilled from lead company/name;
- posts only project name and client label while resolving website, assessment, tenant and report profile server-side;
- delegates conversion to the validated canonical backend merged in PR #111;
- redirects to the created or existing tenant project;
- requires both lead and project management capabilities;
- conceals missing tenant sources through generic responses;
- escapes lead content and keeps GET routes mutation-free;
- replaces the agency workspace’s legacy Leads link with the tenant lead workflow;
- registers the new agency lead router;
- adds tests for authentication, escaping, read-only confirmation, viewer denial, successful conversion, durable link creation and existing-project handoff.

## Boundaries

- no automatic conversion during public capture;
- no bulk conversion;
- no client-controlled tenant, assessment or report-profile identity;
- no deletion of source lead or consent evidence.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Closes #110 when fully validated and merged. Related to #87.