### PR TITLE
Add role-aware navigation to the agency project index

### DIFF
--- a/src/veridra/agency_navigation.py
+++ b/src/veridra/agency_navigation.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from .identity_tenancy import RequestIdentity, TENANT_ROLE_CAPABILITIES, TenantCapability
+
+
+def agency_navigation(identity: RequestIdentity, *, current: str | None = None) -> str:
+    """Render the shared authenticated agency navigation for the current tenant role."""
+
+    capabilities = TENANT_ROLE_CAPABILITIES[identity.membership_role]
+    destinations: list[tuple[str, str, str]] = [
+        ("home", "/agency", "Agency home"),
+        ("projects", "/agency/projects", "Client projects"),
+    ]
+    if TenantCapability.manage_leads in capabilities:
+        destinations.append(("leads", "/agency/leads", "Leads"))
+    if TenantCapability.manage_tenant in capabilities:
+        destinations.append(("workspace", "/workspace", "Plan and usage"))
+    if TenantCapability.manage_memberships in capabilities:
+        destinations.append(("team", "/workspace/members", "Team"))
+
+    links = "".join(
+        "<a href='{href}'{current_attr}>{label}</a>".format(
+            href=href,
+            current_attr=" aria-current='page'" if key == current else "",
+            label=label,
+        )
+        for key, href, label in destinations
+    )
+    return f"<nav class='agency-nav' aria-label='Agency navigation'>{links}</nav>"

--- a/src/veridra/agency_navigation.py
+++ b/src/veridra/agency_navigation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .identity_tenancy import RequestIdentity, TENANT_ROLE_CAPABILITIES, TenantCapability
+from .identity_tenancy import TENANT_ROLE_CAPABILITIES, RequestIdentity, TenantCapability
 
 
 def agency_navigation(identity: RequestIdentity, *, current: str | None = None) -> str:

