### PR TITLE
Migrate authenticated quota enforcement to tenant policy

### DIFF
--- a/src/veridra/tenant_entitlements.py
+++ b/src/veridra/tenant_entitlements.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from .identity_tenancy import RequestIdentity
+from .tenant_workspace_policy import TenantWorkspacePolicy
+from .workspace_policy import (
+    PLAN_CATALOGUE,
+    UsageEvent,
+    UsageKind,
+    WorkspaceConfig,
+    quota_decision,
+)
+
+
+def tenant_workspace_active(
+    policy: TenantWorkspacePolicy,
+    identity: RequestIdentity,
+) -> bool:
+    return policy.workspace_store(identity).path.exists()
+
+
+def active_workspace(
+    policy: TenantWorkspacePolicy,
+    identity: RequestIdentity,
+) -> WorkspaceConfig:
+    return policy.load(identity)
+
+
+def require_tenant_feature(
+    policy: TenantWorkspacePolicy,
+    identity: RequestIdentity,
+    feature: str,
+) -> None:
+    if not tenant_workspace_active(policy, identity):
+        return
+    entitlement = PLAN_CATALOGUE[policy.load(identity).plan]
+    allowed = {
+        "white_label": entitlement.white_label,
+        "embedded_lead_forms": entitlement.embedded_lead_forms,
+    }.get(feature)
+    if allowed is None:
+        raise ValueError("Unknown workspace entitlement feature.")
+    if not allowed:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"The active {entitlement.name.value} plan does not include "
+                f"{feature.replace('_', ' ')}."
+            ),
+        )
+
+
+def require_tenant_project_capacity(
+    policy: TenantWorkspacePolicy,
+    identity: RequestIdentity,
+    current_projects: int,
+) -> None:
+    if not tenant_workspace_active(policy, identity):
+        return
+    entitlement = PLAN_CATALOGUE[policy.load(identity).plan]
+    if current_projects >= entitlement.max_projects:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"The active {entitlement.name.value} plan project allowance is "
+                "exhausted."
+            ),
+        )
+
+
+def reserve_tenant_usage(
+    policy: TenantWorkspacePolicy,
+    identity: RequestIdentity,
+    kind: UsageKind,
+    *,
+    quantity: int = 1,
+) -> None:
+    if not tenant_workspace_active(policy, identity):
+        return
+    workspace = policy.load(identity)
+    decision = quota_decision(
+        workspace,
+        policy.usage_ledger(identity),
+        kind,
+        requested=quantity,
+    )
+    if not decision.allowed:
+        raise HTTPException(status_code=429, detail=decision.reason)
+
+
+def record_tenant_usage(
+    policy: TenantWorkspacePolicy,
+    identity: RequestIdentity,
+    kind: UsageKind,
+    *,
+    quantity: int = 1,
+    related_id: str = "",
+    note: str = "",
+) -> str:
+    if not tenant_workspace_active(policy, identity):
+        return ""
+    return policy.record_usage(
+        identity,
+        UsageEvent(
+            kind=kind,
+            quantity=quantity,
+            occurred_at=datetime.now(UTC),
+            related_id=related_id,
+            note=note,
+        ),
+    )

--- a/src/veridra/tenant_entitlements.py
+++ b/src/veridra/tenant_entitlements.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from pathlib import Path
 
 from fastapi import HTTPException
 

--- a/src/veridra/workspace_enforcement.py
+++ b/src/veridra/workspace_enforcement.py
@@ -1,110 +1,115 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 
 from fastapi import HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 
