### PR TITLE
Add in-context project report profile workflow

### DIFF
--- a/src/veridra/agency_report_profile_web.py
+++ b/src/veridra/agency_report_profile_web.py
@@ -9,7 +9,13 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
-from .identity_tenancy import IdentityBoundaryError, RequestIdentity, TenantCapability, require_tenant_capability
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .project_store import ClientProject
 from .report_profiles import DEFAULT_REPORT_PROFILE, REPORT_SECTIONS, ReportProfile
 from .request_security import require_request_identity
 from .tenant_profile_store import TenantProfileStore, TenantProfileStoreError
@@ -47,7 +53,11 @@ def _require(identity: RequestIdentity) -> None:
         raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
 
 
-def _project(request: Request, identity: RequestIdentity, project_id: str):
+def _project(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+) -> tuple[TenantProjectStore, ClientProject]:
     projects = TenantProjectStore(_root(request))
     try:
         project = projects.load(identity, projects.ref(identity, project_id))

--- a/src/veridra/agency_report_profile_web.py
+++ b/src/veridra/agency_report_profile_web.py
@@ -1,0 +1,132 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .identity_tenancy import IdentityBoundaryError, RequestIdentity, TenantCapability, require_tenant_capability
+from .report_profiles import DEFAULT_REPORT_PROFILE, REPORT_SECTIONS, ReportProfile
+from .request_security import require_request_identity
+from .tenant_profile_store import TenantProfileStore, TenantProfileStoreError
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+
+router = APIRouter(prefix="/agency", tags=["agency-report-profiles"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:980px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:100px}.checks{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}.checks label{font-weight:400;margin:0}.checks input{width:auto;margin-right:7px}@media(max-width:700px){.grid,.checks{grid-template-columns:1fr}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _require(identity: RequestIdentity) -> None:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_reports)
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+
+
+def _project(request: Request, identity: RequestIdentity, project_id: str):
+    projects = TenantProjectStore(_root(request))
+    try:
+        project = projects.load(identity, projects.ref(identity, project_id))
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Report profile source not found.") from exc
+    return projects, project
+
+
+@router.get("/projects/{project_id}/reports/profile", response_class=HTMLResponse)
+def project_report_profile(project_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    _require(identity)
+    _, project = _project(request, identity, project_id)
+    profiles = TenantProfileStore(_root(request)).list(identity)
+    options = ["<option value=''>Default Veridra profile</option>"]
+    for entry in profiles:
+        selected = " selected" if entry.id == project.profile_id else ""
+        label = entry.organisation_name + (f" — {entry.client_name}" if entry.client_name else "")
+        options.append(f"<option value='{html.escape(entry.id, quote=True)}'{selected}>{html.escape(label)}</option>")
+    checks = "".join(
+        f"<label><input type='checkbox' name='sections' value='{html.escape(section, quote=True)}' checked>{html.escape(section.replace('_', ' ').title())}</label>"
+        for section in REPORT_SECTIONS
+    )
+    current = "Default Veridra profile" if project.profile_id is None else project.profile_id
+    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Report hub</a></p><h1>Report profile for {html.escape(project.name)}</h1><p class='notice'><strong>Current profile:</strong> {html.escape(current)}. Opening this page changes nothing.</p><form method='post' action='/agency/projects/{html.escape(project_id, quote=True)}/reports/profile/select'><label for='profile_id'>Use an existing profile</label><select id='profile_id' name='profile_id'>{''.join(options)}</select><p><button type='submit'>Apply selected profile</button></p></form></section><section><h2>Create and apply a new tenant profile</h2><form method='post' action='/agency/projects/{html.escape(project_id, quote=True)}/reports/profile/create'><div class='grid'><div><label for='organisation_name'>Organisation</label><input id='organisation_name' name='organisation_name' maxlength='120' required></div><div><label for='client_name'>Client</label><input id='client_name' name='client_name' maxlength='120' value='{html.escape(project.client_label or '', quote=True)}'></div><div><label for='consultant_name'>Consultant</label><input id='consultant_name' name='consultant_name' maxlength='120'></div><div><label for='agency_email'>Agency email</label><input id='agency_email' name='agency_email' maxlength='254'></div><div><label for='agency_phone'>Agency phone</label><input id='agency_phone' name='agency_phone' maxlength='80'></div><div><label for='agency_website'>Agency website</label><input id='agency_website' name='agency_website' maxlength='2048'></div><div><label for='language'>Language</label><select id='language' name='language'><option value='en'>English</option><option value='es'>Spanish</option></select></div><div><label for='accent_colour'>Accent colour</label><input id='accent_colour' name='accent_colour' value='#22272d' pattern='#[0-9A-Fa-f]{{6}}' required></div></div><label for='introduction'>Introduction</label><textarea id='introduction' name='introduction' maxlength='1200'></textarea><label for='conclusion'>Conclusion</label><textarea id='conclusion' name='conclusion' maxlength='2000'></textarea><div class='grid'><div><label for='call_to_action_label'>CTA label</label><input id='call_to_action_label' name='call_to_action_label' maxlength='80'></div><div><label for='call_to_action_url'>CTA URL</label><input id='call_to_action_url' name='call_to_action_url' maxlength='2048'></div></div><label><input type='checkbox' name='show_raw_evidence' value='yes' checked style='width:auto'> Show raw evidence</label><h3>Report sections</h3><div class='checks'>{checks}</div><p><button type='submit'>Create and apply profile</button> <a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Cancel</a></p></form></section>"""
+    return _page("Project report profile", body)
+
+
+@router.post("/projects/{project_id}/reports/profile/select")
+async def select_project_report_profile(project_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    _require(identity)
+    projects, project = _project(request, identity, project_id)
+    values = _values(await request.body())
+    profile_id = _one(values, "profile_id") or None
+    if profile_id is not None:
+        try:
+            TenantProfileStore(_root(request)).load(identity, TenantProfileStore.ref(identity, profile_id))
+        except TenantProfileStoreError as exc:
+            raise HTTPException(status_code=404, detail="Report profile source not found.") from exc
+    replacement = project.model_copy(update={"profile_id": profile_id})
+    try:
+        projects.replace(identity, projects.ref(identity, project_id), replacement)
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Report profile source not found.") from exc
+    return RedirectResponse(f"/agency/projects/{project_id}/reports?{urlencode({'profile': 'updated'})}", status_code=303)
+
+
+@router.post("/projects/{project_id}/reports/profile/create")
+async def create_project_report_profile(project_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    _require(identity)
+    projects, project = _project(request, identity, project_id)
+    values = _values(await request.body())
+    sections = tuple(values.get("sections", [])) or DEFAULT_REPORT_PROFILE.section_order
+    try:
+        profile = ReportProfile(
+            organisation_name=_one(values, "organisation_name"),
+            client_name=_one(values, "client_name") or None,
+            consultant_name=_one(values, "consultant_name") or None,
+            agency_email=_one(values, "agency_email") or None,
+            agency_phone=_one(values, "agency_phone") or None,
+            agency_website=_one(values, "agency_website") or None,
+            accent_colour=_one(values, "accent_colour"),
+            introduction=_one(values, "introduction") or None,
+            conclusion=_one(values, "conclusion") or None,
+            call_to_action_label=_one(values, "call_to_action_label") or None,
+            call_to_action_url=_one(values, "call_to_action_url") or None,
+            language=_one(values, "language"),
+            show_raw_evidence=_one(values, "show_raw_evidence") == "yes",
+            section_order=sections,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="Report profile input is invalid.") from exc
+    profiles = TenantProfileStore(_root(request))
+    profile_id = profiles.save(identity, profile)
+    replacement = project.model_copy(update={"profile_id": profile_id})
+    try:
+        projects.replace(identity, projects.ref(identity, project_id), replacement)
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Report profile source not found.") from exc
+    return RedirectResponse(f"/agency/projects/{project_id}/reports?{urlencode({'profile': 'created'})}", status_code=303)

--- a/src/veridra/agency_report_web.py
+++ b/src/veridra/agency_report_web.py
@@ -95,6 +95,7 @@ def project_report_hub(
     project_id: str,
     request: Request,
     delivery: str | None = None,
+    profile: str | None = None,
 ) -> str:
     identity = require_request_identity(request)
     try:
@@ -102,16 +103,16 @@ def project_report_hub(
     except IdentityBoundaryError as exc:
         raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
 
-    root, project, assessments, profile, is_default = _context(request, identity, project_id)
+    root, project, assessments, report_profile, is_default = _context(request, identity, project_id)
     latest = assessments[0] if assessments else None
     profile_state = "Default Veridra profile" if is_default else "Tenant report profile"
-    section_labels = ", ".join(profile.section_order)
+    section_labels = ", ".join(report_profile.section_order)
     cta = (
-        f"{profile.call_to_action_label} — {profile.call_to_action_url}"
-        if profile.call_to_action_label and profile.call_to_action_url
+        f"{report_profile.call_to_action_label} — {report_profile.call_to_action_url}"
+        if report_profile.call_to_action_label and report_profile.call_to_action_url
         else "Not configured"
     )
-    profile_summary = f"""<div class='profile'><div><strong>Profile</strong><br>{html.escape(profile_state)}</div><div><strong>Organisation</strong><br>{html.escape(profile.organisation_name)}</div><div><strong>Client</strong><br>{html.escape(profile.client_name or project.client_label or 'Not set')}</div><div><strong>Language</strong><br>{html.escape(profile.language)}</div><div><strong>Accent colour</strong><br>{html.escape(profile.accent_colour)}</div><div><strong>Call to action</strong><br>{html.escape(cta)}</div></div><p><strong>Enabled sections:</strong> {html.escape(section_labels)}</p>"""
+    profile_summary = f"""<div class='profile'><div><strong>Profile</strong><br>{html.escape(profile_state)}</div><div><strong>Organisation</strong><br>{html.escape(report_profile.organisation_name)}</div><div><strong>Client</strong><br>{html.escape(report_profile.client_name or project.client_label or 'Not set')}</div><div><strong>Language</strong><br>{html.escape(report_profile.language)}</div><div><strong>Accent colour</strong><br>{html.escape(report_profile.accent_colour)}</div><div><strong>Call to action</strong><br>{html.escape(cta)}</div></div><p><strong>Enabled sections:</strong> {html.escape(section_labels)}</p><p><a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports/profile'>Create or change report profile</a></p>"""
 
     status = ""
     if delivery == "delivered":
@@ -120,6 +121,10 @@ def project_report_hub(
         status = "<p class='notice danger'><strong>The report delivery attempt failed.</strong> Review the recent attempt details before retrying.</p>"
     elif delivery == "not-configured":
         status = "<p class='notice'><strong>Email delivery is not configured.</strong> Configure the server SMTP environment before retrying.</p>"
+    if profile == "created":
+        status += "<p class='notice success'><strong>The tenant report profile was created and applied to this project.</strong></p>"
+    elif profile == "updated":
+        status += "<p class='notice success'><strong>The project report profile was updated.</strong></p>"
 
     if latest is None:
         output = "<p class='notice'>No saved assessment is available. Run or save a tenant-qualified assessment before generating or sending a report.</p>"

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -8,6 +8,7 @@ from . import public_web
 from .agency_conversion_web import router as agency_conversion_router
 from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
+from .agency_report_profile_web import router as agency_report_profile_router
 from .agency_report_web import router as agency_report_router
 from .agency_task_web import router as agency_task_router
 from .agency_workflow_web import router as agency_workflow_router
@@ -125,6 +126,7 @@ app.include_router(agency_conversion_router)
 app.include_router(agency_lead_router)
 app.include_router(agency_task_router)
 app.include_router(agency_monitoring_router)
+app.include_router(agency_report_profile_router)
 app.include_router(agency_report_router)
 
 

--- a/tests/test_agency_report_profile_web.py
+++ b/tests/test_agency_report_profile_web.py
@@ -4,7 +4,6 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
-import pytest
 from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient
 

--- a/tests/test_agency_report_profile_web.py
+++ b/tests/test_agency_report_profile_web.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_report_profile_web import router
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_profile_store import TenantProfileStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 15, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="agency-profile-owner-001",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="agency-profile-viewer-01",
+    authenticated_at=NOW,
+)
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, str, Path]:
+    root = tmp_path / "tenants"
+    projects = TenantProjectStore(root)
+    project_id = projects.save(
+        OWNER,
+        ClientProject.build(
+            name="Client <Site>",
+            target_url="https://example.com/",
+            client_label="Client Co",
+        ),
+    )
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app), project_id, root
+
+
+def test_profile_page_requires_identity_escapes_and_is_read_only(tmp_path: Path) -> None:
+    client, project_id, root = _client(tmp_path)
+    project_path = root / OWNER.tenant_id / "projects" / f"{project_id}.json"
+    before = project_path.read_bytes()
+
+    anonymous = client.get(f"/agency/projects/{project_id}/reports/profile")
+    owner = client.get(
+        f"/agency/projects/{project_id}/reports/profile",
+        headers={"x-test-role": "owner"},
+    )
+
+    assert anonymous.status_code == 401
+    assert owner.status_code == 200
+    assert "Client &lt;Site&gt;" in owner.text
+    assert "Client <Site>" not in owner.text
+    assert project_path.read_bytes() == before
+
+
+def test_viewer_cannot_manage_project_profile(tmp_path: Path) -> None:
+    client, project_id, _ = _client(tmp_path)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/reports/profile",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_create_profile_applies_it_without_rotating_project_id(tmp_path: Path) -> None:
+    client, project_id, root = _client(tmp_path)
+
+    response = client.post(
+        f"/agency/projects/{project_id}/reports/profile/create",
+        headers={"x-test-role": "owner"},
+        data={
+            "organisation_name": "Agency One",
+            "client_name": "Client Co",
+            "language": "es",
+            "accent_colour": "#123456",
+            "show_raw_evidence": "yes",
+            "sections": ["executive_summary", "findings", "call_to_action"],
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == (
+        f"/agency/projects/{project_id}/reports?profile=created"
+    )
+    projects = TenantProjectStore(root)
+    project = projects.load(OWNER, projects.ref(OWNER, project_id))
+    assert project.profile_id is not None
+    profile = TenantProfileStore(root).load(
+        OWNER,
+        TenantProfileStore.ref(OWNER, project.profile_id),
+    )
+    assert profile.organisation_name == "Agency One"
+    assert profile.language == "es"
+    assert profile.section_order == (
+        "executive_summary",
+        "findings",
+        "call_to_action",
+    )
+    assert len(projects.list(OWNER)) == 1
+
+
+def test_select_default_profile_preserves_project_identity(tmp_path: Path) -> None:
+    client, project_id, root = _client(tmp_path)
+
+    response = client.post(
+        f"/agency/projects/{project_id}/reports/profile/select",
+        headers={"x-test-role": "owner"},
+        data={"profile_id": ""},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    projects = TenantProjectStore(root)
+    project = projects.load(OWNER, projects.ref(OWNER, project_id))
+    assert project.profile_id is None
+    assert len(projects.list(OWNER)) == 1


### PR DESCRIPTION
Completes issue #113 from current main `9eecbd26c9750ef1886281eaa95942df2d362d1d`.

## What changed

- adds a project-attached report profile page from the agency report hub;
- lists only current-tenant profiles plus the default Veridra profile;
- requires both `manage_reports` and `manage_projects` for profile selection or creation;
- keeps GET routes read-only;
- creates bounded profiles through the existing `ReportProfile` model and `TenantProfileStore`;
- supports organisation, client, consultant, agency contact, language, accent colour, introduction, conclusion, CTA, evidence visibility and section selection;
- applies the selected or newly created profile through stable tenant-project replacement;
- preserves project identity and attached assessments, tasks and monitoring relationships;
- redirects to the report hub with visible created/updated confirmation;
- escapes operator-visible project and profile values;
- registers the route in the composed runtime;
- adds tests for authentication, viewer denial, no-GET mutation, escaping, profile creation, section selection, default reset and stable project identity.

## Boundaries

- no custom-domain hosting;
- no profile deletion workflow;
- no arbitrary tenant or project identity in form data;
- no pre-rendered report content in form data;
- no logo upload UI beyond the existing backend model.

## Validation

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic repository audit and Chromium browser audit before readiness or merge.

Closes #113 when fully validated and merged. Related to #87.