### PR TITLE
Add role-aware navigation to agency project overviews

### DIFF
--- a/src/veridra/agency_conversion_web.py
+++ b/src/veridra/agency_conversion_web.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
+from .agency_navigation import agency_navigation
 from .app import dashboard
 from .assessment_project_conversion_api import AssessmentProjectConversion, convert_assessment
 from .collector import CollectionError
@@ -28,7 +29,7 @@ from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
 router = APIRouter(prefix="/agency", tags=["agency-conversion"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.actions{display:flex;gap:8px;flex-wrap:wrap}@media(max-width:700px){.row{grid-template-columns:1fr}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.actions{display:flex;gap:8px;flex-wrap:wrap}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:700px){.row{grid-template-columns:1fr}}
 """
 
 
@@ -162,5 +163,6 @@ def tenant_project_next_actions(
         if task_created
         else ""
     )
-    body = f"""<section><p><a href='/agency'>Agency workflow</a></p><h1>{html.escape(project.name)}</h1>{created_notice}<p><strong>Client:</strong> {html.escape(project.client_label or 'Not set')}<br><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Saved assessment:</strong> {latest_text}</p><div class='actions'><a class='button' href='/?{html.escape(query, quote=True)}'>Review assessment</a><a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Prepare branded report</a>{remediation}<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/monitoring'>Enable monitoring</a></div></section><section><h2>Recommended next step</h2><p>Review the saved evidence, choose the client-facing report output, then convert actionable findings into assigned remediation work before enabling recurring monitoring.</p></section>"""
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a></p><h1>{html.escape(project.name)}</h1>{created_notice}<p><strong>Client:</strong> {html.escape(project.client_label or 'Not set')}<br><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Saved assessment:</strong> {latest_text}</p><div class='actions'><a class='button' href='/?{html.escape(query, quote=True)}'>Review assessment</a><a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Prepare branded report</a>{remediation}<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/monitoring'>Enable monitoring</a></div></section><section><h2>Recommended next step</h2><p>Review the saved evidence, choose the client-facing report output, then convert actionable findings into assigned remediation work before enabling recurring monitoring.</p></section>"""
     return _page(project.name, body)

--- a/tests/test_agency_project_overview_navigation.py
+++ b/tests/test_agency_project_overview_navigation.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_conversion_web import router
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 16, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="project-overview-owner-01",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="project-overview-viewer-1",
+    authenticated_at=NOW,
+)
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Path]:
+    root = tmp_path / "tenants"
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-identity")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app), root
+
+
+def _project(root: Path, identity: RequestIdentity, name: str) -> str:
+    return TenantProjectStore(root).save(
+        identity,
+        ClientProject.build(name=name, target_url="https://example.com"),
+    )
+
+
+def test_owner_project_overview_has_authorized_navigation(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
+    project_id = _project(root, OWNER, "Owner project")
+
+    response = client.get(
+        f"/agency/projects/{project_id}",
+        headers={"x-test-identity": "owner"},
+    )
+
+    assert response.status_code == 200
+    assert "aria-label='Agency navigation'" in response.text
+    assert "href='/agency/projects' aria-current='page'" in response.text
+    assert "href='/agency/leads'" in response.text
+    assert "href='/workspace'" in response.text
+    assert "href='/workspace/members'" in response.text
+    assert "<a href='/agency/projects'>Client projects</a>" in response.text
+
+
+def test_viewer_project_overview_hides_unavailable_navigation(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
+    project_id = _project(root, VIEWER, "Viewer project")
+
+    response = client.get(
+        f"/agency/projects/{project_id}",
+        headers={"x-test-identity": "viewer"},
+    )
+
+    assert response.status_code == 200
+    assert "href='/agency'" in response.text
+    assert "href='/agency/projects' aria-current='page'" in response.text
+    assert "href='/agency/leads'" not in response.text
+    assert "href='/workspace'" not in response.text
+    assert "href='/workspace/members'" not in response.text

--- a/tests/test_agency_project_overview_navigation.py
+++ b/tests/test_agency_project_overview_navigation.py
@@ -9,9 +9,8 @@ from fastapi.testclient import TestClient
 
 from veridra.agency_conversion_web import router
 from veridra.identity_tenancy import RequestIdentity, TenantRole
-from veridra.project_store import ClientProject
+from veridra.project_store import ClientProject, ProjectStore
 from veridra.request_security import bind_verified_request_identity
-from veridra.tenant_project_store import TenantProjectStore
 
 NOW = datetime(2026, 7, 27, 16, 0, tzinfo=UTC)
 OWNER = RequestIdentity(
@@ -52,9 +51,8 @@ def _client(tmp_path: Path) -> tuple[TestClient, Path]:
 
 
 def _project(root: Path, identity: RequestIdentity, name: str) -> str:
-    return TenantProjectStore(root).save(
-        identity,
-        ClientProject.build(name=name, target_url="https://example.com"),
+    return ProjectStore(root / identity.tenant_id / "projects").save(
+        ClientProject.build(name=name, target_url="https://example.com")
     )
 
 


### PR DESCRIPTION
Third bounded implementation slice for issue #124 from current main `9a41d11fa8c2ae92269f448a30de143a577121f2`.

- applies the shared authenticated agency navigation to `/agency/projects/{project_id}`;
- marks Client projects as the current destination;
- adds a consistent breadcrumb back to the tenant-qualified project index;
- preserves project-attached reports, findings and monitoring actions;
- hides Leads, Plan and usage, and Team from viewer navigation while retaining them for owners;
- keeps tenant isolation, escaped project content and read-only GET behavior;
- adds owner and viewer project-overview navigation tests.

This PR does not yet apply the shared shell to report, monitoring, findings, lead and confirmation pages. Those remain tracked in #124.

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit and evidence upload before readiness or merge.