### PR TITLE
Preserve complete custom crawl profile limits

### DIFF
--- a/src/veridra/crawl_profile_web.py
+++ b/src/veridra/crawl_profile_web.py
@@ -32,12 +32,22 @@ def _profile(
     crawl_profile: str,
     max_pages: int | None,
     max_depth: int | None,
+    max_total_bytes: int | None,
+    per_page_bytes: int | None,
+    timeout: float | None,
+    max_sitemaps: int | None,
+    max_sitemap_urls: int | None,
 ) -> CrawlProfile:
     try:
         return resolve_crawl_profile(
             crawl_profile,
             max_pages=max_pages,
             max_depth=max_depth,
+            max_total_bytes=max_total_bytes,
+            per_page_bytes=per_page_bytes,
+            timeout=timeout,
+            max_sitemaps=max_sitemaps,
+            max_sitemap_urls=max_sitemap_urls,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -118,6 +128,28 @@ def _assessment(url: str, profile: CrawlProfile, request: Request) -> Assessment
     return assessment
 
 
+def _active_profile(
+    crawl_profile: str,
+    max_pages: int | None,
+    max_depth: int | None,
+    max_total_bytes: int | None,
+    per_page_bytes: int | None,
+    timeout: float | None,
+    max_sitemaps: int | None,
+    max_sitemap_urls: int | None,
+) -> CrawlProfile:
+    return _profile(
+        crawl_profile,
+        max_pages,
+        max_depth,
+        max_total_bytes,
+        per_page_bytes,
+        timeout,
+        max_sitemaps,
+        max_sitemap_urls,
+    )
+
+
 @router.get("/assess")
 def crawl_assess(
     request: Request,
@@ -125,8 +157,22 @@ def crawl_assess(
     crawl_profile: str = Query(default="quick", max_length=16),
     max_pages: int | None = Query(default=None),
     max_depth: int | None = Query(default=None),
+    max_total_bytes: int | None = Query(default=None),
+    per_page_bytes: int | None = Query(default=None),
+    timeout: float | None = Query(default=None),
+    max_sitemaps: int | None = Query(default=None),
+    max_sitemap_urls: int | None = Query(default=None),
 ) -> dict[str, object]:
-    active = _profile(crawl_profile, max_pages, max_depth)
+    active = _active_profile(
+        crawl_profile,
+        max_pages,
+        max_depth,
+        max_total_bytes,
+        per_page_bytes,
+        timeout,
+        max_sitemaps,
+        max_sitemap_urls,
+    )
     return _assessment(url, active, request).model_dump(mode="json")
 
 
@@ -137,9 +183,23 @@ def crawl_report(
     crawl_profile: str = Query(default="quick", max_length=16),
     max_pages: int | None = Query(default=None),
     max_depth: int | None = Query(default=None),
+    max_total_bytes: int | None = Query(default=None),
+    per_page_bytes: int | None = Query(default=None),
+    timeout: float | None = Query(default=None),
+    max_sitemaps: int | None = Query(default=None),
+    max_sitemap_urls: int | None = Query(default=None),
     profile: str | None = Query(default=None, max_length=24),
 ) -> str:
-    active = _profile(crawl_profile, max_pages, max_depth)
+    active = _active_profile(
+        crawl_profile,
+        max_pages,
+        max_depth,
+        max_total_bytes,
+        per_page_bytes,
+        timeout,
+        max_sitemaps,
+        max_sitemap_urls,
+    )
     return render_report(_assessment(url, active, request), _report_profile(profile))
 
 
@@ -150,10 +210,24 @@ def crawl_report_pdf(
     crawl_profile: str = Query(default="quick", max_length=16),
     max_pages: int | None = Query(default=None),
     max_depth: int | None = Query(default=None),
+    max_total_bytes: int | None = Query(default=None),
+    per_page_bytes: int | None = Query(default=None),
+    timeout: float | None = Query(default=None),
+    max_sitemaps: int | None = Query(default=None),
+    max_sitemap_urls: int | None = Query(default=None),
     profile: str | None = Query(default=None, max_length=24),
 ) -> Response:
     _reserve(request, UsageKind.pdf)
-    active = _profile(crawl_profile, max_pages, max_depth)
+    active = _active_profile(
+        crawl_profile,
+        max_pages,
+        max_depth,
+        max_total_bytes,
+        per_page_bytes,
+        timeout,
+        max_sitemaps,
+        max_sitemap_urls,
+    )
     assessment = _assessment(url, active, request)
     try:
         document = render_pdf(
@@ -181,10 +255,24 @@ def crawl_export(
     crawl_profile: str = Query(default="quick", max_length=16),
     max_pages: int | None = Query(default=None),
     max_depth: int | None = Query(default=None),
+    max_total_bytes: int | None = Query(default=None),
+    per_page_bytes: int | None = Query(default=None),
+    timeout: float | None = Query(default=None),
+    max_sitemaps: int | None = Query(default=None),
+    max_sitemap_urls: int | None = Query(default=None),
     profile: str | None = Query(default=None, max_length=24),
 ) -> Response:
     _reserve(request, UsageKind.export)
-    active = _profile(crawl_profile, max_pages, max_depth)
+    active = _active_profile(
+        crawl_profile,
+        max_pages,
+        max_depth,
+        max_total_bytes,
+        per_page_bytes,
+        timeout,
+        max_sitemaps,
+        max_sitemap_urls,
+    )
     assessment = _assessment(url, active, request)
     package = build_evidence_package(assessment, _report_profile(profile))
     _record(request, UsageKind.export, related_id=str(assessment.target))

--- a/src/veridra/project_store.py
+++ b/src/veridra/project_store.py
@@ -30,6 +30,11 @@ class ClientProject(BaseModel):
     crawl_profile: CrawlProfileName = CrawlProfileName.quick
     crawl_max_pages: int | None = None
     crawl_max_depth: int | None = None
+    crawl_max_total_bytes: int | None = None
+    crawl_per_page_bytes: int | None = None
+    crawl_timeout: float | None = None
+    crawl_max_sitemaps: int | None = None
+    crawl_max_sitemap_urls: int | None = None
     monitoring_schedule: MonitoringSchedule = Field(default_factory=MonitoringSchedule)
     monitoring_email: EmailStr | None = None
 
@@ -46,6 +51,11 @@ class ClientProject(BaseModel):
         crawl_profile: str | CrawlProfileName = CrawlProfileName.quick,
         crawl_max_pages: int | None = None,
         crawl_max_depth: int | None = None,
+        crawl_max_total_bytes: int | None = None,
+        crawl_per_page_bytes: int | None = None,
+        crawl_timeout: float | None = None,
+        crawl_max_sitemaps: int | None = None,
+        crawl_max_sitemap_urls: int | None = None,
         monitoring_schedule: MonitoringSchedule | None = None,
         monitoring_email: str | None = None,
     ) -> ClientProject:
@@ -53,7 +63,13 @@ class ClientProject(BaseModel):
             crawl_profile,
             max_pages=crawl_max_pages,
             max_depth=crawl_max_depth,
+            max_total_bytes=crawl_max_total_bytes,
+            per_page_bytes=crawl_per_page_bytes,
+            timeout=crawl_timeout,
+            max_sitemaps=crawl_max_sitemaps,
+            max_sitemap_urls=crawl_max_sitemap_urls,
         )
+        custom = resolved.name == CrawlProfileName.custom
         return cls(
             name=name,
             target_url=normalize_url(target_url),
@@ -62,16 +78,13 @@ class ClientProject(BaseModel):
             contact_member_id=contact_member_id,
             profile_id=profile_id,
             crawl_profile=resolved.name,
-            crawl_max_pages=(
-                resolved.limits.max_pages
-                if resolved.name == CrawlProfileName.custom
-                else None
-            ),
-            crawl_max_depth=(
-                resolved.limits.max_depth
-                if resolved.name == CrawlProfileName.custom
-                else None
-            ),
+            crawl_max_pages=resolved.limits.max_pages if custom else None,
+            crawl_max_depth=resolved.limits.max_depth if custom else None,
+            crawl_max_total_bytes=(resolved.limits.max_total_bytes if custom else None),
+            crawl_per_page_bytes=(resolved.limits.per_page_bytes if custom else None),
+            crawl_timeout=resolved.limits.timeout if custom else None,
+            crawl_max_sitemaps=resolved.limits.max_sitemaps if custom else None,
+            crawl_max_sitemap_urls=(resolved.limits.max_sitemap_urls if custom else None),
             monitoring_schedule=monitoring_schedule or MonitoringSchedule(),
             monitoring_email=monitoring_email,
         )
@@ -81,6 +94,11 @@ class ClientProject(BaseModel):
             self.crawl_profile,
             max_pages=self.crawl_max_pages,
             max_depth=self.crawl_max_depth,
+            max_total_bytes=self.crawl_max_total_bytes,
+            per_page_bytes=self.crawl_per_page_bytes,
+            timeout=self.crawl_timeout,
+            max_sitemaps=self.crawl_max_sitemaps,
+            max_sitemap_urls=self.crawl_max_sitemap_urls,
         )
 
 

