### PR TITLE
Migrate workspace UI to tenant-qualified policy

### DIFF
--- a/src/veridra/workspace_web.py
+++ b/src/veridra/workspace_web.py
@@ -12,7 +12,13 @@ from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
-from .identity_tenancy import IdentityBoundaryError, TenantCapability, require_tenant_capability
+from .identity_tenancy import (
+    TENANT_ROLE_CAPABILITIES,
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
 from .request_security import require_request_identity
 from .tenant_workspace_policy import TenantWorkspacePolicy, TenantWorkspacePolicyError
 from .workspace_policy import (
@@ -57,9 +63,14 @@ def _tenant_policy(request: Request) -> TenantWorkspacePolicy:
     return TenantWorkspacePolicy(_root(request))
 
 
-def _summary_rows(policy: TenantWorkspacePolicy, identity: object, workspace: WorkspaceConfig, now: datetime) -> str:
+def _summary_rows(
+    policy: TenantWorkspacePolicy,
+    identity: RequestIdentity,
+    workspace: WorkspaceConfig,
+    now: datetime,
+) -> str:
     rows: list[str] = []
-    ledger = policy.usage_ledger(identity)  # type: ignore[arg-type]
+    ledger = policy.usage_ledger(identity)
     for kind in UsageKind:
         decision = quota_decision(workspace, ledger, kind, requested=1, now=now)
         limit = "Metered only" if decision.limit is None else str(decision.limit)
@@ -82,14 +93,21 @@ def workspace_dashboard(request: Request) -> str:
     entitlement = PLAN_CATALOGUE[workspace.plan]
     now = datetime.now(UTC)
     period = usage_period(workspace, now=now)
-    can_manage = TenantCapability.manage_tenant in require_tenant_capability.__globals__["TENANT_ROLE_CAPABILITIES"][identity.membership_role]
+    can_manage = (
+        TenantCapability.manage_tenant
+        in TENANT_ROLE_CAPABILITIES[identity.membership_role]
+    )
     change_rows = "".join(
         f"<tr><td>{html.escape(event.changed_at.isoformat())}</td><td>{html.escape(event.actor_user_id)}</td><td>{event.previous_plan.value}</td><td>{event.new_plan.value}</td></tr>"
         for _, event in reversed(changes[-10:])
     ) or "<tr><td colspan='4'>No plan changes recorded.</td></tr>"
     management = ""
     if can_manage:
-        management = f"<section><h2>Preview or apply local entitlement policy</h2><form method='get' action='/workspace/plan-preview'><div class='row'><div><label>Plan</label><select name='plan'>{''.join(f\"<option value='{plan.value}'{' selected' if plan == workspace.plan else ''}>{plan.value.title()}</option>\" for plan in PlanName)}</select></div><div><label>Cycle anchor day</label><input type='number' min='1' max='28' name='cycle_anchor_day' value='{workspace.cycle_anchor_day}'></div></div><p><button>Preview plan</button></p></form></section>"
+        options = "".join(
+            f"<option value='{plan.value}'{' selected' if plan == workspace.plan else ''}>{plan.value.title()}</option>"
+            for plan in PlanName
+        )
+        management = f"<section><h2>Preview or apply local entitlement policy</h2><form method='get' action='/workspace/plan-preview'><div class='row'><div><label>Plan</label><select name='plan'>{options}</select></div><div><label>Cycle anchor day</label><input type='number' min='1' max='28' name='cycle_anchor_day' value='{workspace.cycle_anchor_day}'></div></div><p><button>Preview plan</button></p></form></section>"
     body = f"""<section><h1>{html.escape(workspace.display_name)}</h1><p><strong>Plan:</strong> {workspace.plan.value.title()} · <strong>Status:</strong> {workspace.status.value.title()}<br><strong>Tenant:</strong> {html.escape(identity.tenant_id)}<br><strong>Current cycle:</strong> {period.starts_at.isoformat()} to {period.ends_at.isoformat()}</p><p class='muted'>This is tenant-qualified local entitlement policy and usage evidence. It is not payment collection, an invoice, or proof of an active external subscription.</p><p><a class='button' href='/workspace/usage.csv'>Export usage CSV</a></p></section><section><h2>Current entitlements</h2><div class='grid'><article class='metric'>Projects<strong>{entitlement.max_projects}</strong></article><article class='metric'>Users<strong>{entitlement.max_users}</strong></article><article class='metric'>White label<strong>{'Yes' if entitlement.white_label else 'No'}</strong></article><article class='metric'>Embedded forms<strong>{'Yes' if entitlement.embedded_lead_forms else 'No'}</strong></article></div></section><section><h2>Usage and allowance</h2><table><thead><tr><th>Resource</th><th>Used</th><th>Limit</th><th>Remaining</th><th>Decision</th></tr></thead><tbody>{_summary_rows(policy, identity, workspace, now)}</tbody></table></section><section><h2>Recent plan changes</h2><table><thead><tr><th>Changed</th><th>Actor</th><th>Previous</th><th>New</th></tr></thead><tbody>{change_rows}</tbody></table></section>{management}"""
     return _page("Workspace usage", body)
 
@@ -173,7 +191,11 @@ def usage_csv(request: Request) -> Response:
     writer.writerow(["event_id", "kind", "quantity", "occurred_at", "related_id", "note"])
     for identifier, event in events:
         writer.writerow([identifier, event.kind.value, event.quantity, event.occurred_at.isoformat(), event.related_id, event.note])
-    return Response(output.getvalue(), media_type="text/csv; charset=utf-8", headers={"Content-Disposition": "attachment; filename=veridra-usage.csv"})
+    return Response(
+        output.getvalue(),
+        media_type="text/csv; charset=utf-8",
+        headers={"Content-Disposition": "attachment; filename=veridra-usage.csv"},
+    )
 
 
 # Legacy process-global helpers remain temporarily for workspace_enforcement.py.
@@ -206,7 +228,10 @@ def require_feature(feature: str) -> None:
     if allowed is None:
         raise ValueError("Unknown workspace entitlement feature.")
     if not allowed:
-        raise HTTPException(status_code=403, detail=f"The active {entitlement.name.value} plan does not include {feature.replace('_', ' ')}.")
+        raise HTTPException(
+            status_code=403,
+            detail=f"The active {entitlement.name.value} plan does not include {feature.replace('_', ' ')}.",
+        )
 
 
 def require_project_capacity(current_projects: int) -> None:
@@ -214,7 +239,10 @@ def require_project_capacity(current_projects: int) -> None:
         return
     entitlement = active_entitlements()
     if current_projects >= entitlement.max_projects:
-        raise HTTPException(status_code=429, detail=f"The active {entitlement.name.value} plan project allowance is exhausted.")
+        raise HTTPException(
+            status_code=429,
+            detail=f"The active {entitlement.name.value} plan project allowance is exhausted.",
+        )
 
 
 def reserve_usage(kind: UsageKind, *, quantity: int = 1) -> None:
@@ -226,7 +254,13 @@ def reserve_usage(kind: UsageKind, *, quantity: int = 1) -> None:
         raise HTTPException(status_code=429, detail=decision.reason)
 
 
-def record_usage(kind: UsageKind, *, quantity: int = 1, related_id: str = "", note: str = "") -> str:
+def record_usage(
+    kind: UsageKind,
+    *,
+    quantity: int = 1,
+    related_id: str = "",
+    note: str = "",
+) -> str:
     if not workspace_policy_active():
         return ""
     try:

--- a/src/veridra/workspace_web.py
+++ b/src/veridra/workspace_web.py
@@ -5,12 +5,16 @@ import csv
 import html
 import io
 from datetime import UTC, datetime
+from pathlib import Path
 from urllib.parse import parse_qs
 
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
+from .identity_tenancy import IdentityBoundaryError, TenantCapability, require_tenant_capability
+from .request_security import require_request_identity
+from .tenant_workspace_policy import TenantWorkspacePolicy, TenantWorkspacePolicyError
 from .workspace_policy import (
     PLAN_CATALOGUE,
     PlanEntitlements,
@@ -37,13 +41,143 @@ label{display:block;font-weight:700;margin:10px 0 4px}input,select{width:100%;pa
 
 
 def _page(title: str, body: str) -> str:
-    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main><p><a href='/workspace'>Workspace</a> · <a href='/commercial'>Commercial operations</a> · <a href='/projects'>Projects</a> · <a href='/'>Assessment console</a></p>{body}</main></body></html>"
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main><p><a href='/agency'>Agency workflow</a> · <a href='/workspace'>Workspace</a> · <a href='/commercial'>Commercial operations</a></p>{body}</main></body></html>"
 
 
 def _single(body: bytes, name: str) -> str:
     return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
 
 
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _tenant_policy(request: Request) -> TenantWorkspacePolicy:
+    return TenantWorkspacePolicy(_root(request))
+
+
+def _summary_rows(policy: TenantWorkspacePolicy, identity: object, workspace: WorkspaceConfig, now: datetime) -> str:
+    rows: list[str] = []
+    ledger = policy.usage_ledger(identity)  # type: ignore[arg-type]
+    for kind in UsageKind:
+        decision = quota_decision(workspace, ledger, kind, requested=1, now=now)
+        limit = "Metered only" if decision.limit is None else str(decision.limit)
+        remaining = "—" if decision.remaining is None else str(decision.remaining)
+        rows.append(
+            f"<tr><td>{html.escape(kind.value.replace('_', ' ').title())}</td><td>{decision.used}</td><td>{limit}</td><td>{remaining}</td><td>{html.escape(decision.reason)}</td></tr>"
+        )
+    return "".join(rows)
+
+
+@router.get("", response_class=HTMLResponse)
+def workspace_dashboard(request: Request) -> str:
+    identity = require_request_identity(request)
+    policy = _tenant_policy(request)
+    try:
+        workspace = policy.load(identity)
+        changes = policy.list_plan_changes(identity)
+    except (IdentityBoundaryError, TenantWorkspacePolicyError) as exc:
+        raise HTTPException(status_code=403, detail="Workspace access is not permitted.") from exc
+    entitlement = PLAN_CATALOGUE[workspace.plan]
+    now = datetime.now(UTC)
+    period = usage_period(workspace, now=now)
+    can_manage = TenantCapability.manage_tenant in require_tenant_capability.__globals__["TENANT_ROLE_CAPABILITIES"][identity.membership_role]
+    change_rows = "".join(
+        f"<tr><td>{html.escape(event.changed_at.isoformat())}</td><td>{html.escape(event.actor_user_id)}</td><td>{event.previous_plan.value}</td><td>{event.new_plan.value}</td></tr>"
+        for _, event in reversed(changes[-10:])
+    ) or "<tr><td colspan='4'>No plan changes recorded.</td></tr>"
+    management = ""
+    if can_manage:
+        management = f"<section><h2>Preview or apply local entitlement policy</h2><form method='get' action='/workspace/plan-preview'><div class='row'><div><label>Plan</label><select name='plan'>{''.join(f\"<option value='{plan.value}'{' selected' if plan == workspace.plan else ''}>{plan.value.title()}</option>\" for plan in PlanName)}</select></div><div><label>Cycle anchor day</label><input type='number' min='1' max='28' name='cycle_anchor_day' value='{workspace.cycle_anchor_day}'></div></div><p><button>Preview plan</button></p></form></section>"
+    body = f"""<section><h1>{html.escape(workspace.display_name)}</h1><p><strong>Plan:</strong> {workspace.plan.value.title()} · <strong>Status:</strong> {workspace.status.value.title()}<br><strong>Tenant:</strong> {html.escape(identity.tenant_id)}<br><strong>Current cycle:</strong> {period.starts_at.isoformat()} to {period.ends_at.isoformat()}</p><p class='muted'>This is tenant-qualified local entitlement policy and usage evidence. It is not payment collection, an invoice, or proof of an active external subscription.</p><p><a class='button' href='/workspace/usage.csv'>Export usage CSV</a></p></section><section><h2>Current entitlements</h2><div class='grid'><article class='metric'>Projects<strong>{entitlement.max_projects}</strong></article><article class='metric'>Users<strong>{entitlement.max_users}</strong></article><article class='metric'>White label<strong>{'Yes' if entitlement.white_label else 'No'}</strong></article><article class='metric'>Embedded forms<strong>{'Yes' if entitlement.embedded_lead_forms else 'No'}</strong></article></div></section><section><h2>Usage and allowance</h2><table><thead><tr><th>Resource</th><th>Used</th><th>Limit</th><th>Remaining</th><th>Decision</th></tr></thead><tbody>{_summary_rows(policy, identity, workspace, now)}</tbody></table></section><section><h2>Recent plan changes</h2><table><thead><tr><th>Changed</th><th>Actor</th><th>Previous</th><th>New</th></tr></thead><tbody>{change_rows}</tbody></table></section>{management}"""
+    return _page("Workspace usage", body)
+
+
+@router.get("/plan-preview", response_class=HTMLResponse)
+def plan_preview(request: Request, plan: PlanName, cycle_anchor_day: int = 1) -> str:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_tenant)
+        current = _tenant_policy(request).load(identity)
+    except (IdentityBoundaryError, TenantWorkspacePolicyError) as exc:
+        raise HTTPException(status_code=403, detail="Workspace changes are not permitted.") from exc
+    try:
+        proposed = WorkspaceConfig(
+            display_name=current.display_name,
+            plan=plan,
+            status=current.status,
+            cycle_anchor_day=cycle_anchor_day,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="Invalid workspace plan configuration.") from exc
+    entitlement = PLAN_CATALOGUE[proposed.plan]
+    rows = "".join(
+        f"<tr><td>{html.escape(label)}</td><td>{html.escape(value)}</td></tr>"
+        for label, value in (
+            ("Projects", str(entitlement.max_projects)),
+            ("Monthly audits", str(entitlement.monthly_audits)),
+            ("Monthly crawled-page reservation", str(entitlement.monthly_crawled_pages)),
+            ("Monthly PDFs", str(entitlement.monthly_pdfs)),
+            ("Monthly exports", str(entitlement.monthly_exports)),
+            ("Monthly lead submissions", str(entitlement.monthly_lead_submissions)),
+            ("Monthly monitoring runs", str(entitlement.monthly_monitoring_runs)),
+            ("White label", "Yes" if entitlement.white_label else "No"),
+            ("Embedded lead forms", "Yes" if entitlement.embedded_lead_forms else "No"),
+            ("Users", str(entitlement.max_users)),
+        )
+    )
+    body = f"<section><h1>Plan preview: {proposed.plan.value.title()}</h1><p class='muted'>Applying this changes only Veridra's tenant-local entitlement policy. It does not charge a payment method or create an external subscription.</p><table><tbody>{rows}</tbody></table><form method='post' action='/workspace/plan'><input type='hidden' name='plan' value='{proposed.plan.value}'><input type='hidden' name='cycle_anchor_day' value='{proposed.cycle_anchor_day}'><p><button>Apply local policy</button></p></form></section>"
+    return _page("Plan preview", body)
+
+
+@router.post("/plan")
+async def apply_plan(request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    policy = _tenant_policy(request)
+    body = await request.body()
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_tenant)
+        current = policy.load(identity)
+        updated = WorkspaceConfig(
+            display_name=current.display_name,
+            plan=PlanName(_single(body, "plan")),
+            status=WorkspaceStatus.active,
+            cycle_anchor_day=int(_single(body, "cycle_anchor_day")),
+        )
+        policy.save(identity, updated)
+        policy.record_plan_change(
+            identity,
+            previous_plan=current.plan,
+            new_plan=updated.plan,
+        )
+    except (IdentityBoundaryError, TenantWorkspacePolicyError) as exc:
+        raise HTTPException(status_code=403, detail="Workspace changes are not permitted.") from exc
+    except (ValueError, ValidationError) as exc:
+        raise HTTPException(status_code=400, detail="Invalid workspace plan configuration.") from exc
+    return RedirectResponse("/workspace", status_code=303)
+
+
+@router.get("/usage.csv")
+def usage_csv(request: Request) -> Response:
+    identity = require_request_identity(request)
+    policy = _tenant_policy(request)
+    try:
+        workspace = policy.load(identity)
+        period = usage_period(workspace)
+        events = policy.list_usage(identity, period=period)
+    except (IdentityBoundaryError, TenantWorkspacePolicyError) as exc:
+        raise HTTPException(status_code=403, detail="Workspace access is not permitted.") from exc
+    output = io.StringIO(newline="")
+    writer = csv.writer(output)
+    writer.writerow(["event_id", "kind", "quantity", "occurred_at", "related_id", "note"])
+    for identifier, event in events:
+        writer.writerow([identifier, event.kind.value, event.quantity, event.occurred_at.isoformat(), event.related_id, event.note])
+    return Response(output.getvalue(), media_type="text/csv; charset=utf-8", headers={"Content-Disposition": "attachment; filename=veridra-usage.csv"})
+
+
+# Legacy process-global helpers remain temporarily for workspace_enforcement.py.
+# Issue #115 tracks their migration to request-tenant policy.
 def _store() -> WorkspaceStore:
     return WorkspaceStore()
 
@@ -72,10 +206,7 @@ def require_feature(feature: str) -> None:
     if allowed is None:
         raise ValueError("Unknown workspace entitlement feature.")
     if not allowed:
-        raise HTTPException(
-            status_code=403,
-            detail=f"The active {entitlement.name.value} plan does not include {feature.replace('_', ' ')}.",
-        )
+        raise HTTPException(status_code=403, detail=f"The active {entitlement.name.value} plan does not include {feature.replace('_', ' ')}.")
 
 
 def require_project_capacity(current_projects: int) -> None:
@@ -83,96 +214,7 @@ def require_project_capacity(current_projects: int) -> None:
         return
     entitlement = active_entitlements()
     if current_projects >= entitlement.max_projects:
-        raise HTTPException(
-            status_code=429,
-            detail=f"The active {entitlement.name.value} plan project allowance is exhausted.",
-        )
-
-
-def _summary_rows(workspace: WorkspaceConfig, now: datetime) -> str:
-    ledger = _ledger()
-    rows: list[str] = []
-    for kind in UsageKind:
-        decision = quota_decision(workspace, ledger, kind, requested=1, now=now)
-        limit = "Metered only" if decision.limit is None else str(decision.limit)
-        remaining = "—" if decision.remaining is None else str(decision.remaining)
-        rows.append(
-            f"<tr><td>{html.escape(kind.value.replace('_', ' ').title())}</td><td>{decision.used}</td><td>{limit}</td><td>{remaining}</td><td>{html.escape(decision.reason)}</td></tr>"
-        )
-    return "".join(rows)
-
-
-@router.get("", response_class=HTMLResponse)
-def workspace_dashboard() -> str:
-    store = _store()
-    workspace = store.load()
-    entitlement = PLAN_CATALOGUE[workspace.plan]
-    now = datetime.now(UTC)
-    period = usage_period(workspace, now=now)
-    activation = "Active and enforcing" if store.path.exists() else "Preview only — save a plan to activate enforcement"
-    body = f"""<section><h1>{html.escape(workspace.display_name)}</h1><p><strong>Plan:</strong> {workspace.plan.value.title()} · <strong>Status:</strong> {workspace.status.value.title()}<br><strong>Policy:</strong> {html.escape(activation)}<br><strong>Current cycle:</strong> {period.starts_at.isoformat()} to {period.ends_at.isoformat()}</p><p class='muted'>This is a local policy and metering layer. It is not authentication, tenant isolation, payment collection or production subscription enforcement.</p><p><a class='button' href='/workspace/usage.csv'>Export usage CSV</a></p></section><section><h2>Current entitlements</h2><div class='grid'><article class='metric'>Projects<strong>{entitlement.max_projects}</strong></article><article class='metric'>Users<strong>{entitlement.max_users}</strong></article><article class='metric'>White label<strong>{'Yes' if entitlement.white_label else 'No'}</strong></article><article class='metric'>Embedded forms<strong>{'Yes' if entitlement.embedded_lead_forms else 'No'}</strong></article></div></section><section><h2>Usage and allowance</h2><table><thead><tr><th>Resource</th><th>Used</th><th>Limit</th><th>Remaining</th><th>Decision</th></tr></thead><tbody>{_summary_rows(workspace, now)}</tbody></table></section><section><h2>Preview or apply plan</h2><form method='get' action='/workspace/plan-preview'><div class='row'><div><label>Plan</label><select name='plan'>{''.join(f"<option value='{plan.value}'{' selected' if plan == workspace.plan else ''}>{plan.value.title()}</option>" for plan in PlanName)}</select></div><div><label>Cycle anchor day</label><input type='number' min='1' max='28' name='cycle_anchor_day' value='{workspace.cycle_anchor_day}'></div></div><p><button>Preview plan</button></p></form></section>"""
-    return _page("Workspace usage", body)
-
-
-@router.get("/plan-preview", response_class=HTMLResponse)
-def plan_preview(plan: PlanName, cycle_anchor_day: int = 1) -> str:
-    current = _store().load()
-    try:
-        proposed = WorkspaceConfig(
-            display_name=current.display_name,
-            plan=plan,
-            status=current.status,
-            cycle_anchor_day=cycle_anchor_day,
-        )
-    except ValidationError as exc:
-        raise HTTPException(status_code=400, detail="Invalid workspace plan configuration.") from exc
-    entitlement = PLAN_CATALOGUE[proposed.plan]
-    rows = "".join(
-        f"<tr><td>{html.escape(label)}</td><td>{html.escape(value)}</td></tr>"
-        for label, value in (
-            ("Projects", str(entitlement.max_projects)),
-            ("Monthly audits", str(entitlement.monthly_audits)),
-            ("Monthly crawled-page reservation", str(entitlement.monthly_crawled_pages)),
-            ("Monthly PDFs", str(entitlement.monthly_pdfs)),
-            ("Monthly exports", str(entitlement.monthly_exports)),
-            ("Monthly lead submissions", str(entitlement.monthly_lead_submissions)),
-            ("Monthly monitoring runs", str(entitlement.monthly_monitoring_runs)),
-            ("White label", "Yes" if entitlement.white_label else "No"),
-            ("Embedded lead forms", "Yes" if entitlement.embedded_lead_forms else "No"),
-            ("Users", str(entitlement.max_users)),
-        )
-    )
-    body = f"<section><h1>Plan preview: {proposed.plan.value.title()}</h1><p class='muted'>Changing the local plan does not charge a payment method or create a subscription.</p><table><tbody>{rows}</tbody></table><form method='post' action='/workspace/plan'><input type='hidden' name='plan' value='{proposed.plan.value}'><input type='hidden' name='cycle_anchor_day' value='{proposed.cycle_anchor_day}'><p><button>Apply local plan</button></p></form></section>"
-    return _page("Plan preview", body)
-
-
-@router.post("/plan")
-async def apply_plan(request: Request) -> RedirectResponse:
-    body = await request.body()
-    current = _store().load()
-    try:
-        updated = WorkspaceConfig(
-            display_name=current.display_name,
-            plan=PlanName(_single(body, "plan")),
-            status=WorkspaceStatus.active,
-            cycle_anchor_day=int(_single(body, "cycle_anchor_day")),
-        )
-    except (ValueError, ValidationError) as exc:
-        raise HTTPException(status_code=400, detail="Invalid workspace plan configuration.") from exc
-    _store().save(updated)
-    return RedirectResponse("/workspace", status_code=303)
-
-
-@router.get("/usage.csv")
-def usage_csv() -> Response:
-    workspace = _store().load()
-    period = usage_period(workspace)
-    output = io.StringIO(newline="")
-    writer = csv.writer(output)
-    writer.writerow(["event_id", "kind", "quantity", "occurred_at", "related_id", "note"])
-    for identifier, event in _ledger().list(period=period):
-        writer.writerow([identifier, event.kind.value, event.quantity, event.occurred_at.isoformat(), event.related_id, event.note])
-    return Response(output.getvalue(), media_type="text/csv; charset=utf-8", headers={"Content-Disposition": "attachment; filename=veridra-usage.csv"})
+        raise HTTPException(status_code=429, detail=f"The active {entitlement.name.value} plan project allowance is exhausted.")
 
 
 def reserve_usage(kind: UsageKind, *, quantity: int = 1) -> None:

--- a/tests/test_workspace_web.py
+++ b/tests/test_workspace_web.py
@@ -1,104 +1,160 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
+from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient
 
-from veridra.runtime import app
-from veridra.workspace_policy import (
-    PlanName,
-    UsageEvent,
-    UsageKind,
-    UsageLedger,
-    WorkspaceConfig,
-    WorkspaceStore,
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_workspace_policy import TenantWorkspacePolicy
+from veridra.workspace_policy import PlanName, UsageEvent, UsageKind, WorkspaceConfig
+from veridra.workspace_web import router
+
+NOW = datetime(2026, 7, 27, 16, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="workspace-owner-session-001",
+    authenticated_at=NOW,
 )
-from veridra.workspace_web import record_usage, reserve_usage, workspace_policy_active
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="workspace-viewer-session-01",
+    authenticated_at=NOW,
+)
+OTHER_OWNER = RequestIdentity(
+    user_id="3" * 24,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.owner,
+    session_id="workspace-other-owner-01",
+    authenticated_at=NOW,
+)
 
 
-def test_workspace_dashboard_is_preview_until_plan_is_saved(
-    tmp_path: Path, monkeypatch: object
-) -> None:
-    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))  # type: ignore[attr-defined]
-    client = TestClient(app)
+def _client(tmp_path: Path) -> tuple[TestClient, Path]:
+    root = tmp_path / "tenants"
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
 
-    response = client.get("/workspace")
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        elif role == "other-owner":
+            bind_verified_request_identity(request, OTHER_OWNER)
+        return await call_next(request)
 
-    assert response.status_code == 200
-    assert "Preview only" in response.text
-    assert "Free" in response.text
-    assert not workspace_policy_active()
+    app.include_router(router)
+    return TestClient(app), root
 
 
-def test_plan_preview_and_apply_activate_policy(
-    tmp_path: Path, monkeypatch: object
-) -> None:
-    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))  # type: ignore[attr-defined]
-    client = TestClient(app)
+def test_workspace_requires_identity_and_defaults_to_free(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
 
-    preview = client.get("/workspace/plan-preview?plan=professional&cycle_anchor_day=15")
+    anonymous = client.get("/workspace")
+    viewer = client.get("/workspace", headers={"x-test-role": "viewer"})
+
+    assert anonymous.status_code == 401
+    assert viewer.status_code == 200
+    assert "Plan:</strong> Free" in viewer.text
+    assert "not payment collection" in viewer.text
+    assert "Preview or apply" not in viewer.text
+    assert not (root / OWNER.tenant_id / "workspace" / "workspace.json").exists()
+
+
+def test_owner_can_preview_and_apply_tenant_plan_with_audit(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
+
+    preview = client.get(
+        "/workspace/plan-preview?plan=professional&cycle_anchor_day=15",
+        headers={"x-test-role": "owner"},
+    )
     applied = client.post(
         "/workspace/plan",
+        headers={"x-test-role": "owner"},
         data={"plan": "professional", "cycle_anchor_day": "15"},
         follow_redirects=False,
     )
 
     assert preview.status_code == 200
-    assert "Monthly audits" in preview.text
+    assert "does not charge a payment method" in preview.text
     assert applied.status_code == 303
-    workspace = WorkspaceStore().load()
+    policy = TenantWorkspacePolicy(root)
+    workspace = policy.load(OWNER)
     assert workspace.plan == PlanName.professional
     assert workspace.cycle_anchor_day == 15
-    assert workspace_policy_active()
+    changes = policy.list_plan_changes(OWNER)
+    assert len(changes) == 1
+    assert changes[0][1].actor_user_id == OWNER.user_id
+    assert changes[0][1].previous_plan == PlanName.free
+    assert changes[0][1].new_plan == PlanName.professional
 
 
-def test_usage_export_contains_current_cycle_events(
-    tmp_path: Path, monkeypatch: object
-) -> None:
-    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))  # type: ignore[attr-defined]
-    WorkspaceStore().save(WorkspaceConfig(plan=PlanName.solo))
-    UsageLedger().record(
+def test_viewer_cannot_preview_or_apply_plan(tmp_path: Path) -> None:
+    client, _ = _client(tmp_path)
+
+    preview = client.get(
+        "/workspace/plan-preview?plan=agency&cycle_anchor_day=1",
+        headers={"x-test-role": "viewer"},
+    )
+    applied = client.post(
+        "/workspace/plan",
+        headers={"x-test-role": "viewer"},
+        data={"plan": "agency", "cycle_anchor_day": "1"},
+    )
+
+    assert preview.status_code == 403
+    assert applied.status_code == 403
+
+
+def test_workspace_and_usage_are_tenant_isolated(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
+    policy = TenantWorkspacePolicy(root)
+    policy.save(OWNER, WorkspaceConfig(plan=PlanName.solo))
+    policy.save(OTHER_OWNER, WorkspaceConfig(plan=PlanName.agency))
+    policy.record_usage(
+        OWNER,
         UsageEvent(
             kind=UsageKind.audit,
             quantity=2,
             occurred_at=datetime.now(UTC),
-            related_id="assessment-1",
-            note="route test",
-        )
+            related_id="tenant-a-assessment",
+            note="tenant A",
+        ),
     )
-    client = TestClient(app)
+    policy.record_usage(
+        OTHER_OWNER,
+        UsageEvent(
+            kind=UsageKind.audit,
+            quantity=7,
+            occurred_at=datetime.now(UTC),
+            related_id="tenant-b-assessment",
+            note="tenant B",
+        ),
+    )
 
-    response = client.get("/workspace/usage.csv")
+    first = client.get("/workspace", headers={"x-test-role": "viewer"})
+    first_csv = client.get("/workspace/usage.csv", headers={"x-test-role": "viewer"})
+    second = client.get("/workspace", headers={"x-test-role": "other-owner"})
+    second_csv = client.get(
+        "/workspace/usage.csv", headers={"x-test-role": "other-owner"}
+    )
 
-    assert response.status_code == 200
-    assert response.headers["content-type"].startswith("text/csv")
-    assert "assessment-1" in response.text
-    assert "audit" in response.text
-
-
-def test_compatibility_mode_does_not_meter_without_explicit_workspace(
-    tmp_path: Path, monkeypatch: object
-) -> None:
-    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))  # type: ignore[attr-defined]
-
-    reserve_usage(UsageKind.audit)
-    identifier = record_usage(UsageKind.audit, related_id="ignored")
-
-    assert identifier == ""
-    assert UsageLedger().list() == []
-
-
-def test_active_workspace_records_usage(
-    tmp_path: Path, monkeypatch: object
-) -> None:
-    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))  # type: ignore[attr-defined]
-    WorkspaceStore().save(WorkspaceConfig(plan=PlanName.solo))
-
-    reserve_usage(UsageKind.audit)
-    identifier = record_usage(UsageKind.audit, related_id="assessment-2")
-
-    assert len(identifier) == 24
-    events = UsageLedger().list()
-    assert len(events) == 1
-    assert events[0][1].related_id == "assessment-2"
+    assert "Plan:</strong> Solo" in first.text
+    assert "tenant-a-assessment" in first_csv.text
+    assert "tenant-b-assessment" not in first_csv.text
+    assert "Plan:</strong> Agency" in second.text
+    assert "tenant-b-assessment" in second_csv.text
+    assert "tenant-a-assessment" not in second_csv.text


### PR DESCRIPTION
Continues issue #115 from main `602b4419b61df5ec193e963ea03a16763e410856`.

- requires verified identity for workspace, plan preview, plan changes, and usage export;
- reads and writes tenant-qualified workspace and usage state;
- lets viewers inspect current plan, entitlements, usage, remaining capacity, and plan-change history;
- requires `manage_tenant` for plan preview and mutation;
- records actor, previous plan, new plan, and timestamp through the merged audit boundary;
- defaults missing tenant state to free without persisting paid access;
- clearly distinguishes local entitlement policy from payment or subscription state;
- adds tenant-isolation, permission, audit, and read-only default tests.

Legacy global quota helpers remain temporarily for `workspace_enforcement.py`; this PR does not close #115.

Requires full exact-head CI before merge.