### PR TITLE
Meter bound lead capture and direct conversion by tenant

### DIFF
--- a/src/veridra/assessment_project_conversion_api.py
+++ b/src/veridra/assessment_project_conversion_api.py
@@ -10,9 +10,10 @@ from .core import Assessment
 from .identity_tenancy import RequestIdentity, TenantCapability
 from .project_store import ClientProject
 from .request_security import require_request_capability
+from .tenant_entitlements import require_tenant_project_capacity
 from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
 from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
-from .workspace_web import require_project_capacity
+from .tenant_workspace_policy import TenantWorkspacePolicy
 
 ProjectManager = Annotated[
     RequestIdentity,
@@ -49,7 +50,11 @@ def convert_assessment(
     root = _root(request)
     projects = TenantProjectStore(root)
     history = TenantHistoryStore(root)
-    require_project_capacity(len(projects.list(identity)))
+    require_tenant_project_capacity(
+        TenantWorkspacePolicy(root),
+        identity,
+        len(projects.list(identity)),
+    )
     project = ClientProject.build(
         name=payload.project_name,
         target_url=str(payload.assessment.target),

--- a/src/veridra/tenant_bound_lead_capture.py
+++ b/src/veridra/tenant_bound_lead_capture.py
@@ -28,8 +28,14 @@ from .lead_web import (
 )
 from .service import assess_url
 from .tenant_delivery_stores import TenantDeliveryStores
+from .tenant_entitlements import (
+    record_bound_tenant_usage,
+    reserve_bound_tenant_usage,
+)
 from .tenant_lead_form_store import TenantLeadFormStore, TenantLeadFormStoreError
 from .tenant_lead_store import TenantLeadStore
+from .tenant_workspace_policy import TenantWorkspacePolicy
+from .workspace_policy import UsageKind
 
 router = APIRouter(tags=["leads"])
 
@@ -44,6 +50,10 @@ def _binding(request: Request, form_id: str) -> LeadFormTenantBinding | None:
 def _tenant_root(request: Request) -> Path | None:
     configured_root = getattr(request.app.state, "veridra_tenant_data_root", None)
     return configured_root if isinstance(configured_root, Path) else None
+
+
+def _resolved_tenant_root(request: Request) -> Path:
+    return TenantWorkspacePolicy(_tenant_root(request)).root
 
 
 def _resolve_form(request: Request, form_id: str) -> LeadFormConfig:
@@ -93,11 +103,24 @@ def tenant_bound_embedded_audit_form(form_id: str, request: Request) -> str:
 @router.post("/embed/audit/{form_id}", response_class=HTMLResponse)
 async def submit_tenant_bound_embedded_audit(form_id: str, request: Request) -> str:
     config = _resolve_form(request, form_id)
+    binding = _binding(request, form_id)
     _enforce_origin(request, config)
     _enforce_rate_limit(request, form_id)
     body = await request.body()
     if _single(body, "consent") != "yes":
         raise HTTPException(status_code=400, detail="Explicit consent is required.")
+    if binding is not None:
+        root = _resolved_tenant_root(request)
+        reserve_bound_tenant_usage(
+            root,
+            binding.tenant_id,
+            UsageKind.audit,
+        )
+        reserve_bound_tenant_usage(
+            root,
+            binding.tenant_id,
+            UsageKind.lead_submission,
+        )
     try:
         assessment = assess_url(_single(body, "website"))
     except (UnsafeTargetError, CollectionError) as exc:
@@ -118,6 +141,22 @@ async def submit_tenant_bound_embedded_audit(form_id: str, request: Request) -> 
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail="Invalid lead submission.") from exc
     lead_id = _save_lead(request, lead)
+    if binding is not None:
+        root = _resolved_tenant_root(request)
+        record_bound_tenant_usage(
+            root,
+            binding.tenant_id,
+            UsageKind.audit,
+            related_id=assessment_id,
+            note="Embedded tenant lead audit",
+        )
+        record_bound_tenant_usage(
+            root,
+            binding.tenant_id,
+            UsageKind.lead_submission,
+            related_id=lead_id,
+            note="Embedded tenant lead submission",
+        )
     webhook_store, email_store = _attempt_stores(request, form_id)
     await deliver_lead_webhook(
         lead_id=lead_id,

--- a/src/veridra/tenant_entitlements.py
+++ b/src/veridra/tenant_entitlements.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from pathlib import Path
 
 from fastapi import HTTPException
 
@@ -10,7 +11,9 @@ from .workspace_policy import (
     PLAN_CATALOGUE,
     UsageEvent,
     UsageKind,
+    UsageLedger,
     WorkspaceConfig,
+    WorkspaceStore,
     quota_decision,
 )
 
@@ -111,4 +114,51 @@ def record_tenant_usage(
             related_id=related_id,
             note=note,
         ),
+    )
+
+
+def _bound_workspace(
+    root: Path,
+    tenant_id: str,
+) -> tuple[WorkspaceStore, UsageLedger]:
+    directory = root / tenant_id / "workspace"
+    return WorkspaceStore(directory), UsageLedger(directory)
+
+
+def reserve_bound_tenant_usage(
+    root: Path,
+    tenant_id: str,
+    kind: UsageKind,
+    *,
+    quantity: int = 1,
+) -> None:
+    workspace_store, ledger = _bound_workspace(root, tenant_id)
+    if not workspace_store.path.exists():
+        return
+    workspace = workspace_store.load()
+    decision = quota_decision(workspace, ledger, kind, requested=quantity)
+    if not decision.allowed:
+        raise HTTPException(status_code=429, detail=decision.reason)
+
+
+def record_bound_tenant_usage(
+    root: Path,
+    tenant_id: str,
+    kind: UsageKind,
+    *,
+    quantity: int = 1,
+    related_id: str = "",
+    note: str = "",
+) -> str:
+    workspace_store, ledger = _bound_workspace(root, tenant_id)
+    if not workspace_store.path.exists():
+        return ""
+    return ledger.record(
+        UsageEvent(
+            kind=kind,
+            quantity=quantity,
+            occurred_at=datetime.now(UTC),
+            related_id=related_id,
+            note=note,
+        )
     )

--- a/tests/test_bound_tenant_usage.py
+++ b/tests/test_bound_tenant_usage.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from starlette.requests import Request
+
+from veridra.assessment_project_conversion_api import (
+    AssessmentProjectConversion,
+    convert_assessment,
+)
+from veridra.core import demo_assessment
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.tenant_entitlements import (
+    record_bound_tenant_usage,
+    reserve_bound_tenant_usage,
+)
+from veridra.tenant_project_store import TenantProjectStore
+from veridra.tenant_workspace_policy import TenantWorkspacePolicy
+from veridra.workspace_policy import PlanName, UsageKind, WorkspaceConfig, usage_period
+
+NOW = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="bound-tenant-usage-owner",
+    authenticated_at=NOW,
+)
+OTHER_TENANT_ID = "b" * 24
+
+
+def _request(root: Path) -> Request:
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/tenant/projects/from-assessment",
+            "headers": [],
+            "app": app,
+        }
+    )
+
+
+def test_bound_free_plan_rejects_lead_submission(tmp_path: Path) -> None:
+    root = tmp_path / "tenants"
+    TenantWorkspacePolicy(root).save(OWNER, WorkspaceConfig(plan=PlanName.free))
+
+    with pytest.raises(HTTPException) as exc_info:
+        reserve_bound_tenant_usage(
+            root,
+            OWNER.tenant_id,
+            UsageKind.lead_submission,
+        )
+
+    assert exc_info.value.status_code == 429
+
+
+def test_bound_usage_is_recorded_only_for_derived_tenant(tmp_path: Path) -> None:
+    root = tmp_path / "tenants"
+    policy = TenantWorkspacePolicy(root)
+    policy.save(OWNER, WorkspaceConfig(plan=PlanName.agency))
+
+    record_bound_tenant_usage(
+        root,
+        OWNER.tenant_id,
+        UsageKind.audit,
+        related_id="assessment-one",
+        note="bound audit",
+    )
+
+    workspace = policy.load(OWNER)
+    totals = policy.usage_ledger(OWNER).totals(usage_period(workspace))
+    assert totals[UsageKind.audit] == 1
+    assert not (root / OTHER_TENANT_ID / "workspace" / "usage").exists()
+
+
+def test_direct_conversion_uses_tenant_project_capacity(tmp_path: Path) -> None:
+    root = tmp_path / "tenants"
+    policy = TenantWorkspacePolicy(root)
+    policy.save(OWNER, WorkspaceConfig(plan=PlanName.free))
+    projects = TenantProjectStore(root)
+    projects.save(
+        OWNER,
+        ClientProject.build(name="Existing", target_url="https://example.com"),
+    )
+    payload = AssessmentProjectConversion(
+        assessment=demo_assessment().model_copy(
+            update={"target": "https://example.net/"}
+        ),
+        project_name="Second",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        convert_assessment(payload, _request(root), OWNER)
+
+    assert exc_info.value.status_code == 429
+    assert len(projects.list(OWNER)) == 1


### PR DESCRIPTION
Continues issue #115 from main `776b1ca695117a843870e0be9232ca1c0a16ad36`.

- adds server-internal quota and usage helpers for a tenant ID resolved from trusted binding data;
- reserves audit and lead-submission allowance before a bound public embedded audit runs;
- records successful audit and lead-submission usage beneath only the bound tenant;
- leaves unbound legacy forms unchanged;
- replaces the canonical assessment conversion service's global project-capacity helper with tenant-qualified capacity enforcement, including internal lead-conversion callers;
- adds tests for free-plan rejection, tenant-isolated bound usage, and direct conversion capacity.

Unconfigured-tenant activation semantics and any remaining legacy global helpers stay tracked in #115. This PR does not close the issue.

Requires full exact-head CI before merge.