-from .project_store import ProjectStore
-from .workspace_policy import UsageKind
-from .workspace_web import (
-    record_usage,
-    require_feature,
-    require_project_capacity,
-    reserve_usage,
-    workspace_policy_active,
+from .request_security import require_request_identity
+from .tenant_entitlements import (
+    record_tenant_usage,
+    require_tenant_feature,
+    require_tenant_project_capacity,
+    reserve_tenant_usage,
+    tenant_workspace_active,
 )
+from .tenant_project_store import TenantProjectStore
+from .tenant_workspace_policy import TenantWorkspacePolicy
+from .workspace_policy import UsageKind
 
 NextHandler = Callable[[Request], Awaitable[Response]]
 
 
-def _is_identifier(value: str) -> bool:
-    return len(value) == 24 and all(char in "0123456789abcdef" for char in value)
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
 
 
 def _profile_write(path: str, method: str) -> bool:
-    if method != "POST":
-        return False
-    parts = path.strip("/").split("/")
-    return parts == ["profiles"] or (
-        len(parts) == 2 and parts[0] == "profiles" and _is_identifier(parts[1])
+    return method in {"POST", "PUT"} and path.startswith(
+        "/api/tenant/report-profiles"
     )
 
 
-def _embedded_form_path(path: str) -> bool:
-    parts = path.strip("/").split("/")
-    return len(parts) == 3 and parts[:2] == ["embed", "audit"]
+def _lead_form_write(path: str, method: str) -> bool:
+    return method in {"POST", "PUT"} and path.startswith(
+        "/api/tenant/lead-forms"
+    )
 
 
 def _monitoring_write(path: str, method: str) -> bool:
     if method != "POST":
         return False
-    return path == "/monitoring/run-due" or path.endswith("/monitor/run") or (
-        path.startswith("/monitoring/projects/") and path.endswith("/run")
+    return (
+        path.endswith("/monitoring/run")
+        or path.endswith("/monitor/run")
+        or path == "/api/tenant/monitoring/run-due"
     )
 
 
-def _legacy_pdf(path: str, method: str) -> bool:
-    return method == "GET" and path == "/report.pdf"
+def _tenant_pdf(path: str, method: str) -> bool:
+    return (
+        method == "GET"
+        and path.startswith("/api/tenant/projects/")
+        and path.endswith("/report.pdf")
+    )
 
 
-def _legacy_export(path: str, method: str) -> bool:
-    return method == "GET" and path == "/export"
+def _tenant_export(path: str, method: str) -> bool:
+    return (
+        method == "GET"
+        and path.startswith("/api/tenant/projects/")
+        and path.endswith("/export")
+    )
 
 
-def _retry_kind(path: str, method: str) -> UsageKind | None:
-    if method != "POST":
-        return None
-    if path.endswith("/delivery/retry"):
-        return UsageKind.webhook_attempt
-    if path.endswith("/email/retry"):
-        return UsageKind.email_attempt
-    return None
-
-
-def _preflight(request: Request) -> list[tuple[UsageKind, int, str]]:
+def _preflight(
+    request: Request,
+    policy: TenantWorkspacePolicy,
+) -> list[tuple[UsageKind, int, str]]:
+    identity = require_request_identity(request)
     path = request.url.path
     method = request.method.upper()
     metered: list[tuple[UsageKind, int, str]] = []
 
-    if method == "POST" and path == "/projects":
-        require_project_capacity(len(ProjectStore().list()))
+    if method == "POST" and path == "/api/tenant/projects/from-assessment":
+        projects = TenantProjectStore(_root(request))
+        require_tenant_project_capacity(
+            policy,
+            identity,
+            len(projects.list(identity)),
+        )
 
     if _profile_write(path, method):
-        require_feature("white_label")
+        require_tenant_feature(policy, identity, "white_label")
 
-    if request.query_params.get("profile") and path in {"/report", "/report.pdf", "/export"}:
-        require_feature("white_label")
-
-    if method == "POST" and path == "/lead-forms":
-        require_feature("embedded_lead_forms")
-
-    if _embedded_form_path(path):
-        require_feature("embedded_lead_forms")
-        if method == "POST":
-            reserve_usage(UsageKind.lead_submission)
-            metered.append((UsageKind.lead_submission, 1, path.rsplit("/", 1)[-1]))
+    if _lead_form_write(path, method):
+        require_tenant_feature(policy, identity, "embedded_lead_forms")
 
     if _monitoring_write(path, method):
-        reserve_usage(UsageKind.monitoring_run)
+        reserve_tenant_usage(policy, identity, UsageKind.monitoring_run)
         metered.append((UsageKind.monitoring_run, 1, path))
 
-    if _legacy_pdf(path, method):
-        reserve_usage(UsageKind.pdf)
-        metered.append((UsageKind.pdf, 1, request.query_params.get("url", "")))
+    if _tenant_pdf(path, method):
+        reserve_tenant_usage(policy, identity, UsageKind.pdf)
+        metered.append((UsageKind.pdf, 1, path))
 
-    if _legacy_export(path, method):
-        reserve_usage(UsageKind.export)
-        metered.append((UsageKind.export, 1, request.query_params.get("url", "")))
+    if _tenant_export(path, method):
+        reserve_tenant_usage(policy, identity, UsageKind.export)
+        metered.append((UsageKind.export, 1, path))
 
-    retry_kind = _retry_kind(path, method)
-    if retry_kind is not None:
-        metered.append((retry_kind, 1, path))
     return metered
 
 
 async def enforce_workspace_policy(request: Request, call_next: NextHandler) -> Response:
-    if not workspace_policy_active():
+    try:
+        identity = require_request_identity(request)
+    except HTTPException:
+        return await call_next(request)
+
+    policy = TenantWorkspacePolicy(_root(request))
+    if not tenant_workspace_active(policy, identity):
         return await call_next(request)
 
     path = request.url.path
@@ -112,14 +117,16 @@ async def enforce_workspace_policy(request: Request, call_next: NextHandler) -> 
         return await call_next(request)
 
     try:
-        metered = _preflight(request)
+        metered = _preflight(request, policy)
     except HTTPException as exc:
         return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
     response = await call_next(request)
     if response.status_code < 400:
         for kind, quantity, related_id in metered:
-            record_usage(
+            record_tenant_usage(
+                policy,
+                identity,
                 kind,
                 quantity=quantity,
                 related_id=related_id,

--- a/tests/test_workspace_enforcement.py
+++ b/tests/test_workspace_enforcement.py
@@ -1,51 +1,78 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 from pathlib import Path
 
-import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from fastapi.responses import PlainTextResponse
 from fastapi.testclient import TestClient
 
-from veridra.project_store import ClientProject, ProjectStore
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_project_store import TenantProjectStore
+from veridra.tenant_workspace_policy import TenantWorkspacePolicy
 from veridra.workspace_enforcement import enforce_workspace_policy
-from veridra.workspace_policy import (
-    PlanName,
-    UsageKind,
-    UsageLedger,
-    WorkspaceConfig,
-    WorkspaceStore,
-    usage_period,
+from veridra.workspace_policy import PlanName, UsageKind, WorkspaceConfig, usage_period
+
+NOW = datetime(2026, 7, 27, 17, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="workspace-enforcement-owner",
+    authenticated_at=NOW,
+)
+OTHER_OWNER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.owner,
+    session_id="workspace-enforcement-other",
+    authenticated_at=NOW,
 )
 
 
-def _app() -> FastAPI:
+def _app(root: Path) -> FastAPI:
     app = FastAPI()
+    app.state.veridra_tenant_data_root = root
     app.middleware("http")(enforce_workspace_policy)
 
-    @app.post("/projects")
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "other-owner":
+            bind_verified_request_identity(request, OTHER_OWNER)
+        return await call_next(request)
+
+    @app.post("/api/tenant/projects/from-assessment")
     def projects() -> PlainTextResponse:
         return PlainTextResponse("saved")
 
-    @app.post("/profiles")
+    @app.post("/api/tenant/report-profiles")
     def profiles() -> PlainTextResponse:
         return PlainTextResponse("saved")
 
-    @app.post("/lead-forms")
+    @app.post("/api/tenant/lead-forms")
     def forms() -> PlainTextResponse:
         return PlainTextResponse("saved")
 
-    @app.post("/embed/audit/{form_id}")
-    def submit(form_id: str) -> PlainTextResponse:
-        return PlainTextResponse(form_id)
+    @app.post("/agency/projects/{project_id}/monitoring/run")
+    def monitoring(project_id: str) -> PlainTextResponse:
+        return PlainTextResponse(project_id)
 
-    @app.post("/monitoring/run-due")
-    def monitoring() -> PlainTextResponse:
-        return PlainTextResponse("run")
+    @app.get("/api/tenant/projects/{project_id}/assessments/{assessment_id}/report.pdf")
+    def pdf(project_id: str, assessment_id: str) -> PlainTextResponse:
+        return PlainTextResponse(f"{project_id}:{assessment_id}:pdf")
 
-    @app.get("/report.pdf")
-    def pdf() -> PlainTextResponse:
-        return PlainTextResponse("pdf")
+    @app.get("/api/tenant/projects/{project_id}/assessments/{assessment_id}/export")
+    def export(project_id: str, assessment_id: str) -> PlainTextResponse:
+        return PlainTextResponse(f"{project_id}:{assessment_id}:export")
 
     @app.get("/free/security")
     def free_tool() -> PlainTextResponse:
@@ -54,55 +81,87 @@ def _app() -> FastAPI:
     return app
 
 
-def _activate(tmp_path: Path, plan: PlanName) -> None:
-    WorkspaceStore(tmp_path / "workspace").save(WorkspaceConfig(plan=plan))
+def test_unconfigured_tenant_preserves_existing_routes(tmp_path: Path) -> None:
+    client = TestClient(_app(tmp_path / "tenants"))
+
+    response = client.post(
+        "/api/tenant/report-profiles", headers={"x-test-role": "owner"}
+    )
+
+    assert response.status_code == 200
 
 
-def test_policy_inactive_preserves_existing_routes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))
-    assert TestClient(_app()).post("/profiles").status_code == 200
+def test_free_plan_blocks_features_and_project_overage(tmp_path: Path) -> None:
+    root = tmp_path / "tenants"
+    TenantWorkspacePolicy(root).save(OWNER, WorkspaceConfig(plan=PlanName.free))
+    TenantProjectStore(root).save(
+        OWNER,
+        ClientProject.build(name="One", target_url="https://example.com"),
+    )
+    client = TestClient(_app(root))
+    headers = {"x-test-role": "owner"}
+
+    assert client.post(
+        "/api/tenant/projects/from-assessment", headers=headers
+    ).status_code == 429
+    assert client.post(
+        "/api/tenant/report-profiles", headers=headers
+    ).status_code == 403
+    assert client.post("/api/tenant/lead-forms", headers=headers).status_code == 403
 
 
-def test_free_plan_blocks_commercial_features_and_project_overage(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))
-    _activate(tmp_path, PlanName.free)
-    ProjectStore().save(ClientProject.build(name="One", target_url="https://example.com"))
-    client = TestClient(_app())
+def test_agency_plan_records_successful_tenant_usage(tmp_path: Path) -> None:
+    root = tmp_path / "tenants"
+    policy = TenantWorkspacePolicy(root)
+    policy.save(OWNER, WorkspaceConfig(plan=PlanName.agency))
+    client = TestClient(_app(root))
+    headers = {"x-test-role": "owner"}
+    project_id = "p" * 24
+    assessment_id = "a" * 24
 
-    assert client.post("/projects").status_code == 429
-    assert client.post("/profiles").status_code == 403
-    assert client.post("/lead-forms").status_code == 403
-    assert client.post("/embed/audit/" + "a" * 24).status_code == 403
+    assert client.post(
+        f"/agency/projects/{project_id}/monitoring/run", headers=headers
+    ).status_code == 200
+    assert client.get(
+        f"/api/tenant/projects/{project_id}/assessments/{assessment_id}/report.pdf",
+        headers=headers,
+    ).status_code == 200
+    assert client.get(
+        f"/api/tenant/projects/{project_id}/assessments/{assessment_id}/export",
+        headers=headers,
+    ).status_code == 200
 
-
-def test_agency_plan_records_successful_commercial_usage(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))
-    _activate(tmp_path, PlanName.agency)
-    client = TestClient(_app())
-
-    assert client.post("/embed/audit/" + "a" * 24).status_code == 200
-    assert client.post("/monitoring/run-due").status_code == 200
-    assert client.get("/report.pdf?url=https://example.com").status_code == 200
-
-    workspace = WorkspaceStore().load()
-    totals = UsageLedger().totals(usage_period(workspace))
-    assert totals[UsageKind.lead_submission] == 1
+    workspace = policy.load(OWNER)
+    totals = policy.usage_ledger(OWNER).totals(usage_period(workspace))
     assert totals[UsageKind.monitoring_run] == 1
     assert totals[UsageKind.pdf] == 1
+    assert totals[UsageKind.export] == 1
 
 
-def test_free_tools_are_isolated_from_workspace_metering(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))
-    _activate(tmp_path, PlanName.free)
-    client = TestClient(_app())
+def test_enforcement_is_tenant_isolated(tmp_path: Path) -> None:
+    root = tmp_path / "tenants"
+    policy = TenantWorkspacePolicy(root)
+    policy.save(OWNER, WorkspaceConfig(plan=PlanName.free))
+    policy.save(OTHER_OWNER, WorkspaceConfig(plan=PlanName.agency))
+    client = TestClient(_app(root))
 