--- a/src/veridra/agency_project_index_web.py
+++ b/src/veridra/agency_project_index_web.py
@@ -7,13 +7,14 @@ from pathlib import Path
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 
+from .agency_navigation import agency_navigation
 from .request_security import require_request_identity
 from .tenant_project_store import TenantProjectStore
 
 router = APIRouter(prefix="/agency", tags=["agency-projects"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1100px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.card{border:1px solid #dfe3e8;border-radius:9px;padding:18px}.button{display:inline-block;border-radius:7px;background:#22272d;color:#fff;padding:9px 13px;text-decoration:none}.secondary{background:#59636e}.muted{color:#68707a}.actions{display:flex;gap:8px;flex-wrap:wrap}@media(max-width:760px){.cards{grid-template-columns:1fr}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1100px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.card{border:1px solid #dfe3e8;border-radius:9px;padding:18px}.button{display:inline-block;border-radius:7px;background:#22272d;color:#fff;padding:9px 13px;text-decoration:none}.secondary{background:#59636e}.muted{color:#68707a}.actions{display:flex;gap:8px;flex-wrap:wrap}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:9px 12px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:760px){.cards{grid-template-columns:1fr}}
 """
 
 
@@ -44,5 +45,5 @@ def agency_projects(request: Request) -> str:
         )
     else:
         cards = "<p class='muted'>No client projects exist yet. Run a quick audit and explicitly convert it after reviewing the result.</p>"
-    body = f"""<section><p><a href='/agency'>Agency workspace</a></p><h1>Client projects</h1><p class='muted'>Persistent tenant projects are the authoritative home for saved assessments, branded reports, remediation and monitoring.</p><div class='actions'><a class='button' href='/agency'>Start a quick audit</a></div></section><section><div class='cards'>{cards}</div></section>"""
+    body = f"""{agency_navigation(identity, current='projects')}<section><h1>Client projects</h1><p class='muted'>Persistent tenant projects are the authoritative home for saved assessments, branded reports, remediation and monitoring.</p><div class='actions'><a class='button' href='/agency'>Start a quick audit</a></div></section><section><div class='cards'>{cards}</div></section>"""
     return _page(body)

--- a/tests/test_agency_project_index_web.py
+++ b/tests/test_agency_project_index_web.py
@@ -22,6 +22,20 @@ OWNER = RequestIdentity(
     session_id="agency-project-index-owner",
     authenticated_at=NOW,
 )
+SALES = RequestIdentity(
+    user_id="3" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.sales,
+    session_id="agency-project-index-sales",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="4" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="agency-project-index-viewer",
+    authenticated_at=NOW,
+)
 OTHER = RequestIdentity(
     user_id="2" * 24,
     tenant_id="b" * 24,
@@ -42,10 +56,9 @@ def _client(tmp_path: Path) -> tuple[TestClient, Path]:
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
         role = request.headers.get("x-test-identity")
-        if role == "owner":
-            bind_verified_request_identity(request, OWNER)
-        elif role == "other":
-            bind_verified_request_identity(request, OTHER)
+        identities = {"owner": OWNER, "sales": SALES, "viewer": VIEWER, "other": OTHER}
+        if role in identities:
+            bind_verified_request_identity(request, identities[role])
         return await call_next(request)
 
     app.include_router(workflow_router)
@@ -55,20 +68,37 @@ def _client(tmp_path: Path) -> tuple[TestClient, Path]:
 
 def test_project_index_requires_identity(tmp_path: Path) -> None:
     client, _ = _client(tmp_path)
-
     response = client.get("/agency/projects")
-
     assert response.status_code == 401
 
 
 def test_empty_project_index_is_read_only(tmp_path: Path) -> None:
     client, root = _client(tmp_path)
-
     response = client.get("/agency/projects", headers={"x-test-identity": "owner"})
-
     assert response.status_code == 200
     assert "No client projects exist yet" in response.text
     assert not (root / OWNER.tenant_id).exists()
+
+
+def test_project_index_navigation_is_role_aware(tmp_path: Path) -> None:
+    client, _ = _client(tmp_path)
+
+    owner = client.get("/agency/projects", headers={"x-test-identity": "owner"})
+    assert "aria-current='page'" in owner.text
+    assert "href='/agency/leads'" in owner.text
+    assert "href='/workspace'" in owner.text
+    assert "href='/workspace/members'" in owner.text
+
+    sales = client.get("/agency/projects", headers={"x-test-identity": "sales"})
+    assert "href='/agency/leads'" in sales.text
+    assert "href='/workspace'" not in sales.text
+    assert "href='/workspace/members'" not in sales.text
+
+    viewer = client.get("/agency/projects", headers={"x-test-identity": "viewer"})
+    assert "href='/agency/leads'" not in viewer.text
+    assert "href='/workspace'" not in viewer.text
+    assert "href='/workspace/members'" not in viewer.text
+    assert "href='/agency/projects'" in viewer.text
 
 
 def test_project_index_is_tenant_isolated_and_escaped(tmp_path: Path) -> None:
@@ -106,9 +136,7 @@ def test_project_index_is_tenant_isolated_and_escaped(tmp_path: Path) -> None:
 
 def test_agency_home_advertises_authoritative_project_index(tmp_path: Path) -> None:
     client, _ = _client(tmp_path)
-
     response = client.get("/agency")
-
     assert response.status_code == 200
     assert "href='/agency/projects'" in response.text
     assert "href='/projects'" not in response.text


### PR DESCRIPTION
Second bounded implementation slice for issue #124 from current main `a6219ece009467cd8be699d7fc47c9f4536fda3e`.

- adds a shared authenticated agency navigation helper;
- always exposes the authoritative agency home and tenant project index;
- exposes Leads only to roles with `manage_leads`;
- exposes Plan and usage only to roles with `manage_tenant`;
- exposes Team only to roles with `manage_memberships`;
- marks the current destination with `aria-current`;
- uses the shared navigation on `/agency/projects`;
- preserves tenant isolation, escaping and read-only GET behavior;
- adds owner, sales and viewer role-navigation tests.

This PR does not yet apply the shared shell to every project detail, report, monitoring, lead and confirmation page. Those remain tracked in #124.

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit and evidence upload before readiness or merge.