### PR TITLE
Quarantine legacy global workspace policy state

### DIFF
--- a/docs/workspace-policy-migration.md
+++ b/docs/workspace-policy-migration.md
@@ -1,0 +1,34 @@
+# Workspace policy migration boundary
+
+Veridra's composed authenticated runtime uses tenant-qualified workspace configuration, usage evidence, quota enforcement and plan-change audit records.
+
+## Authoritative tenant state
+
+For an authenticated tenant, the authoritative files are stored below that tenant's data root:
+
+```text
+<tenant-root>/<tenant-id>/workspace/workspace.json
+<tenant-root>/<tenant-id>/workspace/usage/*.json
+<tenant-root>/<tenant-id>/workspace/plan-changes/*.json
+```
+
+The first-owner bootstrap creates a persisted Free workspace before committing the identity records. A failed bootstrap removes the workspace file and rolls back the identity transaction.
+
+## Legacy process-global files
+
+Older local versions may contain ambiguous files below the process-global workspace directory:
+
+```text
+<VERIDRA_DATA_DIR>/workspace/workspace.json
+<VERIDRA_DATA_DIR>/workspace/usage/*.json
+```
+
+These files are **not** automatically migrated, copied, merged or attributed to any tenant. Their original tenant ownership cannot be proven from the file format, so automatic attachment would risk cross-tenant leakage or incorrect billing evidence.
+
+The legacy helper functions retained in `workspace_web.py` are quarantined for standalone compatibility only. The composed runtime and supported tenant services must not import or call them.
+
+An administrator may archive or delete the legacy directory after independently confirming it is no longer needed. A future explicit migration command would need a human-supplied tenant ID and a preview before any write; no implicit migration is permitted.
+
+## Commercial-state limitation
+
+Workspace plans remain local entitlement policy. They do not prove payment, create a subscription, charge a payment method, issue an invoice or synchronize with an external billing provider.

--- a/src/veridra/crawl_profile_web.py
+++ b/src/veridra/crawl_profile_web.py
@@ -1,20 +1,29 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Query, Response
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
 from fastapi.responses import HTMLResponse
 
 from .collector import CollectionError
 from .core import Assessment, UnsafeTargetError
 from .crawl_profiles import CrawlProfile, resolve_crawl_profile
 from .exports import build_evidence_package
+from .identity_tenancy import RequestIdentity
 from .pdf_reports import PdfRenderError, render_pdf
 from .profile_store import ProfileStore, ProfileStoreError
 from .project_store import ClientProject, ProjectStore, ProjectStoreError
 from .report_profiles import DEFAULT_REPORT_PROFILE, ReportProfile
 from .reports import render_report
 from .service import assess_url
+from .tenant_assessment_usage import crawled_page_count
+from .tenant_entitlements import (
+    record_tenant_usage,
+    reserve_tenant_usage,
+    tenant_workspace_active,
+)
+from .tenant_workspace_policy import TenantWorkspacePolicy
 from .workspace_policy import UsageKind
-from .workspace_web import record_usage, reserve_usage
 
 router = APIRouter(prefix="/crawl", tags=["crawl profiles"])
 
