### PR TITLE
Add shared navigation to agency monitoring workflows

### DIFF
--- a/src/veridra/agency_monitoring_web.py
+++ b/src/veridra/agency_monitoring_web.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
+from .agency_navigation import agency_navigation
 from .history import Comparison
 from .identity_tenancy import (
     IdentityBoundaryError,
@@ -30,7 +31,7 @@ from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
 router = APIRouter(prefix="/agency", tags=["agency-monitoring"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.row{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.actions{display:flex;gap:8px;flex-wrap:wrap}.comparison{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.comparison article{border:1px solid #dfe3e8;border-radius:8px;padding:16px}.comparison ul{padding-left:20px}@media(max-width:700px){.row,.comparison{grid-template-columns:1fr}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.row{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.actions{display:flex;gap:8px;flex-wrap:wrap}.comparison{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.comparison article{border:1px solid #dfe3e8;border-radius:8px;padding:16px}.comparison ul{padding-left:20px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:700px){.row,.comparison{grid-template-columns:1fr}}
 """
 
 
@@ -152,7 +153,8 @@ def project_monitoring(
     else:
         form = "<p class='notice'>Your current workspace role can inspect this configuration but cannot change it.</p>"
         run_action = ""
-    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project</a> · <a href='/agency'>Agency workflow</a></p><h1>Monitoring for {html.escape(project.name)}</h1>{status_panel}<p><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Current cadence:</strong> {html.escape(schedule.cadence.value)}<br><strong>Timezone:</strong> {html.escape(schedule.timezone)}<br><strong>Notification:</strong> {html.escape(str(project.monitoring_email or 'Not configured'))}</p>{history_summary}<div class='actions'>{comparison_action}</div></section><section><h2>Configuration</h2>{form}</section><section><h2>Manual verification</h2><p class='muted'>A manual run performs the existing bounded assessment, saves it to this tenant project and attempts the configured summary email. Email delivery status is evidence of the attempt, not a guarantee of receipt.</p>{run_action}</section>"""
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a></p><h1>Monitoring for {html.escape(project.name)}</h1>{status_panel}<p><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Current cadence:</strong> {html.escape(schedule.cadence.value)}<br><strong>Timezone:</strong> {html.escape(schedule.timezone)}<br><strong>Notification:</strong> {html.escape(str(project.monitoring_email or 'Not configured'))}</p>{history_summary}<div class='actions'>{comparison_action}</div></section><section><h2>Configuration</h2>{form}</section><section><h2>Manual verification</h2><p class='muted'>A manual run performs the existing bounded assessment, saves it to this tenant project and attempts the configured summary email. Email delivery status is evidence of the attempt, not a guarantee of receipt.</p>{run_action}</section>"""
     return _page(f"{project.name} monitoring", body)
 
 
@@ -181,7 +183,8 @@ def compare_project_assessments(
             _comparison_card("Unchanged", project_id, after, comparison.unchanged),
         )
     )
-    body = f"""<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}/monitoring'>Monitoring</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project</a></p><h1>Assessment comparison for {html.escape(project.name)}</h1><p class='notice'><strong>Before:</strong> {html.escape(before)}<br><strong>After:</strong> {html.escape(after)}</p><p>This view reports stored finding changes only. A resolved identifier is not client-facing proof of remediation without reviewing the underlying evidence.</p></section><section class='comparison'>{cards}</section>"""
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}/monitoring'>Monitoring</a></p><h1>Assessment comparison for {html.escape(project.name)}</h1><p class='notice'><strong>Before:</strong> {html.escape(before)}<br><strong>After:</strong> {html.escape(after)}</p><p>This view reports stored finding changes only. A resolved identifier is not client-facing proof of remediation without reviewing the underlying evidence.</p></section><section class='comparison'>{cards}</section>"""
     return _page(f"{project.name} assessment comparison", body)
 
 

--- a/tests/test_agency_monitoring_navigation.py
+++ b/tests/test_agency_monitoring_navigation.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_monitoring_web import router
+from veridra.core import demo_assessment
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_history_store import TenantHistoryStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 18, 0, tzinfo=UTC)
+ANALYST = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.analyst,
+    session_id="monitoring-navigation-analyst",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="monitoring-navigation-viewer-1",
+    authenticated_at=NOW,
+)
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, str, str, str]:
+    root = tmp_path / "tenants"
+    project_id = TenantProjectStore(root).save(
+        ANALYST,
+        ClientProject.build(name="Monitoring navigation", target_url="https://example.com"),
+    )
+    history = TenantHistoryStore(root)
+    before = history.save(ANALYST, project_id, demo_assessment())
+    after = history.save(ANALYST, project_id, demo_assessment())
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if request.headers.get("x-test-role") == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        else:
+            bind_verified_request_identity(request, ANALYST)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app), project_id, before, after
+
+
+def test_monitoring_page_has_project_navigation_for_analyst(tmp_path: Path) -> None:
+    client, project_id, _, _ = _client(tmp_path)
+
+    response = client.get(f"/agency/projects/{project_id}/monitoring")
+
+    assert response.status_code == 200
+    assert "aria-label='Agency navigation'" in response.text
+    assert "href='/agency/projects' aria-current='page'" in response.text
+    assert f"href='/agency/projects/{project_id}'" in response.text
+    assert "href='/agency/leads'" not in response.text
+    assert "href='/workspace'" not in response.text
+
+
+def test_monitoring_page_hides_management_navigation_for_viewer(tmp_path: Path) -> None:
+    client, project_id, _, _ = _client(tmp_path)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/monitoring",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert response.status_code == 200
+    assert "href='/agency/projects' aria-current='page'" in response.text
+    assert "href='/agency/leads'" not in response.text
+    assert "href='/workspace'" not in response.text
+    assert "href='/workspace/members'" not in response.text
+    assert "Save monitoring configuration" not in response.text
+
+
+def test_comparison_page_keeps_project_navigation(tmp_path: Path) -> None:
+    client, project_id, before, after = _client(tmp_path)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/monitoring/compare",
+        params={"before": before, "after": after},
+    )
+
+    assert response.status_code == 200
+    assert "aria-label='Agency navigation'" in response.text
+    assert "href='/agency/projects' aria-current='page'" in response.text
+    assert f"href='/agency/projects/{project_id}'" in response.text
+    assert f"href='/agency/projects/{project_id}/monitoring'" in response.text


### PR DESCRIPTION
Sixth bounded implementation slice for issue #124 from current main `9d45e6cfe112d33a202694ab82c5da8210f2c05c`.

- applies the shared authenticated agency navigation to the project monitoring page;
- applies the same shell to assessment comparison;
- marks Client projects as the current destination;
- adds breadcrumbs to the project index, project overview and monitoring page;
- preserves role-based monitoring configuration and manual-run permissions;
- preserves stored comparison semantics and tenant isolation;
- adds analyst, viewer and comparison navigation tests.

This PR does not yet apply the shell to findings or lead pages and does not retire legacy compatibility routers. Those remain tracked in #124.

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit and evidence upload before readiness or merge.