### PR TITLE
Add one-time browser onboarding for the first agency tenant

### DIFF
--- a/src/veridra/onboarding_web.py
+++ b/src/veridra/onboarding_web.py
@@ -1,0 +1,117 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+import os
+import sqlite3
+from datetime import timedelta
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .identity_bootstrap import BOOTSTRAP_CONFIRMATION, IdentityBootstrapError, SQLiteIdentityBootstrap
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .session_api import set_session_cookie
+from .session_lifecycle import SessionLifecycleService
+from .sqlite_identity_store import SQLiteIdentityRecordStore
+
+router = APIRouter(tags=["onboarding"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:760px;margin:48px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:12px;padding:28px}h1{margin-top:0}label{display:block;font-weight:700;margin:14px 0 5px}input{width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px}button{margin-top:20px;border:0;border-radius:7px;background:#22272d;color:#fff;padding:11px 16px;cursor:pointer}.muted{color:#68707a}.error{border-left:4px solid #b42318;background:#fff1f0;color:#7a271a;padding:12px;margin-bottom:16px}
+"""
+
+
+def _page(error: str | None = None) -> str:
+    error_html = f"<div class='error' role='alert'>{html.escape(error)}</div>" if error else ""
+    return f"""<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>Set up Veridra</title><style>{_STYLE}</style></head><body><main><section><h1>Create your Veridra agency workspace</h1><p class='muted'>This one-time form creates the first tenant owner and starts the workspace on the Free plan. It does not create a payment or subscription.</p>{error_html}<form method='post' action='/onboarding'><label for='tenant_name'>Agency or organisation name</label><input id='tenant_name' name='tenant_name' maxlength='120' required><label for='tenant_slug'>Workspace slug</label><input id='tenant_slug' name='tenant_slug' minlength='3' maxlength='80' pattern='[a-z0-9]+(?:-[a-z0-9]+)*' required><label for='owner_name'>Your name</label><input id='owner_name' name='owner_name' maxlength='120' required><label for='owner_email'>Email</label><input id='owner_email' name='owner_email' type='email' maxlength='254' required><label for='password'>Password</label><input id='password' name='password' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><label for='password_confirm'>Repeat password</label><input id='password_confirm' name='password_confirm' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><button type='submit'>Create agency workspace</button></form></section></main></body></html>"""
+
+
+def _database(request: Request) -> Path:
+    value = getattr(request.app.state, "veridra_identity_database", None)
+    if not isinstance(value, Path):
+        raise HTTPException(status_code=503, detail="Onboarding is not configured.")
+    return value
+
+
+def _identity_store(request: Request) -> SQLiteIdentityRecordStore:
+    value = getattr(request.app.state, "veridra_identity_store", None)
+    if not isinstance(value, SQLiteIdentityRecordStore):
+        raise HTTPException(status_code=503, detail="Onboarding is not configured.")
+    return value
+
+
+def _tenant_root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _is_empty(database: Path) -> bool:
+    with sqlite3.connect(database) as connection:
+        tenants = int(connection.execute("SELECT COUNT(*) FROM tenants").fetchone()[0])
+        users = int(connection.execute("SELECT COUNT(*) FROM users").fetchone()[0])
+    return tenants == 0 and users == 0
+
+
+def _require_available(request: Request) -> Path:
+    database = _database(request)
+    if not _is_empty(database):
+        raise HTTPException(status_code=404, detail="Onboarding is not available.")
+    return database
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Onboarding is not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Onboarding request is not permitted.") from exc
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+@router.get("/onboarding", response_class=HTMLResponse)
+def onboarding(request: Request) -> str:
+    _require_available(request)
+    return _page()
+
+
+@router.post("/onboarding", response_model=None)
+async def create_onboarding(request: Request) -> HTMLResponse | RedirectResponse:
+    database = _require_available(request)
+    _trusted_origin(request)
+    values = _values(await request.body())
+    password = values.get("password", [""])[0]
+    confirmation = values.get("password_confirm", [""])[0]
+    if password != confirmation:
+        return HTMLResponse(_page("Passwords do not match."), status_code=400)
+    try:
+        result = SQLiteIdentityBootstrap(database, tenant_data_root=_tenant_root(request)).create_first_owner(
+            tenant_slug=_one(values, "tenant_slug"),
+            tenant_name=_one(values, "tenant_name"),
+            owner_email=_one(values, "owner_email"),
+            owner_name=_one(values, "owner_name"),
+            password=password,
+            confirmation=BOOTSTRAP_CONFIRMATION,
+        )
+    except (IdentityBootstrapError, ValueError) as exc:
+        return HTMLResponse(_page(str(exc)), status_code=400)
+    lifetime = timedelta(hours=8)
+    issued = SessionLifecycleService(_identity_store(request)).issue(
+        user_id=result.user_id,
+        tenant_id=result.tenant_id,
+        lifetime=lifetime,
+    )
+    response = RedirectResponse("/agency", status_code=303)
+    set_session_cookie(response, issued.credential, max_age=int(lifetime.total_seconds()))
+    return response

--- a/src/veridra/onboarding_web.py
+++ b/src/veridra/onboarding_web.py
@@ -11,7 +11,11 @@ from urllib.parse import parse_qs
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from .identity_bootstrap import BOOTSTRAP_CONFIRMATION, IdentityBootstrapError, SQLiteIdentityBootstrap
+from .identity_bootstrap import (
+    BOOTSTRAP_CONFIRMATION,
+    IdentityBootstrapError,
+    SQLiteIdentityBootstrap,
+)
 from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
 from .session_api import set_session_cookie
 from .session_lifecycle import SessionLifecycleService

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -27,6 +27,7 @@ from .lead_web import router as lead_router
 from .member_assignments_web import router as member_assignments_router
 from .monitoring_job_api import router as monitoring_job_router
 from .monitoring_web import router as monitoring_router
+from .onboarding_web import router as onboarding_router
 from .operations_api import router as operations_router
 from .password_recovery_api import router as password_recovery_router
 from .pdf_web import router as pdf_router
@@ -104,6 +105,7 @@ app.router.routes[:] = [
 
 app.middleware("http")(enforce_workspace_policy)
 configure_identity_middleware(app)
+app.include_router(onboarding_router)
 app.include_router(tenant_assessment_router)
 app.include_router(operations_router)
 app.include_router(auth_router)

--- a/tests/test_onboarding_web.py
+++ b/tests/test_onboarding_web.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import sqlite3
+from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from veridra.identity_tenancy import RequestIdentity
 from veridra.onboarding_web import router
 from veridra.password_auth import SQLitePasswordAuthenticator
 from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
@@ -16,7 +19,10 @@ ORIGIN = "https://veridra.example"
 PASSWORD = "correct-horse-battery-staple"
 
 
-def _client(tmp_path: Path, monkeypatch) -> tuple[TestClient, Path, Path]:
+def _client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TestClient, Path, Path]:
     database = tmp_path / "identity.sqlite3"
     tenant_root = tmp_path / "tenants"
     store = SQLiteIdentityRecordStore(database)
@@ -43,7 +49,10 @@ def _payload() -> dict[str, str]:
     }
 
 
-def test_empty_database_exposes_onboarding_without_mutation(tmp_path: Path, monkeypatch) -> None:
+def test_empty_database_exposes_onboarding_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client, database, tenant_root = _client(tmp_path, monkeypatch)
 
     response = client.get("/onboarding")
@@ -55,17 +64,27 @@ def test_empty_database_exposes_onboarding_without_mutation(tmp_path: Path, monk
     assert not tenant_root.exists()
 
 
-def test_onboarding_requires_trusted_origin(tmp_path: Path, monkeypatch) -> None:
+def test_onboarding_requires_trusted_origin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client, database, _ = _client(tmp_path, monkeypatch)
 
-    response = client.post("/onboarding", data=_payload(), headers={"Origin": "https://evil.example"})
+    response = client.post(
+        "/onboarding",
+        data=_payload(),
+        headers={"Origin": "https://evil.example"},
+    )
 
     assert response.status_code == 403
     with sqlite3.connect(database) as connection:
         assert connection.execute("SELECT COUNT(*) FROM tenants").fetchone()[0] == 0
 
 
-def test_password_mismatch_creates_nothing(tmp_path: Path, monkeypatch) -> None:
+def test_password_mismatch_creates_nothing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     client, database, tenant_root = _client(tmp_path, monkeypatch)
     payload = _payload()
     payload["password_confirm"] = "different-password-value"
@@ -82,7 +101,7 @@ def test_password_mismatch_creates_nothing(tmp_path: Path, monkeypatch) -> None:
 
 def test_success_creates_free_owner_session_and_disables_onboarding(
     tmp_path: Path,
-    monkeypatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client, database, tenant_root = _client(tmp_path, monkeypatch)
 
@@ -102,7 +121,14 @@ def test_success_creates_free_owner_session_and_disables_onboarding(
         password=PASSWORD,
     )
     assert records is not None
-    assert TenantWorkspacePolicy(tenant_root).load(records.identity).plan == PlanName.free
+    identity = RequestIdentity(
+        user_id=records.user.id,
+        tenant_id=records.tenant.id,
+        membership_role=records.membership.role,
+        session_id="onboarding-test-session-01",
+        authenticated_at=datetime.now(UTC),
+    )
+    assert TenantWorkspacePolicy(tenant_root).load(identity).plan == PlanName.free
     with sqlite3.connect(database) as connection:
         assert connection.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
 

--- a/tests/test_onboarding_web.py
+++ b/tests/test_onboarding_web.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.onboarding_web import router
+from veridra.password_auth import SQLitePasswordAuthenticator
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+from veridra.tenant_workspace_policy import TenantWorkspacePolicy
+from veridra.workspace_policy import PlanName
+
+ORIGIN = "https://veridra.example"
+PASSWORD = "correct-horse-battery-staple"
+
+
+def _client(tmp_path: Path, monkeypatch) -> tuple[TestClient, Path, Path]:
+    database = tmp_path / "identity.sqlite3"
+    tenant_root = tmp_path / "tenants"
+    store = SQLiteIdentityRecordStore(database)
+    store.initialize()
+    authenticator = SQLitePasswordAuthenticator(database)
+    authenticator.initialize()
+    app = FastAPI()
+    app.state.veridra_identity_database = database
+    app.state.veridra_identity_store = store
+    app.state.veridra_tenant_data_root = tenant_root
+    app.include_router(router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    return TestClient(app), database, tenant_root
+
+
+def _payload() -> dict[str, str]:
+    return {
+        "tenant_name": "Example Agency",
+        "tenant_slug": "example-agency",
+        "owner_name": "Agency Owner",
+        "owner_email": "owner@example.com",
+        "password": PASSWORD,
+        "password_confirm": PASSWORD,
+    }
+
+
+def test_empty_database_exposes_onboarding_without_mutation(tmp_path: Path, monkeypatch) -> None:
+    client, database, tenant_root = _client(tmp_path, monkeypatch)
+
+    response = client.get("/onboarding")
+
+    assert response.status_code == 200
+    assert "Create your Veridra agency workspace" in response.text
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM tenants").fetchone()[0] == 0
+    assert not tenant_root.exists()
+
+
+def test_onboarding_requires_trusted_origin(tmp_path: Path, monkeypatch) -> None:
+    client, database, _ = _client(tmp_path, monkeypatch)
+
+    response = client.post("/onboarding", data=_payload(), headers={"Origin": "https://evil.example"})
+
+    assert response.status_code == 403
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM tenants").fetchone()[0] == 0
+
+
+def test_password_mismatch_creates_nothing(tmp_path: Path, monkeypatch) -> None:
+    client, database, tenant_root = _client(tmp_path, monkeypatch)
+    payload = _payload()
+    payload["password_confirm"] = "different-password-value"
+
+    response = client.post("/onboarding", data=payload, headers={"Origin": ORIGIN})
+
+    assert response.status_code == 400
+    assert "Passwords do not match" in response.text
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM tenants").fetchone()[0] == 0
+        assert connection.execute("SELECT COUNT(*) FROM users").fetchone()[0] == 0
+    assert not tenant_root.exists()
+
+
+def test_success_creates_free_owner_session_and_disables_onboarding(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    client, database, tenant_root = _client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/onboarding",
+        data=_payload(),
+        headers={"Origin": ORIGIN},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/agency"
+    assert "set-cookie" in response.headers
+    records = SQLitePasswordAuthenticator(database).authenticate(
+        email="owner@example.com",
+        tenant_slug="example-agency",
+        password=PASSWORD,
+    )
+    assert records is not None
+    assert TenantWorkspacePolicy(tenant_root).load(records.identity).plan == PlanName.free
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+    replay_get = client.get("/onboarding")
+    replay_post = client.post("/onboarding", data=_payload(), headers={"Origin": ORIGIN})
+    assert replay_get.status_code == 404
+    assert replay_post.status_code == 404


### PR DESCRIPTION
Implements issue #123 from current main `356f954c019cdb97b8de71ba864d513236bbed3e`.

- adds a one-time `/onboarding` browser flow for an empty configured identity database;
- collects tenant name/slug, owner name/email and password without accepting tenant IDs or roles;
- validates trusted Origin/Referer evidence on POST;
- delegates tenant, owner, credential and persisted Free-workspace creation to the existing atomic bootstrap boundary;
- issues the normal bounded server-side session and secure cookie after successful bootstrap;
- redirects the new owner to `/agency`;
- returns generic unavailable behavior after any tenant or user exists;
- preserves the CLI bootstrap as an administrative/recovery path;
- makes clear that Free workspace creation is local entitlement policy, not payment or subscription state;
- adds tests for read-only GET, cross-origin rejection, password mismatch rollback, successful credentials/session/Free plan and GET/POST replay rejection.

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit and evidence upload before readiness or merge.

Closes #123 when validated and merged.