### PR TITLE
Create free workspace during identity bootstrap

### DIFF
--- a/src/veridra/identity_bootstrap.py
+++ b/src/veridra/identity_bootstrap.py
@@ -127,13 +127,13 @@ class SQLiteIdentityBootstrap:
                 workspace_store = WorkspaceStore(
                     self.tenant_data_root / tenant.id / "workspace"
                 )
+                workspace_path = workspace_store.path
                 workspace_store.save(
                     WorkspaceConfig(
                         display_name=tenant.display_name,
                         plan=PlanName.free,
                     )
                 )
-                workspace_path = workspace_store.path
             connection.commit()
         except Exception:
             connection.rollback()

--- a/src/veridra/identity_bootstrap.py
+++ b/src/veridra/identity_bootstrap.py
@@ -14,6 +14,7 @@ from .identity_tenancy import (
 )
 from .password_auth import SQLitePasswordAuthenticator, hash_password
 from .sqlite_identity_store import SQLiteIdentityRecordStore
+from .workspace_policy import PlanName, WorkspaceConfig, WorkspaceStore
 
 BOOTSTRAP_CONFIRMATION = "CREATE-FIRST-OWNER"
 
@@ -31,8 +32,14 @@ class BootstrapResult:
 
 
 class SQLiteIdentityBootstrap:
-    def __init__(self, database: Path) -> None:
+    def __init__(
+        self,
+        database: Path,
+        *,
+        tenant_data_root: Path | None = None,
+    ) -> None:
         self.database = database
+        self.tenant_data_root = tenant_data_root
 
     def initialize(self) -> None:
         SQLiteIdentityRecordStore(self.database).initialize()
@@ -68,6 +75,7 @@ class SQLiteIdentityBootstrap:
         encoded_password = hash_password(password)
         self.initialize()
         connection = sqlite3.connect(self.database)
+        workspace_path: Path | None = None
         try:
             connection.execute("PRAGMA foreign_keys = ON")
             connection.execute("BEGIN IMMEDIATE")
