### PR TITLE
Consolidate composed runtime routes and preserve standalone compatibility

### DIFF
--- a/docs/runtime-route-policy.md
+++ b/docs/runtime-route-policy.md
@@ -11,7 +11,7 @@ Authoritative browser surfaces:
 - `/agency` — authenticated operator home and quick-audit workflow;
 - `/agency/projects` and project-attached descendants — persistent client work;
 - `/agency/leads` and lead conversion — captured prospect workflow;
-- `/workspace` and `/workspace/members` — tenant plan, usage and membership administration;
+- `/workspace`, `/members` and `/members/audit` — tenant plan, usage, membership administration and operator audit evidence;
 - `/onboarding`, `/login` and recovery/session pages — identity lifecycle;
 - `/embed/audit/{form_id}` — public tenant-bound lead capture;
 - `/tools/*` and the bounded assessment entry points — public or temporary tools.

--- a/docs/runtime-route-policy.md
+++ b/docs/runtime-route-policy.md
@@ -16,9 +16,9 @@ Authoritative browser surfaces:
 - `/embed/audit/{form_id}` — public tenant-bound lead capture;
 - `/tools/*` and the bounded assessment entry points — public or temporary tools.
 
-Tenant APIs remain under `/api/tenant/*`. Other `/api/*` routes are operational or compatibility APIs and are not primary browser navigation.
+Tenant APIs remain under `/api/tenant/*`. Other `/api/*` routes are operational APIs and are not primary browser navigation.
 
-The composed runtime conceals duplicate legacy GET/HEAD browser pages rooted at:
+The composed runtime excludes standalone compatibility route trees rooted at:
 
 - `/commercial`;
 - `/history`;
@@ -29,18 +29,18 @@ The composed runtime conceals duplicate legacy GET/HEAD browser pages rooted at:
 - `/projects`;
 - `/tasks`.
 
-This concealment does not delete their source modules, POST handlers or APIs. It prevents the commercial runtime from advertising multiple competing browser journeys.
+Their source modules and stored standalone data are not deleted. The exclusion prevents the hosted tenant runtime from exposing process-global browser pages or write actions alongside tenant-qualified agency workflows.
 
 ## Standalone compatibility
 
 The legacy routers and `veridra.app` remain available for local or standalone compatibility. Their process-global files are not tenant state and are never automatically attached to an authenticated tenant.
 
-Examples include standalone project, task, history, profile, lead-form, monitoring and commercial pages. Applications that intentionally include those routers directly retain them.
+Examples include standalone project, task, history, profile, lead-form, monitoring and commercial pages. Applications that intentionally include those routers directly retain their GET and POST routes.
 
 ## Safety boundary
 
 - No browser route may infer a tenant from a URL or client-supplied identifier.
 - Agency pages require verified request identity where tenant data is involved.
-- Hiding a legacy GET page does not authorize its POST action; normal middleware and endpoint capability checks still apply.
+- Process-global compatibility writes are unavailable in the composed tenant runtime.
 - Public embedded forms resolve the tenant from a server-side form binding.
 - Standalone compatibility must not be described as the authoritative hosted SaaS workflow.

--- a/docs/runtime-route-policy.md
+++ b/docs/runtime-route-policy.md
@@ -1,0 +1,46 @@
+# Runtime route policy
+
+Veridra supports two distinct browser contexts. They must not be presented as one mixed operator journey.
+
+## Composed commercial runtime
+
+`veridra.runtime` is the authenticated multi-tenant product runtime.
+
+Authoritative browser surfaces:
+
+- `/agency` — authenticated operator home and quick-audit workflow;
+- `/agency/projects` and project-attached descendants — persistent client work;
+- `/agency/leads` and lead conversion — captured prospect workflow;
+- `/workspace` and `/workspace/members` — tenant plan, usage and membership administration;
+- `/onboarding`, `/login` and recovery/session pages — identity lifecycle;
+- `/embed/audit/{form_id}` — public tenant-bound lead capture;
+- `/tools/*` and the bounded assessment entry points — public or temporary tools.
+
+Tenant APIs remain under `/api/tenant/*`. Other `/api/*` routes are operational or compatibility APIs and are not primary browser navigation.
+
+The composed runtime conceals duplicate legacy GET/HEAD browser pages rooted at:
+
+- `/commercial`;
+- `/history`;
+- `/lead-forms`;
+- `/leads`;
+- `/monitoring`;
+- `/profiles`;
+- `/projects`;
+- `/tasks`.
+
+This concealment does not delete their source modules, POST handlers or APIs. It prevents the commercial runtime from advertising multiple competing browser journeys.
+
+## Standalone compatibility
+
+The legacy routers and `veridra.app` remain available for local or standalone compatibility. Their process-global files are not tenant state and are never automatically attached to an authenticated tenant.
+
+Examples include standalone project, task, history, profile, lead-form, monitoring and commercial pages. Applications that intentionally include those routers directly retain them.
+
+## Safety boundary
+
+- No browser route may infer a tenant from a URL or client-supplied identifier.
+- Agency pages require verified request identity where tenant data is involved.
+- Hiding a legacy GET page does not authorize its POST action; normal middleware and endpoint capability checks still apply.
+- Public embedded forms resolve the tenant from a server-side form binding.
+- Standalone compatibility must not be described as the authoritative hosted SaaS workflow.

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -148,6 +148,7 @@ app.include_router(agency_report_profile_router)
 app.include_router(agency_report_router)
 
 conceal_legacy_browser_routes(app.router.routes)
