### PR TITLE
Add tenant-qualified workspace persistence primitives

### DIFF
--- a/src/veridra/tenant_workspace_policy.py
+++ b/src/veridra/tenant_workspace_policy.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .identity_tenancy import (
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .tenant_project_store import default_tenant_data_directory
+from .workspace_policy import (
+    PlanName,
+    UsageEvent,
+    UsageLedger,
+    UsagePeriod,
+    WorkspaceConfig,
+    WorkspacePolicyError,
+    WorkspaceStore,
+)
+
+
+class TenantWorkspacePolicyError(RuntimeError):
+    pass
+
+
+class WorkspacePlanChange(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    actor_user_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    previous_plan: PlanName
+    new_plan: PlanName
+    changed_at: datetime
+
+
+class TenantWorkspacePolicy:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or default_tenant_data_directory()
+
+    def _workspace_directory(self, tenant_id: str) -> Path:
+        return self.root / tenant_id / "workspace"
+
+    def workspace_store(self, identity: RequestIdentity) -> WorkspaceStore:
+        return WorkspaceStore(self._workspace_directory(identity.tenant_id))
+
+    def usage_ledger(self, identity: RequestIdentity) -> UsageLedger:
+        return UsageLedger(self._workspace_directory(identity.tenant_id))
+
+    def load(self, identity: RequestIdentity) -> WorkspaceConfig:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        try:
+            return self.workspace_store(identity).load()
+        except WorkspacePolicyError as exc:
+            raise TenantWorkspacePolicyError(
+                "Tenant workspace configuration could not be read safely."
+            ) from exc
+
+    def save(self, identity: RequestIdentity, workspace: WorkspaceConfig) -> None:
+        require_tenant_capability(identity, TenantCapability.manage_tenant)
+        try:
+            self.workspace_store(identity).save(workspace)
+        except WorkspacePolicyError as exc:
+            raise TenantWorkspacePolicyError(
+                "Tenant workspace configuration could not be saved safely."
+            ) from exc
+
+    def record_usage(self, identity: RequestIdentity, event: UsageEvent) -> str:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        try:
+            return self.usage_ledger(identity).record(event)
+        except WorkspacePolicyError as exc:
+            raise TenantWorkspacePolicyError(
+                "Tenant usage evidence could not be saved safely."
+            ) from exc
+
+    def list_usage(
+        self,
+        identity: RequestIdentity,
+        *,
+        period: UsagePeriod | None = None,
+    ) -> list[tuple[str, UsageEvent]]:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        return self.usage_ledger(identity).list(period=period)
+
+    def record_plan_change(
+        self,
+        identity: RequestIdentity,
+        *,
+        previous_plan: PlanName,
+        new_plan: PlanName,
+        changed_at: datetime | None = None,
+    ) -> str:
+        require_tenant_capability(identity, TenantCapability.manage_tenant)
+        event = WorkspacePlanChange(
+            actor_user_id=identity.user_id,
+            previous_plan=previous_plan,
+            new_plan=new_plan,
+            changed_at=(changed_at or datetime.now(UTC)).astimezone(UTC),
+        )
+        content = json.dumps(
+            event.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        identifier = hashlib.sha256(content).hexdigest()[:24]
+        destination = (
+            self._workspace_directory(identity.tenant_id)
+            / "plan-changes"
+            / f"{identifier}.json"
+        )
+        if not destination.exists():
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            temporary = destination.with_suffix(".tmp")
+            temporary.write_bytes(content)
+            temporary.replace(destination)
+        return identifier
+
+    def list_plan_changes(
+        self,
+        identity: RequestIdentity,
+    ) -> list[tuple[str, WorkspacePlanChange]]:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        directory = self._workspace_directory(identity.tenant_id) / "plan-changes"
+        if not directory.exists():
+            return []
+        events: list[tuple[str, WorkspacePlanChange]] = []
+        for path in sorted(directory.glob("*.json")):
+            try:
+                event = WorkspacePlanChange.model_validate_json(
+                    path.read_text(encoding="utf-8")
+                )
+            except (OSError, ValueError):
+                continue
+            events.append((path.stem, event))
+        return sorted(events, key=lambda item: (item[1].changed_at, item[0]))

--- a/tests/test_tenant_workspace_policy.py
+++ b/tests/test_tenant_workspace_policy.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from veridra.identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantRole,
+)
+from veridra.tenant_workspace_policy import TenantWorkspacePolicy
+from veridra.workspace_policy import (
+    PlanName,
+    UsageEvent,
+    UsageKind,
+    WorkspaceConfig,
+)
+
+NOW = datetime(2026, 7, 27, 16, 0, tzinfo=UTC)
+OWNER_A = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="tenant-workspace-owner-a1",
+    authenticated_at=NOW,
+)
+OWNER_B = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.owner,
+    session_id="tenant-workspace-owner-b1",
+    authenticated_at=NOW,
+)
+VIEWER_A = RequestIdentity(
+    user_id="3" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="tenant-workspace-viewer1",
+    authenticated_at=NOW,
+)
+
+
+def test_missing_tenant_workspace_defaults_to_free(tmp_path: Path) -> None:
+    policy = TenantWorkspacePolicy(tmp_path)
+
+    workspace = policy.load(OWNER_A)
+
+    assert workspace.plan == PlanName.free
+    assert not (tmp_path / OWNER_A.tenant_id / "workspace" / "workspace.json").exists()
+
+
+def test_workspace_and_usage_are_tenant_isolated(tmp_path: Path) -> None:
+    policy = TenantWorkspacePolicy(tmp_path)
+    policy.save(
+        OWNER_A,
+        WorkspaceConfig(display_name="Agency A", plan=PlanName.professional),
+    )
+    policy.save(
+        OWNER_B,
+        WorkspaceConfig(display_name="Agency B", plan=PlanName.solo),
+    )
+    policy.record_usage(
+        OWNER_A,
+        UsageEvent(kind=UsageKind.audit, quantity=2, occurred_at=NOW),
+    )
+
+    assert policy.load(OWNER_A).plan == PlanName.professional
+    assert policy.load(OWNER_B).plan == PlanName.solo
+    assert len(policy.list_usage(OWNER_A)) == 1
+    assert policy.list_usage(OWNER_B) == []
+
+
+def test_viewer_can_read_but_cannot_change_workspace(tmp_path: Path) -> None:
+    policy = TenantWorkspacePolicy(tmp_path)
+    policy.save(OWNER_A, WorkspaceConfig(display_name="Agency A", plan=PlanName.solo))
+
+    assert policy.load(VIEWER_A).plan == PlanName.solo
+    with pytest.raises(IdentityBoundaryError):
+        policy.save(
+            VIEWER_A,
+            WorkspaceConfig(display_name="Forbidden", plan=PlanName.agency),
+        )
+
+
+def test_plan_change_records_actor_and_transition(tmp_path: Path) -> None:
+    policy = TenantWorkspacePolicy(tmp_path)
+
+    identifier = policy.record_plan_change(
+        OWNER_A,
+        previous_plan=PlanName.free,
+        new_plan=PlanName.professional,
+        changed_at=NOW,
+    )
+    repeated = policy.record_plan_change(
+        OWNER_A,
+        previous_plan=PlanName.free,
+        new_plan=PlanName.professional,
+        changed_at=NOW,
+    )
+
+    assert repeated == identifier
+    changes = policy.list_plan_changes(VIEWER_A)
+    assert len(changes) == 1
+    _, event = changes[0]
+    assert event.actor_user_id == OWNER_A.user_id
+    assert event.previous_plan == PlanName.free
+    assert event.new_plan == PlanName.professional
+    assert event.changed_at == NOW
+
+
+def test_viewer_cannot_record_plan_change(tmp_path: Path) -> None:
+    policy = TenantWorkspacePolicy(tmp_path)
+
+    with pytest.raises(IdentityBoundaryError):
+        policy.record_plan_change(
+            VIEWER_A,
+            previous_plan=PlanName.free,
+            new_plan=PlanName.solo,
+            changed_at=NOW,
+        )


### PR DESCRIPTION
Backend prerequisite for #115.

Adds tenant-scoped workspace configuration, usage ledger access, and plan-change audit records using existing identity capabilities and workspace models. Includes tests for free defaults, tenant isolation, viewer reads, owner-only changes, usage isolation, and idempotent audit evidence.

This PR does not replace the global workspace UI or quota call sites and does not close #115.

Requires full exact-head CI before merge.