--- a/tests/test_crawl_profile_web.py
+++ b/tests/test_crawl_profile_web.py
@@ -46,6 +46,16 @@ def test_unknown_and_out_of_range_profiles_fail_before_collection() -> None:
     )
     assert too_large.status_code == 400
 
+    excessive_bytes = client.get(
+        "/crawl/assess",
+        params={
+            "url": "https://example.com",
+            "crawl_profile": "custom",
+            "max_total_bytes": 30_000_001,
+        },
+    )
+    assert excessive_bytes.status_code == 400
+
 
 def test_named_profile_is_applied_to_operator_route(monkeypatch: MonkeyPatch) -> None:
     captured: list[CrawlProfile] = []
@@ -64,15 +74,55 @@ def test_named_profile_is_applied_to_operator_route(monkeypatch: MonkeyPatch) ->
     assert captured[0].limits.max_depth == 2
 
 
-def test_saved_project_uses_its_crawl_profile(
+def test_complete_custom_profile_is_applied_to_operator_route(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured: list[CrawlProfile] = []
+    monkeypatch.setattr(
+        crawl_profile_web,
+        "_assessment",
+        _capture_assessment(captured),
+    )
+    parameters = {
+        "url": "https://example.com",
+        "crawl_profile": "custom",
+        "max_pages": 35,
+        "max_depth": 2,
+        "max_total_bytes": 7_000_000,
+        "per_page_bytes": 550_000,
+        "timeout": 6.5,
+        "max_sitemaps": 6,
+        "max_sitemap_urls": 160,
+    }
+    response = TestClient(app).get("/crawl/assess", params=parameters)
+    assert response.status_code == 200
+
+    limits = captured[0].limits
+    assert limits.max_pages == 35
+    assert limits.max_depth == 2
+    assert limits.max_total_bytes == 7_000_000
+    assert limits.per_page_bytes == 550_000
+    assert limits.timeout == 6.5
+    assert limits.max_sitemaps == 6
+    assert limits.max_sitemap_urls == 160
+
+
+def test_saved_project_uses_its_complete_custom_crawl_profile(
     monkeypatch: MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     monkeypatch.setenv("VERIDRA_DATA_DIR", str(tmp_path))
     project = ClientProject.build(
-        name="Deep client",
+        name="Custom client",
         target_url="https://example.com",
-        crawl_profile="deep",
+        crawl_profile="custom",
+        crawl_max_pages=45,
+        crawl_max_depth=2,
+        crawl_max_total_bytes=9_000_000,
+        crawl_per_page_bytes=650_000,
+        crawl_timeout=8.5,
+        crawl_max_sitemaps=8,
+        crawl_max_sitemap_urls=220,
     )
     entry_id = ProjectStore().save(project)
     captured: list[CrawlProfile] = []
@@ -84,8 +134,14 @@ def test_saved_project_uses_its_crawl_profile(
 
     response = TestClient(app).get(f"/crawl/projects/{entry_id}/assess")
     assert response.status_code == 200
-    assert captured[0].name == CrawlProfileName.deep
-    assert captured[0].limits.max_pages == 100
+    limits = captured[0].limits
+    assert limits.max_pages == 45
+    assert limits.max_depth == 2
+    assert limits.max_total_bytes == 9_000_000
+    assert limits.per_page_bytes == 650_000
+    assert limits.timeout == 8.5
+    assert limits.max_sitemaps == 8
+    assert limits.max_sitemap_urls == 220
 
 
 def test_profile_report_and_export_routes_share_assessment(
@@ -98,7 +154,17 @@ def test_profile_report_and_export_routes_share_assessment(
         _capture_assessment(captured),
     )
     client = TestClient(app)
-    parameters = {"url": "https://example.com", "crawl_profile": "quick"}
+    parameters = {
+        "url": "https://example.com",
+        "crawl_profile": "custom",
+        "max_pages": 20,
+        "max_depth": 2,
+        "max_total_bytes": 6_000_000,
+        "per_page_bytes": 500_000,
+        "timeout": 6.0,
+        "max_sitemaps": 5,
+        "max_sitemap_urls": 140,
+    }
 
     report = client.get("/crawl/report", params=parameters)
     assert report.status_code == 200
@@ -114,3 +180,4 @@ def test_profile_report_and_export_routes_share_assessment(
             "report.html",
         }
     assert len(captured) == 2
+    assert captured[0].limits == captured[1].limits

--- a/tests/test_crawl_profiles.py
+++ b/tests/test_crawl_profiles.py
@@ -26,6 +26,16 @@ def test_custom_profile_enforces_hard_caps() -> None:
         resolve_crawl_profile("custom", max_pages=101)
     with pytest.raises(ValueError, match="max_depth"):
         resolve_crawl_profile("custom", max_depth=4)
+    with pytest.raises(ValueError, match="max_total_bytes"):
+        resolve_crawl_profile("custom", max_total_bytes=30_000_001)
+    with pytest.raises(ValueError, match="per_page_bytes"):
+        resolve_crawl_profile("custom", per_page_bytes=1_000_001)
+    with pytest.raises(ValueError, match="timeout"):
+        resolve_crawl_profile("custom", timeout=12.1)
+    with pytest.raises(ValueError, match="max_sitemaps"):
+        resolve_crawl_profile("custom", max_sitemaps=16)
+    with pytest.raises(ValueError, match="max_sitemap_urls"):
+        resolve_crawl_profile("custom", max_sitemap_urls=1_001)
 
 
 def test_named_profile_rejects_custom_values() -> None:
@@ -45,7 +55,7 @@ def test_anonymous_profile_remains_conservative() -> None:
     assert profile.limits.max_depth == 1
 
 
-def test_project_persists_named_and_custom_profiles() -> None:
+def test_project_persists_named_and_complete_custom_profiles() -> None:
     standard = ClientProject.build(
         name="Client",
         target_url="example.com",
@@ -53,6 +63,7 @@ def test_project_persists_named_and_custom_profiles() -> None:
     )
     assert standard.crawl_profile == CrawlProfileName.standard
     assert standard.resolved_crawl_profile().limits.max_pages == 25
+    assert standard.crawl_max_total_bytes is None
 
     custom = ClientProject.build(
         name="Custom",
@@ -60,6 +71,25 @@ def test_project_persists_named_and_custom_profiles() -> None:
         crawl_profile="custom",
         crawl_max_pages=30,
         crawl_max_depth=2,
+        crawl_max_total_bytes=8_000_000,
+        crawl_per_page_bytes=600_000,
+        crawl_timeout=7.5,
+        crawl_max_sitemaps=7,
+        crawl_max_sitemap_urls=180,
     )
     assert custom.crawl_max_pages == 30
-    assert custom.resolved_crawl_profile().limits.max_depth == 2
+    assert custom.crawl_max_depth == 2
+    assert custom.crawl_max_total_bytes == 8_000_000
+    assert custom.crawl_per_page_bytes == 600_000
+    assert custom.crawl_timeout == 7.5
+    assert custom.crawl_max_sitemaps == 7
+    assert custom.crawl_max_sitemap_urls == 180
+
+    resolved = custom.resolved_crawl_profile().limits
+    assert resolved.max_pages == 30
+    assert resolved.max_depth == 2
+    assert resolved.max_total_bytes == 8_000_000
+    assert resolved.per_page_bytes == 600_000
+    assert resolved.timeout == 7.5
+    assert resolved.max_sitemaps == 7
+    assert resolved.max_sitemap_urls == 180


### PR DESCRIPTION
Bounded continuation of issue #60 from `main` at `a0c5acca25fad4f2c0c813753e26eeac1a7d88fe`.

- persists every custom crawl limit with saved client projects;
- preserves max pages, depth, total bytes, per-page bytes, timeout, sitemap-file count and sitemap-URL count;
- propagates the complete custom contract through `/crawl/assess`, HTML report, PDF and evidence export;
- retains Quick, Standard and Deep named profiles unchanged;
- retains the hard 100-page and depth-3 server ceilings;
- adds deterministic hard-cap, route-propagation and project-persistence tests.

This does not add concurrency, background workers, higher page tiers or unbounded crawling.

Part of #60. Merge only after exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit and evidence upload pass.