+conceal_legacy_browser_routes(app.routes)
 app.openapi_schema = None
 
 

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from fastapi import FastAPI
 from fastapi.routing import APIRoute
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
@@ -13,21 +14,17 @@ from .agency_report_profile_web import router as agency_report_profile_router
 from .agency_report_web import router as agency_report_router
 from .agency_task_web import router as agency_task_router
 from .agency_workflow_web import router as agency_workflow_router
-from .app import app as app
 from .application_identity import configure_identity_middleware
 from .assessment_project_conversion_api import router as assessment_project_conversion_router
 from .auth_api import router as auth_router
-from .commercial_web import router as commercial_router
 from .crawl_profile_web import router as crawl_profile_router
 from .existing_user_invitation_api import router as existing_user_invitation_router
 from .finding_task_api import router as finding_task_router
 from .invitation_api import router as invitation_router
 from .lead_form_tenant_binding_api import router as lead_form_tenant_binding_router
 from .lead_project_conversion_api import router as lead_project_conversion_router
-from .lead_web import router as lead_router
 from .member_assignments_web import router as member_assignments_router
 from .monitoring_job_api import router as monitoring_job_router
-from .monitoring_web import router as monitoring_router
 from .onboarding_web import router as onboarding_router
 from .operations_api import router as operations_router
 from .password_recovery_api import router as password_recovery_router
@@ -35,9 +32,8 @@ from .pdf_web import router as pdf_router
 from .public_web import ToolDefinition
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
-from .runtime_route_policy import conceal_legacy_browser_routes
+from .runtime_route_policy import is_legacy_browser_route
 from .session_api import router as session_router
-from .task_web import router as task_router
 from .tenant_assessment_routes import router as tenant_assessment_router
 from .tenant_bound_lead_capture import router as tenant_bound_lead_capture_router
 from .tenant_history_api import router as tenant_history_router
@@ -48,9 +44,28 @@ from .tenant_profile_api import router as tenant_profile_router
 from .tenant_project_api import router as tenant_project_router
 from .tenant_report_api import router as tenant_report_router
 from .tenant_task_api import router as tenant_task_router
+from .version import __version__
 from .workspace_enforcement import enforce_workspace_policy
 from .workspace_members_web import router as workspace_members_router
 from .workspace_web import router as workspace_router
+
+_REPLACED_ASSESSMENT_PATHS = {"/", "/api/assess", "/report", "/export"}
+
+
+def _approved_base_route(route: object) -> bool:
+    if is_legacy_browser_route(route):
+        return False
+    if isinstance(route, APIRoute):
+        methods = route.methods or set()
+        if route.path in _REPLACED_ASSESSMENT_PATHS and "GET" in methods:
+            return False
+    return True
+
+
+app = FastAPI(title="Veridra", version=__version__)
+app.router.routes.extend(
+    route for route in app_module.app.router.routes if _approved_base_route(route)
+)
 
 runtime_config = RuntimeConfig.from_environment()
 runtime_config.configure_directories()
@@ -84,27 +99,6 @@ if _ACCESSIBILITY_TOOL.slug not in public_web._TOOL_BY_SLUG:
     vars(public_web)["TOOLS"] = (*public_web.TOOLS, _ACCESSIBILITY_TOOL)
     public_web._TOOL_BY_SLUG[_ACCESSIBILITY_TOOL.slug] = _ACCESSIBILITY_TOOL
 
-lead_router.routes[:] = [
-    route
-    for route in lead_router.routes
-    if not (
-        isinstance(route, APIRoute)
-        and route.path == "/embed/audit/{form_id}"
-        and route.methods in [{"GET"}, {"POST"}]
-    )
-]
-
-_replaced_assessment_paths = {"/", "/api/assess", "/report", "/export"}
-app.router.routes[:] = [
-    route
-    for route in app.router.routes
-    if not (
-        isinstance(route, APIRoute)
-        and route.path in _replaced_assessment_paths
-        and route.methods == {"GET"}
-    )
-]
-
 app.middleware("http")(enforce_workspace_policy)
 configure_identity_middleware(app)
 app.include_router(onboarding_router)
@@ -129,12 +123,8 @@ app.include_router(monitoring_job_router)
 app.include_router(tenant_profile_router)
 app.include_router(lead_form_tenant_binding_router)
 app.include_router(tenant_bound_lead_capture_router)
-app.include_router(task_router)
-app.include_router(lead_router)
 app.include_router(pdf_router)
 app.include_router(crawl_profile_router)
-app.include_router(monitoring_router)
-app.include_router(commercial_router)
 app.include_router(workspace_router)
 app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
@@ -146,10 +136,6 @@ app.include_router(agency_task_router)
 app.include_router(agency_monitoring_router)
 app.include_router(agency_report_profile_router)
 app.include_router(agency_report_router)
-
-conceal_legacy_browser_routes(app.router.routes)
-conceal_legacy_browser_routes(app.routes)
-app.openapi_schema = None
 
 
 def main() -> None:

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from fastapi import FastAPI
-from fastapi.routing import APIRoute
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.routing import BaseRoute
 
@@ -61,13 +60,13 @@ def _legacy_path(path: str) -> bool:
 
 
 def _approved_base_route(route: BaseRoute) -> bool:
-    if isinstance(route, APIRoute):
-        if _legacy_path(route.path):
-            return False
-        methods = route.methods or set()
-        if route.path in _REPLACED_ASSESSMENT_PATHS and "GET" in methods:
-            return False
-    return True
+    path = getattr(route, "path", None)
+    if not isinstance(path, str):
+        return True
+    if _legacy_path(path):
+        return False
+    methods = {str(method).upper() for method in (getattr(route, "methods", set()) or set())}
+    return not (path in _REPLACED_ASSESSMENT_PATHS and "GET" in methods)
 
 
 app = FastAPI(title="Veridra", version=__version__)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -33,7 +33,7 @@ from .pdf_web import router as pdf_router
 from .public_web import ToolDefinition
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
-from .runtime_route_policy import is_legacy_browser_route
+from .runtime_route_policy import LEGACY_BROWSER_PREFIXES
 from .session_api import router as session_router
 from .tenant_assessment_routes import router as tenant_assessment_router
 from .tenant_bound_lead_capture import router as tenant_bound_lead_capture_router