@@ -50,37 +59,80 @@ def _project(entry_id: str) -> ClientProject:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-def _assessment(url: str, profile: CrawlProfile) -> Assessment:
-    reserve_usage(UsageKind.audit)
-    reserve_usage(UsageKind.crawled_page, quantity=profile.limits.max_pages)
+def _tenant_context(
+    request: Request,
+) -> tuple[TenantWorkspacePolicy, RequestIdentity] | None:
+    identity = getattr(request.state, "veridra_verified_identity", None)
+    if not isinstance(identity, RequestIdentity):
+        return None
+    configured = getattr(request.app.state, "veridra_tenant_data_root", None)
+    root = configured if isinstance(configured, Path) else None
+    policy = TenantWorkspacePolicy(root)
+    if not tenant_workspace_active(policy, identity):
+        return None
+    return policy, identity
+
+
+def _reserve(request: Request, kind: UsageKind, *, quantity: int = 1) -> None:
+    context = _tenant_context(request)
+    if context is not None:
+        reserve_tenant_usage(context[0], context[1], kind, quantity=quantity)
+
+
+def _record(
+    request: Request,
+    kind: UsageKind,
+    *,
+    quantity: int = 1,
+    related_id: str = "",
+    note: str = "",
+) -> None:
+    context = _tenant_context(request)
+    if context is not None:
+        record_tenant_usage(
+            context[0],
+            context[1],
+            kind,
+            quantity=quantity,
+            related_id=related_id,
+            note=note,
+        )
+
+
+def _assessment(url: str, profile: CrawlProfile, request: Request) -> Assessment:
+    _reserve(request, UsageKind.audit)
+    _reserve(request, UsageKind.crawled_page, quantity=profile.limits.max_pages)
     try:
         assessment = assess_url(url, crawl_profile=profile)
     except (UnsafeTargetError, CollectionError, ValueError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     correlation = str(assessment.target)
-    record_usage(UsageKind.audit, related_id=correlation, note=profile.name.value)
-    record_usage(
+    _record(request, UsageKind.audit, related_id=correlation, note=profile.name.value)
+    _record(
+        request,
         UsageKind.crawled_page,
-        quantity=profile.limits.max_pages,
+        quantity=crawled_page_count(assessment),
         related_id=correlation,
-        note=f"Reserved crawl capacity for {profile.name.value} profile",
+        note=f"Successful {profile.name.value} crawl pages",
     )
     return assessment
 
 
 @router.get("/assess")
 def crawl_assess(
+    request: Request,
     url: str = Query(min_length=1, max_length=2048),
     crawl_profile: str = Query(default="quick", max_length=16),
     max_pages: int | None = Query(default=None),
     max_depth: int | None = Query(default=None),
 ) -> dict[str, object]:
     active = _profile(crawl_profile, max_pages, max_depth)
-    return _assessment(url, active).model_dump(mode="json")
+    return _assessment(url, active, request).model_dump(mode="json")
 
 
 @router.get("/report", response_class=HTMLResponse)
 def crawl_report(
+    request: Request,
     url: str = Query(min_length=1, max_length=2048),
     crawl_profile: str = Query(default="quick", max_length=16),
     max_pages: int | None = Query(default=None),
@@ -88,20 +140,21 @@ def crawl_report(
     profile: str | None = Query(default=None, max_length=24),
 ) -> str:
     active = _profile(crawl_profile, max_pages, max_depth)
-    return render_report(_assessment(url, active), _report_profile(profile))
+    return render_report(_assessment(url, active, request), _report_profile(profile))
 
 
 @router.get("/report.pdf")
 def crawl_report_pdf(
+    request: Request,
     url: str = Query(min_length=1, max_length=2048),
     crawl_profile: str = Query(default="quick", max_length=16),
     max_pages: int | None = Query(default=None),
     max_depth: int | None = Query(default=None),
     profile: str | None = Query(default=None, max_length=24),
 ) -> Response:
-    reserve_usage(UsageKind.pdf)
+    _reserve(request, UsageKind.pdf)
     active = _profile(crawl_profile, max_pages, max_depth)
-    assessment = _assessment(url, active)
+    assessment = _assessment(url, active, request)
     try:
         document = render_pdf(
             render_report(assessment, _report_profile(profile)),
@@ -109,7 +162,7 @@ def crawl_report_pdf(
         )
     except PdfRenderError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
-    record_usage(UsageKind.pdf, related_id=str(assessment.target))
+    _record(request, UsageKind.pdf, related_id=str(assessment.target))
     return Response(
         content=document.content,
         media_type="application/pdf",
@@ -123,17 +176,18 @@ def crawl_report_pdf(
 
 @router.get("/export")
 def crawl_export(
+    request: Request,
     url: str = Query(min_length=1, max_length=2048),
     crawl_profile: str = Query(default="quick", max_length=16),
     max_pages: int | None = Query(default=None),
     max_depth: int | None = Query(default=None),
     profile: str | None = Query(default=None, max_length=24),
 ) -> Response:
-    reserve_usage(UsageKind.export)
+    _reserve(request, UsageKind.export)
     active = _profile(crawl_profile, max_pages, max_depth)
-    assessment = _assessment(url, active)
+    assessment = _assessment(url, active, request)
     package = build_evidence_package(assessment, _report_profile(profile))
-    record_usage(UsageKind.export, related_id=str(assessment.target))
+    _record(request, UsageKind.export, related_id=str(assessment.target))
     return Response(
         content=package.content,
         media_type="application/zip",
@@ -145,28 +199,37 @@ def crawl_export(
 
 
 @router.get("/projects/{entry_id}/assess")
-def project_crawl_assess(entry_id: str) -> dict[str, object]:
+def project_crawl_assess(entry_id: str, request: Request) -> dict[str, object]:
     project = _project(entry_id)
     return _assessment(
         project.target_url,
         project.resolved_crawl_profile(),
+        request,
     ).model_dump(mode="json")
 
 
 @router.get("/projects/{entry_id}/report", response_class=HTMLResponse)
-def project_crawl_report(entry_id: str) -> str:
+def project_crawl_report(entry_id: str, request: Request) -> str:
     project = _project(entry_id)
-    assessment = _assessment(project.target_url, project.resolved_crawl_profile())
+    assessment = _assessment(
+        project.target_url,
+        project.resolved_crawl_profile(),
+        request,
+    )
     return render_report(assessment, _report_profile(project.profile_id))
 
 
 @router.get("/projects/{entry_id}/export")
-def project_crawl_export(entry_id: str) -> Response:
-    reserve_usage(UsageKind.export)
+def project_crawl_export(entry_id: str, request: Request) -> Response:
+    _reserve(request, UsageKind.export)
     project = _project(entry_id)
-    assessment = _assessment(project.target_url, project.resolved_crawl_profile())
+    assessment = _assessment(
+        project.target_url,
+        project.resolved_crawl_profile(),
+        request,
+    )
     package = build_evidence_package(assessment, _report_profile(project.profile_id))
-    record_usage(UsageKind.export, related_id=str(assessment.target))
+    _record(request, UsageKind.export, related_id=str(assessment.target))
     return Response(
         content=package.content,
         media_type="application/zip",

--- a/tests/test_crawl_profile_web.py
+++ b/tests/test_crawl_profile_web.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
 
+from fastapi import Request
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
@@ -17,8 +18,9 @@ from veridra.runtime import app
 
 def _capture_assessment(
     captured: list[CrawlProfile],
-) -> Callable[[str, CrawlProfile], Assessment]:
-    def fake(url: str, profile: CrawlProfile) -> Assessment:
+) -> Callable[[str, CrawlProfile, Request], Assessment]:
+    def fake(url: str, profile: CrawlProfile, request: Request) -> Assessment:
+        del url, request
         captured.append(profile)
         return demo_assessment()
 

--- a/tests/test_workspace_policy_migration_boundary.py
+++ b/tests/test_workspace_policy_migration_boundary.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.tenant_workspace_policy import TenantWorkspacePolicy
-from veridra.workspace_policy import PlanName, UsageEvent, UsageKind, WorkspaceConfig, WorkspaceStore
+from veridra.workspace_policy import (
+    PlanName,
+    UsageEvent,
+    UsageKind,
+    WorkspaceConfig,
+    WorkspaceStore,
+)
 
 NOW = datetime(2026, 7, 27, 21, 0, tzinfo=UTC)
 IDENTITY = RequestIdentity(

--- a/tests/test_workspace_policy_migration_boundary.py
+++ b/tests/test_workspace_policy_migration_boundary.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.tenant_workspace_policy import TenantWorkspacePolicy
+from veridra.workspace_policy import PlanName, UsageEvent, UsageKind, WorkspaceConfig, WorkspaceStore
+
+NOW = datetime(2026, 7, 27, 21, 0, tzinfo=UTC)
+IDENTITY = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="workspace-migration-boundary",
+    authenticated_at=NOW,
+)
+
+LEGACY_NAMES = {
+    "workspace_policy_active",
+    "active_entitlements",
+    "require_feature",
+    "require_project_capacity",
+    "reserve_usage",
+    "record_usage",
+}
+
+
+def test_tenant_policy_ignores_ambiguous_global_workspace_and_usage(tmp_path: Path) -> None:
+    global_store = WorkspaceStore(tmp_path / "workspace")
+    global_store.save(WorkspaceConfig(plan=PlanName.agency))
+    global_store.directory.joinpath("usage").mkdir(parents=True, exist_ok=True)
+    global_store.directory.joinpath("usage", "legacy.json").write_text(
+        UsageEvent(
+            kind=UsageKind.audit,
+            quantity=99,
+            occurred_at=NOW,
+            related_id="ambiguous-global-event",
+        ).model_dump_json(),
+        encoding="utf-8",
+    )
+
+    policy = TenantWorkspacePolicy(tmp_path / "tenants")
+
+    assert policy.load(IDENTITY).plan == PlanName.free
+    assert policy.list_usage(IDENTITY) == []
+    assert not (tmp_path / "tenants" / IDENTITY.tenant_id).exists()
+
+
+def test_supported_source_does_not_import_legacy_global_helpers() -> None:
+    source_root = Path(__file__).resolve().parents[1] / "src" / "veridra"
+    offenders: list[str] = []
+    for path in sorted(source_root.glob("*.py")):
+        if path.name == "workspace_web.py":
+            continue
+        content = path.read_text(encoding="utf-8")
+        if "workspace_web import" not in content:
+            continue
+        if any(name in content for name in LEGACY_NAMES):
+            offenders.append(path.name)
+
+    assert offenders == []


### PR DESCRIPTION
Final cleanup for issue #115 from current main `c40992056d44a280e2095cd2153f422047e8cfa3`.

- documents the authoritative tenant workspace, usage, and plan-change locations;
- explicitly declares legacy process-global workspace and usage files ambiguous and never automatically assigned to a tenant;
- documents the remaining `workspace_web.py` global helpers as standalone-compatibility quarantine only;
- adds a regression test proving an Agency global workspace and global usage event do not affect a tenant, which still resolves to an unpersisted Free default;
- adds a source scan proving supported production modules do not import the quarantined global helpers;
- preserves the explicit boundary that local entitlement policy is not payment or external subscription state.

Closes #115 after fresh exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit, and evidence upload.