### PR TITLE
Meter authenticated assessments and crawled pages by tenant

### DIFF
--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -35,6 +35,7 @@ from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
 from .session_api import router as session_router
 from .task_web import router as task_router
+from .tenant_assessment_routes import router as tenant_assessment_router
 from .tenant_bound_lead_capture import router as tenant_bound_lead_capture_router
 from .tenant_history_api import router as tenant_history_router
 from .tenant_lead_api import router as tenant_lead_router
@@ -90,8 +91,20 @@ lead_router.routes[:] = [
     )
 ]
 
+_replaced_assessment_paths = {"/", "/api/assess", "/report", "/export"}
+app.router.routes[:] = [
+    route
+    for route in app.router.routes
+    if not (
+        isinstance(route, APIRoute)
+        and route.path in _replaced_assessment_paths
+        and route.methods == {"GET"}
+    )
+]
+
 app.middleware("http")(enforce_workspace_policy)
 configure_identity_middleware(app)
+app.include_router(tenant_assessment_router)
 app.include_router(operations_router)
 app.include_router(auth_router)
 app.include_router(password_recovery_router)

--- a/src/veridra/tenant_assessment_routes.py
+++ b/src/veridra/tenant_assessment_routes.py
@@ -84,7 +84,7 @@ def index(
     status: str | None = Query(default=None, max_length=16),
     profile: str | None = Query(default=None, max_length=24),
 ) -> str:
