### PR TITLE
Add authoritative tenant agency project index

### DIFF
--- a/src/veridra/agency_project_index_web.py
+++ b/src/veridra/agency_project_index_web.py
@@ -1,0 +1,48 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from .request_security import require_request_identity
+from .tenant_project_store import TenantProjectStore
+
+router = APIRouter(prefix="/agency", tags=["agency-projects"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1100px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.card{border:1px solid #dfe3e8;border-radius:9px;padding:18px}.button{display:inline-block;border-radius:7px;background:#22272d;color:#fff;padding:9px 13px;text-decoration:none}.secondary{background:#59636e}.muted{color:#68707a}.actions{display:flex;gap:8px;flex-wrap:wrap}@media(max-width:760px){.cards{grid-template-columns:1fr}}
+"""
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _page(body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>Client projects · Veridra</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+@router.get("/projects", response_class=HTMLResponse)
+def agency_projects(request: Request) -> str:
+    identity = require_request_identity(request)
+    entries = TenantProjectStore(_root(request)).list(identity)
+    if entries:
+        cards = "".join(
+            "<article class='card'><p class='muted'>{client}</p><h2>{name}</h2><p><strong>Website:</strong> {target}<br><strong>Crawl:</strong> {crawl}<br><strong>Monitoring:</strong> {monitoring}</p><div class='actions'><a class='button' href='/agency/projects/{identifier}'>Open project</a><a class='button secondary' href='/agency/projects/{identifier}/reports'>Reports</a><a class='button secondary' href='/agency/projects/{identifier}/monitoring'>Monitoring</a></div></article>".format(
+                client=html.escape(entry.client_label or "Client not labelled"),
+                name=html.escape(entry.name),
+                target=html.escape(entry.target_url),
+                crawl=html.escape(entry.crawl_profile.value.title()),
+                monitoring=html.escape(entry.monitoring_cadence.value.title()),
+                identifier=html.escape(entry.id, quote=True),
+            )
+            for entry in entries
+        )
+    else:
+        cards = "<p class='muted'>No client projects exist yet. Run a quick audit and explicitly convert it after reviewing the result.</p>"
+    body = f"""<section><p><a href='/agency'>Agency workspace</a></p><h1>Client projects</h1><p class='muted'>Persistent tenant projects are the authoritative home for saved assessments, branded reports, remediation and monitoring.</p><div class='actions'><a class='button' href='/agency'>Start a quick audit</a></div></section><section><div class='cards'>{cards}</div></section>"""
+    return _page(body)

--- a/src/veridra/agency_workflow_web.py
+++ b/src/veridra/agency_workflow_web.py
@@ -63,7 +63,7 @@ def agency_workflow_home() -> str:
       <a href='/commercial'><strong>Commercial operations</strong><br><span class='muted'>Follow-up and bounded engagement evidence.</span></a>
       <a href='/workspace'><strong>Workspace controls</strong><br><span class='muted'>Review plan, usage, permissions and plan-change history.</span></a>
     </div></section>
-    <p class='notice'><strong>Boundary:</strong> A quick audit is temporary until an operator explicitly creates a client project. Persistent work should continue from the tenant-qualified client-project index.</p>
+    <p class='notice'><strong>Boundary:</strong> A quick audit is temporary until an operator explicitly creates a client project. Veridra does not infer a tenant, client or project from a submitted URL. Persistent work should continue from the tenant-qualified client-project index.</p>
     """
     return _page(body)
 

--- a/src/veridra/agency_workflow_web.py
+++ b/src/veridra/agency_workflow_web.py
@@ -51,19 +51,19 @@ def agency_workflow_home() -> str:
       <input id='target' name='target' maxlength='2048' placeholder='example.com' required>
       <button type='submit'>Start quick audit</button></form></section>
       <section><p class='eyebrow'>Ongoing client work</p><h2>Client projects</h2>
-      <p>Create a persistent project when the website needs reports, remediation tasks, recurring monitoring and change comparison.</p>
-      <div class='actions'><a class='button' href='/projects'>Open projects</a><a class='button secondary' href='/monitoring'>Monitoring operations</a></div></section>
+      <p>Open persistent tenant projects for saved evidence, branded reports, remediation, monitoring and comparison.</p>
+      <div class='actions'><a class='button' href='/agency/projects'>Open client projects</a></div></section>
     </div>
-    <section><h2>Agency operations</h2><p class='muted'>Existing capabilities remain separate security and persistence boundaries; this page provides one understandable entry point.</p>
+    <section><h2>Agency operations</h2><p class='muted'>Project-attached work uses the tenant-qualified agency journey. Remaining compatibility operations are being consolidated separately.</p>
     <div class='links'>
-      <a href='/profiles'><strong>Report profiles</strong><br><span class='muted'>Brand and configure reports.</span></a>
+      <a href='/agency/projects'><strong>Client projects</strong><br><span class='muted'>Open saved assessments, reports, remediation and monitoring.</span></a>
       <a href='/agency/leads'><strong>Leads</strong><br><span class='muted'>Review captured prospects and convert qualified audits into client projects.</span></a>
       <a href='/lead-forms'><strong>Lead forms</strong><br><span class='muted'>Configure embedded capture.</span></a>
-      <a href='/tasks'><strong>Remediation tasks</strong><br><span class='muted'>Track implementation work.</span></a>
-      <a href='/commercial'><strong>Commercial operations</strong><br><span class='muted'>Follow-up and engagement evidence.</span></a>
-      <a href='/history'><strong>Assessment history</strong><br><span class='muted'>Review saved evidence and comparisons.</span></a>
+      <a href='/profiles'><strong>Report profile library</strong><br><span class='muted'>Manage reusable compatibility profiles; project profiles are configured from each report hub.</span></a>
+      <a href='/commercial'><strong>Commercial operations</strong><br><span class='muted'>Follow-up and bounded engagement evidence.</span></a>
+      <a href='/workspace'><strong>Workspace controls</strong><br><span class='muted'>Review plan, usage, permissions and plan-change history.</span></a>
     </div></section>
-    <p class='notice'><strong>Boundary:</strong> A quick audit is temporary until an operator explicitly saves it or creates a client project. Veridra does not infer a tenant, client or project from a submitted URL.</p>
+    <p class='notice'><strong>Boundary:</strong> A quick audit is temporary until an operator explicitly creates a client project. Persistent work should continue from the tenant-qualified client-project index.</p>
     """
     return _page(body)
 

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -8,6 +8,7 @@ from . import public_web
 from .agency_conversion_web import router as agency_conversion_router
 from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
+from .agency_project_index_web import router as agency_project_index_router
 from .agency_report_profile_web import router as agency_report_profile_router
 from .agency_report_web import router as agency_report_router
 from .agency_task_web import router as agency_task_router
@@ -137,6 +138,7 @@ app.include_router(workspace_router)
 app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)
+app.include_router(agency_project_index_router)
 app.include_router(agency_conversion_router)
 app.include_router(agency_lead_router)
 app.include_router(agency_task_router)

--- a/tests/test_agency_project_index_web.py
+++ b/tests/test_agency_project_index_web.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_project_index_web import router
+from veridra.agency_workflow_web import router as workflow_router
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 22, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="agency-project-index-owner",
+    authenticated_at=NOW,
+)
+OTHER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.owner,
+    session_id="agency-project-index-other",
+    authenticated_at=NOW,
+)
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Path]:
+    root = tmp_path / "tenants"
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-identity")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "other":
+            bind_verified_request_identity(request, OTHER)
+        return await call_next(request)
+
+    app.include_router(workflow_router)
+    app.include_router(router)
+    return TestClient(app), root
+
+
+def test_project_index_requires_identity(tmp_path: Path) -> None:
+    client, _ = _client(tmp_path)
+
+    response = client.get("/agency/projects")
+
+    assert response.status_code == 401
+
+
+def test_empty_project_index_is_read_only(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
+
+    response = client.get("/agency/projects", headers={"x-test-identity": "owner"})
+
+    assert response.status_code == 200
+    assert "No client projects exist yet" in response.text
+    assert not (root / OWNER.tenant_id).exists()
+
+
+def test_project_index_is_tenant_isolated_and_escaped(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
+    store = TenantProjectStore(root)
+    project_id = store.save(
+        OWNER,
+        ClientProject.build(
+            name="<script>Client project</script>",
+            target_url="https://example.com",
+            client_label="A & B",
+            crawl_profile="standard",
+        ),
+    )
+    store.save(
+        OTHER,
+        ClientProject.build(
+            name="Other tenant project",
+            target_url="https://other.example",
+        ),
+    )
+
+    response = client.get("/agency/projects", headers={"x-test-identity": "owner"})
+
+    assert response.status_code == 200
+    assert "&lt;script&gt;Client project&lt;/script&gt;" in response.text
+    assert "<script>Client project</script>" not in response.text
+    assert "A &amp; B" in response.text
+    assert "Other tenant project" not in response.text
+    assert f"/agency/projects/{project_id}" in response.text
+    assert f"/agency/projects/{project_id}/reports" in response.text
+    assert f"/agency/projects/{project_id}/monitoring" in response.text
+    assert "Standard" in response.text
+
+
+def test_agency_home_advertises_authoritative_project_index(tmp_path: Path) -> None:
+    client, _ = _client(tmp_path)
+
+    response = client.get("/agency")
+
+    assert response.status_code == 200
+    assert "href='/agency/projects'" in response.text
+    assert "href='/projects'" not in response.text
+    assert "href='/monitoring'" not in response.text

--- a/tests/test_agency_workflow_web.py
+++ b/tests/test_agency_workflow_web.py
@@ -22,7 +22,9 @@ def test_agency_home_explains_quick_and_persistent_workflows() -> None:
     assert "does not create a project or save data automatically" in response.text
     assert "Veridra does not infer a tenant, client or project" in response.text
     assert "href='/profiles'" in response.text
-    assert "href='/monitoring'" in response.text
+    assert "href='/agency/projects'" in response.text
+    assert "href='/projects'" not in response.text
+    assert "href='/monitoring'" not in response.text
 
 
 def test_quick_audit_handoff_redirects_to_completed_agency_result() -> None:


### PR DESCRIPTION
First bounded implementation slice for issue #124 from current main `5e5e0fd7a515f730bea99f09607c5af8c8187b35`.

- adds authenticated tenant-qualified `/agency/projects` as the authoritative project index;
- lists only current-tenant projects with escaped client, website, crawl-profile and monitoring state;
- routes each project into its project-attached overview, reports and monitoring workflows;
- provides a clear empty state and quick-audit handoff without persisting on GET;
- changes `/agency` primary project and monitoring actions away from legacy `/projects` and `/monitoring` destinations;
- removes legacy task/history links from the primary home shell where project-attached actions are authoritative;
- labels remaining compatibility operations rather than presenting them as the primary workflow;
- adds tests for authentication, read-only empty state, tenant isolation, escaping, project action links and authoritative home destinations.

This PR does not remove legacy routers or complete all breadcrumbs/role-aware navigation. Those remain in #124.

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit and evidence upload before readiness or merge.