### PR TITLE
Add shared navigation to agency lead workflows

### DIFF
--- a/src/veridra/agency_lead_web.py
+++ b/src/veridra/agency_lead_web.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
+from .agency_navigation import agency_navigation
 from .identity_tenancy import (
     IdentityBoundaryError,
     RequestIdentity,
@@ -23,7 +24,7 @@ from .tenant_lead_store import TenantLeadStore, TenantLeadStoreError
 router = APIRouter(prefix="/agency", tags=["agency-leads"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1050px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}label{display:block;font-weight:700;margin:12px 0 5px}input{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}@media(max-width:700px){.row{grid-template-columns:1fr}table{display:block;overflow:auto}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1050px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}label{display:block;font-weight:700;margin:12px 0 5px}input{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:700px){.row{grid-template-columns:1fr}table{display:block;overflow:auto}}
 """
 
 
@@ -57,6 +58,10 @@ def _require_conversion_capabilities(identity: RequestIdentity) -> None:
 @router.get("/leads", response_class=HTMLResponse)
 def agency_leads(request: Request) -> str:
     identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
     leads = TenantLeadStore(_root(request))
     try:
         entries = leads.list(identity)
@@ -84,7 +89,8 @@ def agency_leads(request: Request) -> str:
         if rows
         else "<p class='notice'>No tenant audit leads are available yet.</p>"
     )
-    body = f"<section><p><a href='/agency'>Agency workflow</a></p><h1>Audit leads</h1><p class='muted'>Convert a qualified captured audit into persistent client work without re-entering its website or assessment.</p>{table}</section>"
+    navigation = agency_navigation(identity, current="leads")
+    body = f"{navigation}<section><p><a href='/agency'>Agency home</a></p><h1>Audit leads</h1><p class='muted'>Convert a qualified captured audit into persistent client work without re-entering its website or assessment.</p>{table}</section>"
     return _page("Audit leads", body)
 
 
@@ -109,7 +115,8 @@ def lead_conversion_confirmation(
         return RedirectResponse(f"/agency/projects/{link.project_id}", status_code=303)
     project_name = lead.company or f"{lead.name} website"
     client_label = lead.company or lead.name
-    body = f"""<section><p><a href='/agency/leads'>Audit leads</a></p><h1>Convert lead to client project</h1><p class='notice'><strong>Prospect:</strong> {html.escape(lead.name)}<br><strong>Website:</strong> {html.escape(str(lead.website))}<br><strong>Assessment:</strong> {html.escape(lead.assessment_id)}</p><p>The website, assessment and tenant report profile are resolved server-side from this tenant-owned lead. Opening this page creates nothing.</p><form method='post' action='/agency/leads/{html.escape(lead_id, quote=True)}/convert'><div class='row'><div><label for='project_name'>Project name</label><input id='project_name' name='project_name' maxlength='120' value='{html.escape(project_name, quote=True)}' required></div><div><label for='client_label'>Client label</label><input id='client_label' name='client_label' maxlength='120' value='{html.escape(client_label, quote=True)}'></div></div><p><button type='submit'>Create client project</button> <a class='button secondary' href='/agency/leads'>Cancel</a></p></form></section>"""
+    navigation = agency_navigation(identity, current="leads")
+    body = f"""{navigation}<section><p><a href='/agency'>Agency home</a> · <a href='/agency/leads'>Audit leads</a></p><h1>Convert lead to client project</h1><p class='notice'><strong>Prospect:</strong> {html.escape(lead.name)}<br><strong>Website:</strong> {html.escape(str(lead.website))}<br><strong>Assessment:</strong> {html.escape(lead.assessment_id)}</p><p>The website, assessment and tenant report profile are resolved server-side from this tenant-owned lead. Opening this page creates nothing.</p><form method='post' action='/agency/leads/{html.escape(lead_id, quote=True)}/convert'><div class='row'><div><label for='project_name'>Project name</label><input id='project_name' name='project_name' maxlength='120' value='{html.escape(project_name, quote=True)}' required></div><div><label for='client_label'>Client label</label><input id='client_label' name='client_label' maxlength='120' value='{html.escape(client_label, quote=True)}'></div></div><p><button type='submit'>Create client project</button> <a class='button secondary' href='/agency/leads'>Cancel</a></p></form></section>"""
     return _page("Convert lead", body)
 
 

--- a/tests/test_agency_lead_web.py
+++ b/tests/test_agency_lead_web.py
@@ -92,6 +92,23 @@ def test_lead_inbox_requires_identity_and_escapes_content(
     assert "Alex &lt;Client&gt;" in response.text
     assert "Alex <Client>" not in response.text
     assert f"/agency/leads/{lead_id}/convert" in response.text
+    assert "aria-label='Agency navigation'" in response.text
+    assert "href='/agency/leads' aria-current='page'" in response.text
+    assert "href='/agency/projects'" in response.text
+    assert "href='/workspace'" in response.text
+    assert "href='/workspace/members'" in response.text
+    assert "<a href='/agency'>Agency home</a>" in response.text
+
+
+def test_viewer_cannot_open_lead_inbox(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _client(tmp_path, monkeypatch)
+
+    response = client.get("/agency/leads", headers={"x-test-role": "viewer"})
+
+    assert response.status_code == 403
 
 
 def test_confirmation_is_read_only_and_viewer_is_denied(
@@ -114,6 +131,10 @@ def test_confirmation_is_read_only_and_viewer_is_denied(
 
     assert viewer.status_code == 403
     assert owner.status_code == 200
+    assert "aria-label='Agency navigation'" in owner.text
+    assert "href='/agency/leads' aria-current='page'" in owner.text
+    assert "<a href='/agency'>Agency home</a>" in owner.text
+    assert "<a href='/agency/leads'>Audit leads</a>" in owner.text
     assert lead_path.read_bytes() == before
     assert not (root / OWNER.tenant_id / "lead-project-links").exists()
 


### PR DESCRIPTION
Eighth bounded implementation slice for issue #124 from current main `9706675227407f9a3f2e993f1ec55ad35ef87b88`.

- applies the shared authenticated agency navigation to `/agency/leads`;
- applies the same shell to lead-to-project confirmation;
- marks Leads as the current destination;
- adds consistent breadcrumbs to Agency home and Audit leads;
- requires `manage_leads` for the lead inbox, matching the role-aware navigation boundary;
- preserves tenant isolation, escaped lead data, read-only confirmation GET behavior and server-side lead-to-project resolution;
- adds owner navigation assertions and viewer denial coverage.

This PR does not yet retire legacy compatibility routers or add the final composed-runtime route inventory. Those remain tracked in #124.

Requires fresh exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit and evidence upload before readiness or merge.