-    selected_profile = _profile(profile)
+    _profile(profile)
     entries = ProfileStore().list()
     if demo or url is None:
         return dashboard(
@@ -115,5 +115,3 @@ def index(
             selected_profile=profile,
             profile_entries=entries,
         )
-    finally:
-        del selected_profile

--- a/src/veridra/tenant_assessment_routes.py
+++ b/src/veridra/tenant_assessment_routes.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi.responses import HTMLResponse
+
+from .app import dashboard
+from .collector import CollectionError
+from .core import Assessment, UnsafeTargetError, demo_assessment
+from .exports import build_evidence_package
+from .profile_store import ProfileStore
+from .report_profiles import ReportProfile
+from .reports import render_report
+from .tenant_assessment_usage import assess_for_request
+
+router = APIRouter(tags=["tenant-assessments"])
+
+
+def _profile(profile: str | None) -> ReportProfile:
+    from .app import _resolve_profile
+
+    return _resolve_profile(profile)
+
+
+def _assessment(
+    request: Request,
+    url: str | None,
+    demo: bool,
+) -> Assessment:
+    if demo:
+        return demo_assessment()
+    if url is None:
+        raise HTTPException(status_code=400, detail="A target URL is required.")
+    try:
+        return assess_for_request(request, url)
+    except (UnsafeTargetError, CollectionError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/api/assess")
+def assess(
+    request: Request,
+    url: str = Query(min_length=1, max_length=2048),
+) -> dict[str, object]:
+    return _assessment(request, url, False).model_dump(mode="json")
+
+
+@router.get("/report", response_class=HTMLResponse)
+def report(
+    request: Request,
+    url: str | None = Query(default=None, min_length=1, max_length=2048),
+    demo: bool = False,
+    profile: str | None = Query(default=None, max_length=24),
+) -> str:
+    return render_report(_assessment(request, url, demo), _profile(profile))
+
+
+@router.get("/export")
+def export(
+    request: Request,
+    url: str | None = Query(default=None, min_length=1, max_length=2048),
+    demo: bool = False,
+    profile: str | None = Query(default=None, max_length=24),
+) -> Response:
+    package = build_evidence_package(
+        _assessment(request, url, demo),
+        _profile(profile),
+    )
+    return Response(
+        content=package.content,
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{package.filename}"',
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@router.get("/", response_class=HTMLResponse)
+def index(
+    request: Request,
+    url: str | None = Query(default=None, min_length=1, max_length=2048),
+    demo: bool = False,
+    area: str | None = Query(default=None, max_length=64),
+    status: str | None = Query(default=None, max_length=16),
+    profile: str | None = Query(default=None, max_length=24),
+) -> str:
+    selected_profile = _profile(profile)
+    entries = ProfileStore().list()
+    if demo or url is None:
+        return dashboard(
+            demo_assessment(),
+            demo_mode=True,
+            area=area,
+            status=status,
+            selected_profile=profile,
+            profile_entries=entries,
+        )
+    try:
+        return dashboard(
+            assess_for_request(request, url),
+            submitted_url=url,
+            area=area,
+            status=status,
+            selected_profile=profile,
+            profile_entries=entries,
+        )
+    except (UnsafeTargetError, CollectionError) as exc:
+        return dashboard(
+            demo_assessment(),
+            submitted_url=url,
+            error=str(exc),
+            demo_mode=True,
+            area=area,
+            status=status,
+            selected_profile=profile,
+            profile_entries=entries,
+        )
+    finally:
+        del selected_profile

--- a/src/veridra/tenant_assessment_usage.py
+++ b/src/veridra/tenant_assessment_usage.py
@@ -8,7 +8,7 @@ from .core import Assessment
 from .crawl_profiles import anonymous_crawl_profile
 from .identity_tenancy import RequestIdentity
 from .service import assess_url
-from .tenant_workspace_enforcement import (
+from .tenant_entitlements import (
     record_tenant_usage,
     reserve_tenant_usage,
     tenant_workspace_active,

--- a/src/veridra/tenant_assessment_usage.py
+++ b/src/veridra/tenant_assessment_usage.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 from fastapi import Request
 
+from . import app as app_module
 from .core import Assessment
 from .crawl_profiles import anonymous_crawl_profile
 from .identity_tenancy import RequestIdentity
-from .service import assess_url
 from .tenant_entitlements import (
     record_tenant_usage,
     reserve_tenant_usage,
@@ -50,7 +50,7 @@ def assess_for_request(request: Request, url: str) -> Assessment:
             UsageKind.crawled_page,
             quantity=anonymous_crawl_profile().limits.max_pages,
         )
-    assessment = assess_url(url)
+    assessment = app_module.assess_url(url)
     if active and identity is not None:
         related_id = str(assessment.target)
         record_tenant_usage(

--- a/src/veridra/tenant_assessment_usage.py
+++ b/src/veridra/tenant_assessment_usage.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, cast
+from typing import cast
 
 from fastapi import Request
 
@@ -53,7 +54,7 @@ def assess_for_request(request: Request, url: str) -> Assessment:
         )
     assessor = cast(
         Callable[[str], Assessment],
-        getattr(app_module, "assess_url"),
+        vars(app_module)["assess_url"],
     )
     assessment = assessor(url)
     if active and identity is not None:

--- a/src/veridra/tenant_assessment_usage.py
+++ b/src/veridra/tenant_assessment_usage.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import Request
+
+from .core import Assessment
+from .crawl_profiles import anonymous_crawl_profile
+from .identity_tenancy import RequestIdentity
+from .service import assess_url
+from .tenant_workspace_enforcement import (
+    record_tenant_usage,
+    reserve_tenant_usage,
+    tenant_workspace_active,
+)
+from .tenant_workspace_policy import TenantWorkspacePolicy
+from .workspace_policy import UsageKind
+
+
+def _identity(request: Request) -> RequestIdentity | None:
+    candidate = getattr(request.state, "veridra_verified_identity", None)
+    return candidate if isinstance(candidate, RequestIdentity) else None
+
+
+def _policy(request: Request) -> TenantWorkspacePolicy:
+    configured = getattr(request.app.state, "veridra_tenant_data_root", None)
+    root = configured if isinstance(configured, Path) else None
+    return TenantWorkspacePolicy(root)
+
+
+def crawled_page_count(assessment: Assessment) -> int:
+    for finding in assessment.findings:
+        if finding.id != "crawl.http-status":
+            continue
+        value = finding.evidence.get("crawled_pages")
+        if isinstance(value, int) and value > 0:
+            return value
+    return 1
+
+
+def assess_for_request(request: Request, url: str) -> Assessment:
+    identity = _identity(request)
+    policy = _policy(request)
+    active = identity is not None and tenant_workspace_active(policy, identity)
+    if active and identity is not None:
+        reserve_tenant_usage(policy, identity, UsageKind.audit)
+        reserve_tenant_usage(
+            policy,
+            identity,
+            UsageKind.crawled_page,
+            quantity=anonymous_crawl_profile().limits.max_pages,
+        )
+    assessment = assess_url(url)
+    if active and identity is not None:
+        related_id = str(assessment.target)
+        record_tenant_usage(
+            policy,
+            identity,
+            UsageKind.audit,
+            related_id=related_id,
+            note="Authenticated website assessment",
+        )
+        record_tenant_usage(
+            policy,
+            identity,
+            UsageKind.crawled_page,
+            quantity=crawled_page_count(assessment),
+            related_id=related_id,
+            note="Successful bounded crawl pages",
+        )
+    return assessment

--- a/src/veridra/tenant_assessment_usage.py
+++ b/src/veridra/tenant_assessment_usage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Callable, cast
 
 from fastapi import Request
 
@@ -50,7 +51,11 @@ def assess_for_request(request: Request, url: str) -> Assessment:
             UsageKind.crawled_page,
             quantity=anonymous_crawl_profile().limits.max_pages,
         )
-    assessment = app_module.assess_url(url)
+    assessor = cast(
+        Callable[[str], Assessment],
+        getattr(app_module, "assess_url"),
+    )
+    assessment = assessor(url)
     if active and identity is not None:
         related_id = str(assessment.target)
         record_tenant_usage(

--- a/tests/test_tenant_assessment_usage.py
+++ b/tests/test_tenant_assessment_usage.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from starlette.requests import Request
+
+from veridra.core import Assessment, Finding, Status
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_assessment_usage import assess_for_request, crawled_page_count
+from veridra.tenant_workspace_policy import TenantWorkspacePolicy
+from veridra.workspace_policy import PlanName, UsageEvent, UsageKind, WorkspaceConfig
+
+NOW = datetime(2026, 7, 27, 20, 0, tzinfo=UTC)
+
+
+def _identity(tenant_id: str = "a" * 24) -> RequestIdentity:
+    return RequestIdentity(
+        user_id="b" * 24,
+        tenant_id=tenant_id,
+        membership_role=TenantRole.owner,
+        session_id="c" * 24,
+        authenticated_at=NOW,
+    )
+
+
+def _request(tmp_path: Path, identity: RequestIdentity | None) -> Request:
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path / "tenants"
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/assess",
+            "headers": [],
+            "app": app,
+        }
+    )
+    if identity is not None:
+        bind_verified_request_identity(request, identity)
+    return request
+
+
+def _assessment(*, pages: int = 4) -> Assessment:
+    return Assessment.build(
+        "https://example.com/",
+        [
+            Finding(
+                id="crawl.http-status",
+                area="Website health",
+                title="Multi-page page response",
+                status=Status.passed,
+                severity="info",
+                summary="Crawl completed.",
+                evidence={"crawled_pages": pages},
+            )
+        ],
+        generated_at=NOW,
+    )
+
+
+def test_crawled_page_count_uses_crawl_evidence() -> None:
+    assert crawled_page_count(_assessment(pages=7)) == 7
+
+
+def test_crawled_page_count_falls_back_to_one() -> None:
+    assessment = Assessment.build(
+        "https://example.com/",
+        [],
+        generated_at=NOW,
+    )
+    assert crawled_page_count(assessment) == 1
+
+
+def test_authenticated_assessment_records_tenant_usage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _identity()
+    request = _request(tmp_path, identity)
+    policy = TenantWorkspacePolicy(tmp_path / "tenants")
+    policy.save(identity, WorkspaceConfig(plan=PlanName.agency))
+    monkeypatch.setattr(
+        "veridra.tenant_assessment_usage.assess_url",
+        lambda _url: _assessment(pages=4),
+    )
+
+    result = assess_for_request(request, "https://example.com")
+
+    assert result.target.host == "example.com"
+    totals = policy.usage_ledger(identity).totals(
+        __import__("veridra.workspace_policy", fromlist=["usage_period"]).usage_period(
+            policy.load(identity), now=NOW
+        )
+    )
+    assert totals[UsageKind.audit] == 1
+    assert totals[UsageKind.crawled_page] == 4
+
+
+def test_exhausted_audit_allowance_blocks_before_collection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = _identity()
+    request = _request(tmp_path, identity)
+    policy = TenantWorkspacePolicy(tmp_path / "tenants")
+    policy.save(identity, WorkspaceConfig(plan=PlanName.free))
+    for index in range(3):
+        policy.record_usage(
+            identity,
+            UsageEvent(
+                kind=UsageKind.audit,
+                quantity=1,
+                occurred_at=NOW,
+                related_id=f"existing-{index}",
+            ),
+        )
+    called = False
+
+    def fake_assess(_url: str) -> Assessment:
+        nonlocal called
+        called = True
+        return _assessment()
+
+    monkeypatch.setattr("veridra.tenant_assessment_usage.assess_url", fake_assess)
+
+    with pytest.raises(HTTPException) as exc_info:
+        assess_for_request(request, "https://example.com")
+
+    assert exc_info.value.status_code == 429
+    assert called is False
+
+
+def test_anonymous_assessment_preserves_unmetered_compatibility(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _request(tmp_path, None)
+    monkeypatch.setattr(
+        "veridra.tenant_assessment_usage.assess_url",
+        lambda _url: _assessment(pages=2),
+    )
+
+    assess_for_request(request, "https://example.com")
+
+    assert not (tmp_path / "tenants").exists()

--- a/tests/test_tenant_assessment_usage.py
+++ b/tests/test_tenant_assessment_usage.py
@@ -12,7 +12,13 @@ from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.request_security import bind_verified_request_identity
 from veridra.tenant_assessment_usage import assess_for_request, crawled_page_count
 from veridra.tenant_workspace_policy import TenantWorkspacePolicy
-from veridra.workspace_policy import PlanName, UsageEvent, UsageKind, WorkspaceConfig
+from veridra.workspace_policy import (
+    PlanName,
+    UsageEvent,
+    UsageKind,
+    WorkspaceConfig,
+    usage_period,
+)
 
 NOW = datetime(2026, 7, 27, 20, 0, tzinfo=UTC)
 
@@ -84,7 +90,7 @@ def test_authenticated_assessment_records_tenant_usage(
     policy = TenantWorkspacePolicy(tmp_path / "tenants")
     policy.save(identity, WorkspaceConfig(plan=PlanName.agency))
     monkeypatch.setattr(
-        "veridra.tenant_assessment_usage.assess_url",
+        "veridra.app.assess_url",
         lambda _url: _assessment(pages=4),
     )
 
@@ -92,9 +98,7 @@ def test_authenticated_assessment_records_tenant_usage(
 
     assert result.target.host == "example.com"
     totals = policy.usage_ledger(identity).totals(
-        __import__("veridra.workspace_policy", fromlist=["usage_period"]).usage_period(
-            policy.load(identity), now=NOW
-        )
+        usage_period(policy.load(identity), now=NOW)
     )
     assert totals[UsageKind.audit] == 1
     assert totals[UsageKind.crawled_page] == 4
@@ -125,7 +129,7 @@ def test_exhausted_audit_allowance_blocks_before_collection(
         called = True
         return _assessment()
 
-    monkeypatch.setattr("veridra.tenant_assessment_usage.assess_url", fake_assess)
+    monkeypatch.setattr("veridra.app.assess_url", fake_assess)
 
     with pytest.raises(HTTPException) as exc_info:
         assess_for_request(request, "https://example.com")
@@ -140,7 +144,7 @@ def test_anonymous_assessment_preserves_unmetered_compatibility(
 ) -> None:
     request = _request(tmp_path, None)
     monkeypatch.setattr(
-        "veridra.tenant_assessment_usage.assess_url",
+        "veridra.app.assess_url",
         lambda _url: _assessment(pages=2),
     )
 


### PR DESCRIPTION
Final implementation slice for issue #115 from current main `dff250f2c76b698b71c40b4a8169d5758659aa82`.

- adds a request-aware assessment boundary that preserves anonymous standalone compatibility;
- reserves one audit and the active anonymous crawl profile page allowance before collection for configured authenticated tenants;
- records one successful audit and the actual crawled-page count from deterministic crawl evidence;
- replaces only `/`, `/api/assess`, `/report`, and `/export` in the composed runtime while leaving the standalone app compatible;
- keeps demo assessments unmetered;
- keeps existing report and export behavior;
- adds tests for page-count extraction, tenant-local usage, quota rejection before collection, and anonymous compatibility.

A follow-up cleanup in this PR may remove obsolete process-global helper functions after exact repository search and CI evidence.

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit, and evidence upload before readiness or merge.