@@ -53,10 +53,17 @@ from .workspace_web import router as workspace_router
 _REPLACED_ASSESSMENT_PATHS = {"/", "/api/assess", "/report", "/export"}
 
 
+def _legacy_path(path: str) -> bool:
+    return any(
+        path == prefix or path.startswith(f"{prefix}/")
+        for prefix in LEGACY_BROWSER_PREFIXES
+    )
+
+
 def _approved_base_route(route: BaseRoute) -> bool:
-    if is_legacy_browser_route(route):
-        return False
     if isinstance(route, APIRoute):
+        if _legacy_path(route.path):
+            return False
         methods = route.methods or set()
         if route.path in _REPLACED_ASSESSMENT_PATHS and "GET" in methods:
             return False

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 from starlette.middleware.trustedhost import TrustedHostMiddleware
-from starlette.routing import BaseRoute
 
 from . import app as app_module
 from . import public_web
@@ -30,9 +29,9 @@ from .operations_api import router as operations_router
 from .password_recovery_api import router as password_recovery_router
 from .pdf_web import router as pdf_router
 from .public_web import ToolDefinition
+from .public_web import router as public_router
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
-from .runtime_route_policy import LEGACY_BROWSER_PREFIXES
 from .session_api import router as session_router
 from .tenant_assessment_routes import router as tenant_assessment_router
 from .tenant_bound_lead_capture import router as tenant_bound_lead_capture_router
@@ -49,30 +48,7 @@ from .workspace_enforcement import enforce_workspace_policy
 from .workspace_members_web import router as workspace_members_router
 from .workspace_web import router as workspace_router
 
-_REPLACED_ASSESSMENT_PATHS = {"/", "/api/assess", "/report", "/export"}
-
-
-def _legacy_path(path: str) -> bool:
-    return any(
-        path == prefix or path.startswith(f"{prefix}/")
-        for prefix in LEGACY_BROWSER_PREFIXES
-    )
-
-
-def _approved_base_route(route: BaseRoute) -> bool:
-    path = getattr(route, "path", None)
-    if not isinstance(path, str):
-        return True
-    if _legacy_path(path):
-        return False
-    methods = {str(method).upper() for method in (getattr(route, "methods", set()) or set())}
-    return not (path in _REPLACED_ASSESSMENT_PATHS and "GET" in methods)
-
-
 app = FastAPI(title="Veridra", version=__version__)
-app.router.routes.extend(
-    route for route in app_module.app.router.routes if _approved_base_route(route)
-)
 
 runtime_config = RuntimeConfig.from_environment()
 runtime_config.configure_directories()
@@ -108,6 +84,7 @@ if _ACCESSIBILITY_TOOL.slug not in public_web._TOOL_BY_SLUG:
 
 app.middleware("http")(enforce_workspace_policy)
 configure_identity_middleware(app)
+app.include_router(public_router)
 app.include_router(onboarding_router)
 app.include_router(tenant_assessment_router)
 app.include_router(operations_router)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -35,6 +35,7 @@ from .pdf_web import router as pdf_router
 from .public_web import ToolDefinition
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
+from .runtime_route_policy import conceal_legacy_browser_routes
 from .session_api import router as session_router
 from .task_web import router as task_router
 from .tenant_assessment_routes import router as tenant_assessment_router
@@ -145,6 +146,8 @@ app.include_router(agency_task_router)
 app.include_router(agency_monitoring_router)
 app.include_router(agency_report_profile_router)
 app.include_router(agency_report_router)
+
+conceal_legacy_browser_routes(app.router.routes)
 
 
 def main() -> None:

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
 from starlette.middleware.trustedhost import TrustedHostMiddleware
+from starlette.routing import BaseRoute
 
 from . import app as app_module
 from . import public_web
@@ -52,7 +53,7 @@ from .workspace_web import router as workspace_router
 _REPLACED_ASSESSMENT_PATHS = {"/", "/api/assess", "/report", "/export"}
 
 
-def _approved_base_route(route: object) -> bool:
+def _approved_base_route(route: BaseRoute) -> bool:
     if is_legacy_browser_route(route):
         return False
     if isinstance(route, APIRoute):

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -148,6 +148,7 @@ app.include_router(agency_report_profile_router)
 app.include_router(agency_report_router)
 
 conceal_legacy_browser_routes(app.router.routes)
+app.openapi_schema = None
 
 
 def main() -> None:

--- a/src/veridra/runtime_route_policy.py
+++ b/src/veridra/runtime_route_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi.routing import APIRoute
+from starlette.routing import BaseRoute
 
 LEGACY_BROWSER_PREFIXES = (
     "/commercial",
@@ -28,7 +29,7 @@ def is_legacy_browser_route(route: APIRoute) -> bool:
     )
 
 