-    assert client.get("/free/security").status_code == 200
-    assert UsageLedger().list() == []
+    first = client.post(
+        "/api/tenant/report-profiles", headers={"x-test-role": "owner"}
+    )
+    second = client.post(
+        "/api/tenant/report-profiles", headers={"x-test-role": "other-owner"}
+    )
+
+    assert first.status_code == 403
+    assert second.status_code == 200
+
+
+def test_anonymous_and_free_tools_are_not_tenant_metered(tmp_path: Path) -> None:
+    root = tmp_path / "tenants"
+    policy = TenantWorkspacePolicy(root)
+    policy.save(OWNER, WorkspaceConfig(plan=PlanName.agency))
+    client = TestClient(_app(root))
+
+    assert client.get("/free/security", headers={"x-test-role": "owner"}).status_code == 200
+    assert client.post("/api/tenant/report-profiles").status_code == 200
+    assert policy.usage_ledger(OWNER).list() == []


### PR DESCRIPTION
Continues issue #115 from main `588bcaa7ed25bfcb61b583bf1aa59dd6762343a9`.

- adds reusable tenant entitlement, feature, capacity, reservation, and usage-recording helpers;
- moves authenticated configured tenants off process-global workspace enforcement;
- enforces project capacity on assessment-to-project conversion routes;
- enforces white-label profile and embedded-form creation entitlements;
- meters tenant monitoring runs, tenant PDF downloads, and evidence exports;
- records usage beneath the authenticated tenant only;
- skips anonymous requests instead of applying another tenant's global policy;
- preserves unconfigured-tenant compatibility during the remaining migration;
- adds tests for free and agency behavior, tenant isolation, successful metering, anonymous isolation, and free-tool exclusion.

Public embedded submission metering and final first-run activation semantics remain in #115. This PR does not close the issue.

Requires full exact-head CI before merge.