@@ -115,9 +123,22 @@ class SQLiteIdentityBootstrap:
                 VALUES (?, ?, ?)""",
                 (user.id, encoded_password, now.isoformat()),
             )
+            if self.tenant_data_root is not None:
+                workspace_store = WorkspaceStore(
+                    self.tenant_data_root / tenant.id / "workspace"
+                )
+                workspace_store.save(
+                    WorkspaceConfig(
+                        display_name=tenant.display_name,
+                        plan=PlanName.free,
+                    )
+                )
+                workspace_path = workspace_store.path
             connection.commit()
         except Exception:
             connection.rollback()
+            if workspace_path is not None:
+                workspace_path.unlink(missing_ok=True)
             raise
         finally:
             connection.close()

--- a/src/veridra/identity_bootstrap_cli.py
+++ b/src/veridra/identity_bootstrap_cli.py
@@ -9,6 +9,7 @@ from .identity_bootstrap import (
     IdentityBootstrapError,
     SQLiteIdentityBootstrap,
 )
+from .tenant_project_store import default_tenant_data_directory
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -17,6 +18,14 @@ def build_parser() -> argparse.ArgumentParser:
         description="Create the first Veridra tenant owner in an empty identity database.",
     )
     parser.add_argument("--database", required=True, type=Path)
+    parser.add_argument(
+        "--tenant-data-root",
+        type=Path,
+        help=(
+            "Tenant data directory. Defaults to the configured Veridra tenant data "
+            "directory. The initial free workspace is created here."
+        ),
+    )
     parser.add_argument("--tenant-slug", required=True)
     parser.add_argument("--tenant-name", required=True)
     parser.add_argument("--owner-email", required=True)
@@ -36,8 +45,16 @@ def main(argv: list[str] | None = None) -> int:
     if password != confirmation:
         print("Passwords do not match.")
         return 2
+    tenant_data_root = (
+        args.tenant_data_root.expanduser().resolve()
+        if args.tenant_data_root is not None
+        else default_tenant_data_directory()
+    )
     try:
-        result = SQLiteIdentityBootstrap(args.database.expanduser().resolve()).create_first_owner(
+        result = SQLiteIdentityBootstrap(
+            args.database.expanduser().resolve(),
+            tenant_data_root=tenant_data_root,
+        ).create_first_owner(
             tenant_slug=args.tenant_slug,
             tenant_name=args.tenant_name,
             owner_email=args.owner_email,

--- a/tests/test_identity_bootstrap_cli.py
+++ b/tests/test_identity_bootstrap_cli.py
@@ -7,14 +7,17 @@ import pytest
 from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION
 from veridra.identity_bootstrap_cli import main
 from veridra.password_auth import SQLitePasswordAuthenticator
+from veridra.workspace_policy import PlanName, WorkspaceStore
 
 PASSWORD = "correct-horse-battery-staple"
 
 
-def _args(database: Path) -> list[str]:
+def _args(database: Path, tenant_data_root: Path) -> list[str]:
     return [
         "--database",
         str(database),
+        "--tenant-data-root",
+        str(tenant_data_root),
         "--tenant-slug",
         "customer-one",
         "--tenant-name",
@@ -28,37 +31,46 @@ def _args(database: Path) -> list[str]:
     ]
 
 
-def test_cli_bootstraps_without_password_in_arguments(
+def test_cli_bootstraps_owner_and_free_workspace(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     database = tmp_path / "identity.sqlite3"
+    tenant_data_root = tmp_path / "tenants"
     answers = iter([PASSWORD, PASSWORD])
     monkeypatch.setattr("getpass.getpass", lambda _prompt: next(answers))
 
-    result = main(_args(database))
+    result = main(_args(database, tenant_data_root))
 
     assert result == 0
-    assert "Bootstrap complete" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "Bootstrap complete" in output
     records = SQLitePasswordAuthenticator(database).authenticate(
         email="owner@example.com",
         tenant_slug="customer-one",
         password=PASSWORD,
     )
     assert records is not None
-    assert PASSWORD not in _args(database)
+    workspace = WorkspaceStore(
+        tenant_data_root / records.tenant.id / "workspace"
+    ).load()
+    assert workspace.plan == PlanName.free
+    assert workspace.display_name == "Customer one"
+    assert PASSWORD not in _args(database, tenant_data_root)
 
 
-def test_cli_rejects_password_mismatch(
+def test_cli_rejects_password_mismatch_without_workspace(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     answers = iter([PASSWORD, "different-password-value"])
     monkeypatch.setattr("getpass.getpass", lambda _prompt: next(answers))
+    tenant_data_root = tmp_path / "tenants"
 
-    result = main(_args(tmp_path / "identity.sqlite3"))
+    result = main(_args(tmp_path / "identity.sqlite3", tenant_data_root))
 
     assert result == 2
     assert "Passwords do not match" in capsys.readouterr().out
+    assert not tenant_data_root.exists()

--- a/tests/test_identity_bootstrap_workspace.py
+++ b/tests/test_identity_bootstrap_workspace.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_tenancy import Tenant
+from veridra.workspace_policy import PlanName, WorkspaceStore
+
+NOW = datetime(2026, 7, 27, 19, 0, tzinfo=UTC)
+PASSWORD = "correct-horse-battery-staple"
+
+
+def _create(bootstrap: SQLiteIdentityBootstrap) -> None:
+    bootstrap.create_first_owner(
+        tenant_slug="customer-one",
+        tenant_name="Customer one",
+        owner_email="owner@example.com",
+        owner_name="Owner",
+        password=PASSWORD,
+        confirmation=BOOTSTRAP_CONFIRMATION,
+        created_at=NOW,
+    )
+
+
+def test_direct_bootstrap_creates_free_tenant_workspace(tmp_path: Path) -> None:
+    database = tmp_path / "identity.sqlite3"
+    tenant_root = tmp_path / "tenants"
+    bootstrap = SQLiteIdentityBootstrap(database, tenant_data_root=tenant_root)
+
+    result = bootstrap.create_first_owner(
+        tenant_slug="customer-one",
+        tenant_name="Customer one",
+        owner_email="owner@example.com",
+        owner_name="Owner",
+        password=PASSWORD,
+        confirmation=BOOTSTRAP_CONFIRMATION,
+        created_at=NOW,
+    )
+
+    workspace = WorkspaceStore(tenant_root / result.tenant_id / "workspace").load()
+    assert workspace.plan == PlanName.free
+    assert workspace.display_name == "Customer one"
+
+
+def test_workspace_failure_rolls_back_identity_and_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = tmp_path / "identity.sqlite3"
+    tenant_root = tmp_path / "tenants"
+    bootstrap = SQLiteIdentityBootstrap(database, tenant_data_root=tenant_root)
+    original_save = WorkspaceStore.save
+
+    def fail_after_write(store: WorkspaceStore, workspace: object) -> None:
+        original_save(store, workspace)  # type: ignore[arg-type]
+        raise OSError("workspace write failed")
+
+    monkeypatch.setattr(WorkspaceStore, "save", fail_after_write)
+
+    with pytest.raises(OSError, match="workspace write failed"):
+        _create(bootstrap)
+
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM tenants").fetchone()[0] == 0
+        assert connection.execute("SELECT COUNT(*) FROM users").fetchone()[0] == 0
+        assert connection.execute("SELECT COUNT(*) FROM memberships").fetchone()[0] == 0
+        assert connection.execute(
+            "SELECT COUNT(*) FROM password_credentials"
+        ).fetchone()[0] == 0
+
+    tenant = Tenant.build(
+        slug="customer-one",
+        display_name="Customer one",
+        now=NOW,
+    )
+    workspace_path = tenant_root / tenant.id / "workspace" / "workspace.json"
+    assert not workspace_path.exists()

--- a/tests/test_identity_bootstrap_workspace.py
+++ b/tests/test_identity_bootstrap_workspace.py
@@ -8,7 +8,7 @@ import pytest
 
 from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
 from veridra.identity_tenancy import Tenant
-from veridra.workspace_policy import PlanName, WorkspaceStore
+from veridra.workspace_policy import PlanName, WorkspaceConfig, WorkspaceStore
 
 NOW = datetime(2026, 7, 27, 19, 0, tzinfo=UTC)
 PASSWORD = "correct-horse-battery-staple"
@@ -55,8 +55,8 @@ def test_workspace_failure_rolls_back_identity_and_file(
     bootstrap = SQLiteIdentityBootstrap(database, tenant_data_root=tenant_root)
     original_save = WorkspaceStore.save
 
-    def fail_after_write(store: WorkspaceStore, workspace: object) -> None:
-        original_save(store, workspace)  # type: ignore[arg-type]
+    def fail_after_write(store: WorkspaceStore, workspace: WorkspaceConfig) -> None:
+        original_save(store, workspace)
         raise OSError("workspace write failed")
 
     monkeypatch.setattr(WorkspaceStore, "save", fail_after_write)


### PR DESCRIPTION
Continues issue #115 from main `24b16b559da6417a208fd6ce96b858b4884f711d`.

- initializes the first tenant with a persisted Free workspace during first-owner bootstrap;
- uses the tenant display name for the workspace display name;
- adds an explicit `--tenant-data-root` CLI option and otherwise uses the configured tenant data directory;
- creates the workspace before committing identity records so paid-only compatibility mode is not the first-run state;
- removes the workspace file if bootstrap fails and rolls back SQLite identity records;
- adds direct and CLI tests for Free initialization, password-mismatch no-write behavior, and filesystem-failure rollback.

No payment, checkout, or external subscription state is created. Legacy global workspace-file handling and authenticated audit/crawled-page metering remain tracked in #115; this PR does not close the issue.

Requires full exact-head CI before merge.