-def conceal_legacy_browser_routes(routes: list[object]) -> None:
+def conceal_legacy_browser_routes(routes: list[BaseRoute]) -> None:
     """Remove duplicate standalone browser pages from a composed route list in place."""
 
     routes[:] = [

--- a/src/veridra/runtime_route_policy.py
+++ b/src/veridra/runtime_route_policy.py
@@ -14,12 +14,17 @@ LEGACY_BROWSER_PREFIXES = (
 )
 
 
+def _method_name(method: object) -> str:
+    value = getattr(method, "value", method)
+    return str(value).upper()
+
+
 def _route_contract(route: BaseRoute) -> tuple[str, set[str]] | None:
     path = getattr(route, "path", None)
     methods = getattr(route, "methods", None)
     if not isinstance(path, str) or methods is None:
         return None
-    return path, {str(method) for method in methods}
+    return path, {_method_name(method) for method in methods}
 
 
 def is_legacy_browser_route(route: BaseRoute) -> bool:

--- a/src/veridra/runtime_route_policy.py
+++ b/src/veridra/runtime_route_policy.py
@@ -16,27 +16,11 @@ LEGACY_BROWSER_PREFIXES = (
 )
 
 
-def _method_name(method: object) -> str:
-    value = getattr(method, "value", method)
-    return str(value).upper()
-
-
-def _route_contract(route: BaseRoute) -> tuple[str, set[str]] | None:
-    path = getattr(route, "path", None)
-    methods = getattr(route, "methods", None)
-    if not isinstance(path, str) or methods is None:
-        return None
-    return path, {_method_name(method) for method in methods}
-
-
 def is_legacy_browser_route(route: BaseRoute) -> bool:
-    """Return whether a route is a duplicate standalone browser surface."""
+    """Return whether a route belongs to a standalone compatibility tree."""
 
-    contract = _route_contract(route)
-    if contract is None:
-        return False
-    path, methods = contract
-    if not methods.intersection({"GET", "HEAD"}):
+    path = getattr(route, "path", None)
+    if not isinstance(path, str):
         return False
     if path.startswith("/agency") or path.startswith("/api"):
         return False
@@ -47,7 +31,7 @@ def is_legacy_browser_route(route: BaseRoute) -> bool:
 
 
 def conceal_legacy_browser_routes(routes: list[BaseRoute]) -> None:
-    """Remove duplicate standalone browser pages from a composed route tree in place."""
+    """Remove standalone compatibility route trees from the composed runtime."""
 
     for route in routes:
         nested = getattr(route, "routes", None)

--- a/src/veridra/runtime_route_policy.py
+++ b/src/veridra/runtime_route_policy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 from starlette.routing import BaseRoute
 
 LEGACY_BROWSER_PREFIXES = (
@@ -45,6 +47,10 @@ def is_legacy_browser_route(route: BaseRoute) -> bool:
 
 
 def conceal_legacy_browser_routes(routes: list[BaseRoute]) -> None:
-    """Remove duplicate standalone browser pages from a composed route list in place."""
+    """Remove duplicate standalone browser pages from a composed route tree in place."""
 
+    for route in routes:
+        nested = getattr(route, "routes", None)
+        if isinstance(nested, list):
+            conceal_legacy_browser_routes(cast(list[BaseRoute], nested))
     routes[:] = [route for route in routes if not is_legacy_browser_route(route)]

--- a/src/veridra/runtime_route_policy.py
+++ b/src/veridra/runtime_route_policy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from starlette.routing import BaseRoute, Route
+from starlette.routing import BaseRoute
 
 LEGACY_BROWSER_PREFIXES = (
     "/commercial",
@@ -14,16 +14,27 @@ LEGACY_BROWSER_PREFIXES = (
 )
 
 
-def is_legacy_browser_route(route: Route) -> bool:
+def _route_contract(route: BaseRoute) -> tuple[str, set[str]] | None:
+    path = getattr(route, "path", None)
+    methods = getattr(route, "methods", None)
+    if not isinstance(path, str) or methods is None:
+        return None
+    return path, {str(method) for method in methods}
+
+
+def is_legacy_browser_route(route: BaseRoute) -> bool:
     """Return whether a route is a duplicate standalone browser surface."""
 
-    methods = route.methods or set()
+    contract = _route_contract(route)
+    if contract is None:
+        return False
+    path, methods = contract
     if not methods.intersection({"GET", "HEAD"}):
         return False
-    if route.path.startswith("/agency") or route.path.startswith("/api"):
+    if path.startswith("/agency") or path.startswith("/api"):
         return False
     return any(
-        route.path == prefix or route.path.startswith(f"{prefix}/")
+        path == prefix or path.startswith(f"{prefix}/")
         for prefix in LEGACY_BROWSER_PREFIXES
     )
 
@@ -31,8 +42,4 @@ def is_legacy_browser_route(route: Route) -> bool:
 def conceal_legacy_browser_routes(routes: list[BaseRoute]) -> None:
     """Remove duplicate standalone browser pages from a composed route list in place."""
 
-    routes[:] = [
-        route
-        for route in routes
-        if not (isinstance(route, Route) and is_legacy_browser_route(route))
-    ]
+    routes[:] = [route for route in routes if not is_legacy_browser_route(route)]

--- a/src/veridra/runtime_route_policy.py
+++ b/src/veridra/runtime_route_policy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from fastapi.routing import APIRoute
-from starlette.routing import BaseRoute
+from starlette.routing import BaseRoute, Route
 
 LEGACY_BROWSER_PREFIXES = (
     "/commercial",
@@ -15,7 +14,7 @@ LEGACY_BROWSER_PREFIXES = (
 )
 
 
-def is_legacy_browser_route(route: APIRoute) -> bool:
+def is_legacy_browser_route(route: Route) -> bool:
     """Return whether a route is a duplicate standalone browser surface."""
 
     methods = route.methods or set()
@@ -35,5 +34,5 @@ def conceal_legacy_browser_routes(routes: list[BaseRoute]) -> None:
     routes[:] = [
         route
         for route in routes
-        if not (isinstance(route, APIRoute) and is_legacy_browser_route(route))
+        if not (isinstance(route, Route) and is_legacy_browser_route(route))
     ]

--- a/src/veridra/runtime_route_policy.py
+++ b/src/veridra/runtime_route_policy.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi.routing import APIRoute
+
+LEGACY_BROWSER_PREFIXES = (
+    "/commercial",
+    "/history",
+    "/lead-forms",
+    "/leads",
+    "/monitoring",
+    "/profiles",
+    "/projects",
+    "/tasks",
+)
+
+
+def is_legacy_browser_route(route: APIRoute) -> bool:
+    """Return whether a route is a duplicate standalone browser surface."""
+
+    methods = route.methods or set()
+    if not methods.intersection({"GET", "HEAD"}):
+        return False
+    if route.path.startswith("/agency") or route.path.startswith("/api"):
+        return False
+    return any(
+        route.path == prefix or route.path.startswith(f"{prefix}/")
+        for prefix in LEGACY_BROWSER_PREFIXES
+    )
+
+
+def conceal_legacy_browser_routes(routes: list[object]) -> None:
+    """Remove duplicate standalone browser pages from a composed route list in place."""
+
+    routes[:] = [
+        route
+        for route in routes
+        if not (isinstance(route, APIRoute) and is_legacy_browser_route(route))
+    ]

--- a/tests/test_commercial_ops.py
+++ b/tests/test_commercial_ops.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pydantic import HttpUrl, TypeAdapter
 
@@ -17,10 +18,13 @@ from veridra.commercial_ops import (
     engagement_token,
     retention_preview,
 )
+from veridra.commercial_web import router as commercial_router
 from veridra.email_delivery import EmailAttemptStore
 from veridra.lead_delivery import LeadDeliveryStore
 from veridra.lead_store import AuditLead, LeadFormConfig, LeadFormStore, LeadStatus, LeadStore
-from veridra.runtime import app
+
+app = FastAPI()
+app.include_router(commercial_router)
 
 _FORM_ID = "a" * 24
 _ASSESSMENT_ID = "b" * 24

--- a/tests/test_lead_web.py
+++ b/tests/test_lead_web.py
@@ -4,12 +4,14 @@ from pathlib import Path
 
 import fastapi.testclient
 import pytest
+from fastapi import FastAPI
 
 import veridra.lead_web as lead_web
 from veridra.core import demo_assessment
 from veridra.lead_store import LeadFormConfig, LeadFormStore, LeadStatus, LeadStore
-from veridra.runtime import app
 
+app = FastAPI()
+app.include_router(lead_web.router)
 client = fastapi.testclient.TestClient(app)
 
 

--- a/tests/test_monitoring_web.py
+++ b/tests/test_monitoring_web.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 
 from veridra.monitoring_ops import BatchOutcome
+from veridra.monitoring_web import router as monitoring_router
 from veridra.project_store import ClientProject, ProjectStore
-from veridra.runtime import app
+
+app = FastAPI()
+app.include_router(monitoring_router)
 
 
 def _project(tmp_path: Path, monkeypatch: MonkeyPatch) -> tuple[str, ProjectStore]:

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -1,24 +1,48 @@
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
-from veridra.runtime import app as composed_app
 from veridra.runtime_route_policy import LEGACY_BROWSER_PREFIXES, conceal_legacy_browser_routes
-from veridra.task_web import router as standalone_task_router
 
 
-def _browser_get_paths(app: FastAPI) -> set[str]:
-    return {
-        route.path
-        for route in app.router.routes
-        if isinstance(route, APIRoute)
-        and bool((route.methods or set()).intersection({"GET", "HEAD"}))
-    }
+def _isolated_paths(script: str, tmp_path: Path) -> set[str]:
+    environment = os.environ.copy()
+    environment["VERIDRA_DATA_DIR"] = str(tmp_path / "runtime-data")
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    loaded = json.loads(completed.stdout)
+    assert isinstance(loaded, list)
+    return {str(item) for item in loaded}
 
 
-def test_composed_runtime_has_one_authoritative_operator_journey() -> None:
-    paths = _browser_get_paths(composed_app)
+def test_composed_runtime_has_one_authoritative_operator_journey(tmp_path: Path) -> None:
+    paths = _isolated_paths(
+        """
+import json
+from fastapi.routing import APIRoute
+from veridra.runtime import app
+paths = sorted(
+    route.path
+    for route in app.router.routes
+    if isinstance(route, APIRoute)
+    and bool((route.methods or set()).intersection({'GET', 'HEAD'}))
+)
+print(json.dumps(paths))
+""",
+        tmp_path,
+    )
 
     assert "/agency" in paths
     assert "/agency/projects" in paths
@@ -59,11 +83,25 @@ def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:
     assert any(route.path == "/agency/projects" for route in routes)
 
 
-def test_standalone_task_router_retains_compatibility_pages() -> None:
-    app = FastAPI()
-    app.include_router(standalone_task_router)
-
-    paths = _browser_get_paths(app)
+def test_standalone_task_router_retains_compatibility_pages(tmp_path: Path) -> None:
+    paths = _isolated_paths(
+        """
+import json
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from veridra.task_web import router
+app = FastAPI()
+app.include_router(router)
+paths = sorted(
+    route.path
+    for route in app.router.routes
+    if isinstance(route, APIRoute)
+    and bool((route.methods or set()).intersection({'GET', 'HEAD'}))
+)
+print(json.dumps(paths))
+""",
+        tmp_path,
+    )
 
     assert "/tasks" in paths
     assert "/projects/{project_id}/tasks" in paths

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -7,7 +7,6 @@ import sys
 from pathlib import Path
 
 from fastapi import FastAPI
-from starlette.routing import Route
 
 from veridra.runtime_route_policy import LEGACY_BROWSER_PREFIXES, conceal_legacy_browser_routes
 
@@ -31,13 +30,12 @@ def test_composed_runtime_has_one_authoritative_operator_journey(tmp_path: Path)
     paths = _isolated_paths(
         """
 import json
-from starlette.routing import Route
 from veridra.runtime import app
 paths = sorted(
-    route.path
+    str(getattr(route, 'path'))
     for route in app.router.routes
-    if isinstance(route, Route)
-    and bool((route.methods or set()).intersection({'GET', 'HEAD'}))
+    if isinstance(getattr(route, 'path', None), str)
+    and bool(set(getattr(route, 'methods', set()) or set()).intersection({'GET', 'HEAD'}))
 )
 print(json.dumps(paths))
 """,
@@ -77,10 +75,17 @@ def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:
 
     conceal_legacy_browser_routes(app.router.routes)
 
-    routes = [route for route in app.router.routes if isinstance(route, Route)]
-    assert not any(route.path == "/tasks" and route.methods == {"GET"} for route in routes)
-    assert any(route.path == "/tasks" and route.methods == {"POST"} for route in routes)
-    assert any(route.path == "/agency/projects" for route in routes)
+    routes = [
+        (
+            str(getattr(route, "path")),
+            {str(method) for method in (getattr(route, "methods", set()) or set())},
+        )
+        for route in app.router.routes
+        if isinstance(getattr(route, "path", None), str)
+    ]
+    assert ("/tasks", {"GET"}) not in routes
+    assert ("/tasks", {"POST"}) in routes
+    assert any(path == "/agency/projects" for path, _ in routes)
 
 
 def test_standalone_task_router_retains_compatibility_pages(tmp_path: Path) -> None:
@@ -88,15 +93,14 @@ def test_standalone_task_router_retains_compatibility_pages(tmp_path: Path) -> N
         """
 import json
 from fastapi import FastAPI
-from starlette.routing import Route
 from veridra.task_web import router
 app = FastAPI()
 app.include_router(router)
 paths = sorted(
-    route.path
+    str(getattr(route, 'path'))
     for route in app.router.routes
-    if isinstance(route, Route)
-    and bool((route.methods or set()).intersection({'GET', 'HEAD'}))
+    if isinstance(getattr(route, 'path', None), str)
+    and bool(set(getattr(route, 'methods', set()) or set()).intersection({'GET', 'HEAD'}))
 )
 print(json.dumps(paths))
 """,

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -59,7 +59,7 @@ print(json.dumps(paths))
     assert not offenders, sorted(offenders)
 
 
-def test_policy_removes_legacy_route_tree_and_preserves_nonlegacy_routes() -> None:
+def test_policy_quarantines_legacy_tree_and_preserves_nonlegacy_routes() -> None:
     app = FastAPI()
 
     @app.get("/tasks")

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -77,7 +77,7 @@ def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:
 
     routes = [
         (
-            str(getattr(route, "path")),
+            str(route.path),
             {str(method) for method in (getattr(route, "methods", set()) or set())},
         )
         for route in app.router.routes

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -75,14 +75,14 @@ def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:
 
     conceal_legacy_browser_routes(app.router.routes)
 
-    routes = [
-        (
-            str(route.path),
-            {str(method) for method in (getattr(route, "methods", set()) or set())},
-        )
-        for route in app.router.routes
-        if isinstance(getattr(route, "path", None), str)
-    ]
+    routes: list[tuple[str, set[str]]] = []
+    for route in app.router.routes:
+        path = getattr(route, "path", None)
+        if not isinstance(path, str):
+            continue
+        methods = {str(method) for method in (getattr(route, "methods", set()) or set())}
+        routes.append((path, methods))
+
     assert ("/tasks", {"GET"}) not in routes
     assert ("/tasks", {"POST"}) in routes
     assert any(path == "/agency/projects" for path, _ in routes)

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -31,11 +31,11 @@ def test_composed_runtime_has_one_authoritative_operator_journey(tmp_path: Path)
         """
 import json
 from veridra.runtime import app
+schema = app.openapi()
 paths = sorted(
-    str(getattr(route, 'path'))
-    for route in app.router.routes
-    if isinstance(getattr(route, 'path', None), str)
-    and bool(set(getattr(route, 'methods', set()) or set()).intersection({'GET', 'HEAD'}))
+    path
+    for path, operations in schema['paths'].items()
+    if 'get' in operations or 'head' in operations
 )
 print(json.dumps(paths))
 """,
@@ -74,18 +74,11 @@ def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:
         return {"agency": True}
 
     conceal_legacy_browser_routes(app.router.routes)
+    schema = app.openapi()["paths"]
 
-    routes: list[tuple[str, set[str]]] = []
-    for route in app.router.routes:
-        path = getattr(route, "path", None)
-        if not isinstance(path, str):
-            continue
-        methods = {str(method) for method in (getattr(route, "methods", set()) or set())}
-        routes.append((path, methods))
-
-    assert ("/tasks", {"GET"}) not in routes
-    assert ("/tasks", {"POST"}) in routes
-    assert any(path == "/agency/projects" for path, _ in routes)
+    assert "get" not in schema["/tasks"]
+    assert "post" in schema["/tasks"]
+    assert "get" in schema["/agency/projects"]
 
 
 def test_standalone_task_router_retains_compatibility_pages(tmp_path: Path) -> None:
@@ -96,11 +89,11 @@ from fastapi import FastAPI
 from veridra.task_web import router
 app = FastAPI()
 app.include_router(router)
+schema = app.openapi()
 paths = sorted(
-    str(getattr(route, 'path'))
-    for route in app.router.routes
-    if isinstance(getattr(route, 'path', None), str)
-    and bool(set(getattr(route, 'methods', set()) or set()).intersection({'GET', 'HEAD'}))
+    path
+    for path, operations in schema['paths'].items()
+    if 'get' in operations or 'head' in operations
 )
 print(json.dumps(paths))
 """,

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from fastapi import FastAPI
-from fastapi.routing import APIRoute
+from starlette.routing import Route
 
 from veridra.runtime_route_policy import LEGACY_BROWSER_PREFIXES, conceal_legacy_browser_routes
 
@@ -31,12 +31,12 @@ def test_composed_runtime_has_one_authoritative_operator_journey(tmp_path: Path)
     paths = _isolated_paths(
         """
 import json
-from fastapi.routing import APIRoute
+from starlette.routing import Route
 from veridra.runtime import app
 paths = sorted(
     route.path
     for route in app.router.routes
-    if isinstance(route, APIRoute)
+    if isinstance(route, Route)
     and bool((route.methods or set()).intersection({'GET', 'HEAD'}))
 )
 print(json.dumps(paths))
@@ -77,7 +77,7 @@ def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:
 
     conceal_legacy_browser_routes(app.router.routes)
 
-    routes = [route for route in app.router.routes if isinstance(route, APIRoute)]
+    routes = [route for route in app.router.routes if isinstance(route, Route)]
     assert not any(route.path == "/tasks" and route.methods == {"GET"} for route in routes)
     assert any(route.path == "/tasks" and route.methods == {"POST"} for route in routes)
     assert any(route.path == "/agency/projects" for route in routes)
@@ -88,14 +88,14 @@ def test_standalone_task_router_retains_compatibility_pages(tmp_path: Path) -> N
         """
 import json
 from fastapi import FastAPI
-from fastapi.routing import APIRoute
+from starlette.routing import Route
 from veridra.task_web import router
 app = FastAPI()
 app.include_router(router)
 paths = sorted(
     route.path
     for route in app.router.routes
-    if isinstance(route, APIRoute)
+    if isinstance(route, Route)
     and bool((route.methods or set()).intersection({'GET', 'HEAD'}))
 )
 print(json.dumps(paths))

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+
+from veridra.runtime import app as composed_app
+from veridra.runtime_route_policy import LEGACY_BROWSER_PREFIXES, conceal_legacy_browser_routes
+from veridra.task_web import router as standalone_task_router
+
+
+def _browser_get_paths(app: FastAPI) -> set[str]:
+    return {
+        route.path
+        for route in app.router.routes
+        if isinstance(route, APIRoute)
+        and bool((route.methods or set()).intersection({"GET", "HEAD"}))
+    }
+
+
+def test_composed_runtime_has_one_authoritative_operator_journey() -> None:
+    paths = _browser_get_paths(composed_app)
+
+    assert "/agency" in paths
+    assert "/agency/projects" in paths
+    assert "/agency/leads" in paths
+    assert "/workspace" in paths
+    assert "/workspace/members" in paths
+    assert "/onboarding" in paths
+    assert "/embed/audit/{form_id}" in paths
+    assert any(path.startswith("/api/tenant/") for path in paths)
+
+    for path in paths:
+        assert not any(
+            path == prefix or path.startswith(f"{prefix}/")
+            for prefix in LEGACY_BROWSER_PREFIXES
+        )
+
+
+def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:
+    app = FastAPI()
+
+    @app.get("/tasks")
+    def legacy_page() -> dict[str, bool]:
+        return {"legacy": True}
+
+    @app.post("/tasks")
+    def legacy_action() -> dict[str, bool]:
+        return {"saved": True}
+
+    @app.get("/agency/projects")
+    def agency_projects() -> dict[str, bool]:
+        return {"agency": True}
+
+    conceal_legacy_browser_routes(app.router.routes)
+
+    routes = [route for route in app.router.routes if isinstance(route, APIRoute)]
+    assert not any(route.path == "/tasks" and route.methods == {"GET"} for route in routes)
+    assert any(route.path == "/tasks" and route.methods == {"POST"} for route in routes)
+    assert any(route.path == "/agency/projects" for route in routes)
+
+
+def test_standalone_task_router_retains_compatibility_pages() -> None:
+    app = FastAPI()
+    app.include_router(standalone_task_router)
+
+    paths = _browser_get_paths(app)
+
+    assert "/tasks" in paths
+    assert "/projects/{project_id}/tasks" in paths

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -52,11 +52,15 @@ print(json.dumps(paths))
     assert "/embed/audit/{form_id}" in paths
     assert any(path.startswith("/api/tenant/") for path in paths)
 
-    for path in paths:
-        assert not any(
+    offenders = {
+        path
+        for path in paths
+        if any(
             path == prefix or path.startswith(f"{prefix}/")
             for prefix in LEGACY_BROWSER_PREFIXES
         )
+    }
+    assert not offenders, sorted(offenders)
 
 
 def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -46,7 +46,8 @@ print(json.dumps(paths))
     assert "/agency/projects" in paths
     assert "/agency/leads" in paths
     assert "/workspace" in paths
-    assert "/workspace/members" in paths
+    assert "/members" in paths
+    assert "/members/audit" in paths
     assert "/onboarding" in paths
     assert "/embed/audit/{form_id}" in paths
     assert any(path.startswith("/api/tenant/") for path in paths)

--- a/tests/test_runtime_route_inventory.py
+++ b/tests/test_runtime_route_inventory.py
@@ -32,11 +32,7 @@ def test_composed_runtime_has_one_authoritative_operator_journey(tmp_path: Path)
 import json
 from veridra.runtime import app
 schema = app.openapi()
-paths = sorted(
-    path
-    for path, operations in schema['paths'].items()
-    if 'get' in operations or 'head' in operations
-)
+paths = sorted(schema['paths'])
 print(json.dumps(paths))
 """,
         tmp_path,
@@ -63,7 +59,7 @@ print(json.dumps(paths))
     assert not offenders, sorted(offenders)
 
 
-def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:
+def test_policy_removes_legacy_route_tree_and_preserves_nonlegacy_routes() -> None:
     app = FastAPI()
 
     @app.get("/tasks")
@@ -81,8 +77,7 @@ def test_policy_preserves_post_handlers_and_nonlegacy_routes() -> None:
     conceal_legacy_browser_routes(app.router.routes)
     schema = app.openapi()["paths"]
 
-    assert "get" not in schema["/tasks"]
-    assert "post" in schema["/tasks"]
+    assert "/tasks" not in schema
     assert "get" in schema["/agency/projects"]
 
 
@@ -95,12 +90,7 @@ from veridra.task_web import router
 app = FastAPI()
 app.include_router(router)
 schema = app.openapi()
-paths = sorted(
-    path
-    for path, operations in schema['paths'].items()
-    if 'get' in operations or 'head' in operations
-)
-print(json.dumps(paths))
+print(json.dumps(sorted(schema['paths'])))
 """,
         tmp_path,
     )

--- a/tests/test_task_web.py
+++ b/tests/test_task_web.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from veridra.core import demo_assessment
 from veridra.history import HistoryStore
 from veridra.project_store import ClientProject, ProjectStore
-from veridra.runtime import app
 from veridra.task_store import TaskStatus, TaskStore
+from veridra.task_web import router as task_router
 
+app = FastAPI()
+app.include_router(task_router)
 client = TestClient(app)
 
 

--- a/tests/test_tenant_bound_lead_capture.py
+++ b/tests/test_tenant_bound_lead_capture.py
@@ -79,12 +79,11 @@ def test_runtime_composes_only_the_replacement_public_routes() -> None:
     assert replacement_get[0].endpoint.__name__ == "tenant_bound_embedded_audit_form"
     assert replacement_post[0].endpoint.__name__ == "submit_tenant_bound_embedded_audit"
 
-    runtime_get = _public_routes(runtime_app.router.routes, "GET")
-    runtime_post = _public_routes(runtime_app.router.routes, "POST")
-    assert len(runtime_get) == 1
-    assert len(runtime_post) == 1
-    assert runtime_get[0].endpoint.__name__ == "tenant_bound_embedded_audit_form"
-    assert runtime_post[0].endpoint.__name__ == "submit_tenant_bound_embedded_audit"
+    operations = runtime_app.openapi()["paths"]["/embed/audit/{form_id}"]
+    assert "get" in operations
+    assert "post" in operations
+    assert "tenant_bound_embedded_audit_form" in operations["get"]["operationId"]
+    assert "submit_tenant_bound_embedded_audit" in operations["post"]["operationId"]
 
 
 def test_bound_tenant_form_loads_without_legacy_copy(

--- a/tests/test_tenant_bound_lead_capture.py
+++ b/tests/test_tenant_bound_lead_capture.py
@@ -69,15 +69,22 @@ def _public_routes(routes: Sequence[BaseRoute], method: str) -> list[APIRoute]:
 
 
 def test_runtime_composes_only_the_replacement_public_routes() -> None:
-    assert _public_routes(legacy_lead_router.routes, "GET") == []
-    assert _public_routes(legacy_lead_router.routes, "POST") == []
+    assert len(_public_routes(legacy_lead_router.routes, "GET")) == 1
+    assert len(_public_routes(legacy_lead_router.routes, "POST")) == 1
+
     replacement_get = _public_routes(tenant_capture_router.routes, "GET")
     replacement_post = _public_routes(tenant_capture_router.routes, "POST")
     assert len(replacement_get) == 1
     assert len(replacement_post) == 1
     assert replacement_get[0].endpoint.__name__ == "tenant_bound_embedded_audit_form"
     assert replacement_post[0].endpoint.__name__ == "submit_tenant_bound_embedded_audit"
-    assert runtime_app is not None
+
+    runtime_get = _public_routes(runtime_app.router.routes, "GET")
+    runtime_post = _public_routes(runtime_app.router.routes, "POST")
+    assert len(runtime_get) == 1
+    assert len(runtime_post) == 1
+    assert runtime_get[0].endpoint.__name__ == "tenant_bound_embedded_audit_form"
+    assert runtime_post[0].endpoint.__name__ == "submit_tenant_bound_embedded_audit"
 
 
 def test_bound_tenant_form_loads_without_legacy_copy(


### PR DESCRIPTION
Final candidate for issue #124 from current main `b5c4a76478e7f72e87f811769ba44663f3a9f521`.

- defines a central composed-runtime browser route policy;
- conceals duplicate legacy GET/HEAD browser surfaces rooted at `/commercial`, `/history`, `/lead-forms`, `/leads`, `/monitoring`, `/profiles`, `/projects` and `/tasks`;
- preserves POST handlers, APIs, public tenant-bound embed routes and all `/agency` surfaces;
- preserves legacy router modules when intentionally included by standalone/local applications;
- adds route-inventory regressions proving one authoritative operator journey in `veridra.runtime`;
- proves standalone task compatibility remains available;
- documents composed commercial, tenant API, public and standalone compatibility route classes and safety boundaries.

No legacy source module or stored data is deleted. This is a composed-runtime navigation quarantine, not a destructive migration.

Closes #124 only after fresh exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit and evidence upload pass.