### PR TITLE
Complete project crawl profile workflow

### DIFF
--- a/src/veridra/agency_crawl_profile_web.py
+++ b/src/veridra/agency_crawl_profile_web.py
@@ -1,0 +1,128 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .agency_navigation import agency_navigation
+from .crawl_profiles import CrawlProfileName, resolve_crawl_profile
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .project_store import ClientProject
+from .request_security import require_request_identity
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+
+router = APIRouter(prefix="/agency", tags=["agency-crawl-profile"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:920px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}label{display:block;font-weight:700;margin:12px 0 5px}select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.actions{display:flex;gap:8px;flex-wrap:wrap}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}
+"""
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _load(request: Request, identity: RequestIdentity, project_id: str) -> tuple[TenantProjectStore, ClientProject]:
+    store = TenantProjectStore(_root(request))
+    try:
+        return store, store.load(identity, store.ref(identity, project_id))
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+
+def _can_manage(identity: RequestIdentity) -> bool:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+    except IdentityBoundaryError:
+        return False
+    return True
+
+
+def _options(selected: CrawlProfileName) -> str:
+    labels = {
+        CrawlProfileName.quick: "Quick — up to 10 pages, depth 1",
+        CrawlProfileName.standard: "Standard — up to 25 pages, depth 2",
+        CrawlProfileName.deep: "Deep — up to 100 pages, depth 3",
+    }
+    return "".join(
+        "<option value='{value}'{selected}>{label}</option>".format(
+            value=profile.value,
+            selected=" selected" if profile is selected else "",
+            label=html.escape(label),
+        )
+        for profile, label in labels.items()
+    )
+
+
+def _single(body: bytes, name: str) -> str:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
+
+
+@router.get("/projects/{project_id}/crawl-profile", response_class=HTMLResponse)
+def project_crawl_profile(project_id: str, request: Request, saved: bool = False) -> str:
+    identity = require_request_identity(request)
+    _, project = _load(request, identity, project_id)
+    active = project.resolved_crawl_profile()
+    limits = active.limits
+    status = "<p class='notice'><strong>Crawl profile saved.</strong> Future project assessments and monitoring runs will use these limits.</p>" if saved else ""
+    if _can_manage(identity):
+        form = f"<form method='post' action='/agency/projects/{html.escape(project_id, quote=True)}/crawl-profile'><label for='crawl_profile'>Named crawl profile</label><select id='crawl_profile' name='crawl_profile'>{_options(project.crawl_profile)}</select><p class='muted'>Only server-defined profiles are available here. Deep remains capped at 100 pages and depth 3.</p><button type='submit'>Save crawl profile</button></form>"
+    else:
+        form = "<p class='notice'>Your current workspace role can inspect this profile but cannot change it.</p>"
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a></p><h1>Crawl profile for {html.escape(project.name)}</h1>{status}<p><strong>Current profile:</strong> {html.escape(active.name.value.title())}<br><strong>Effective pages:</strong> {limits.max_pages}<br><strong>Effective depth:</strong> {limits.max_depth}<br><strong>Total byte ceiling:</strong> {limits.max_total_bytes}<br><strong>Per-page byte ceiling:</strong> {limits.per_page_bytes}<br><strong>Timeout:</strong> {limits.timeout:g} seconds<br><strong>Sitemap files:</strong> {limits.max_sitemaps}<br><strong>Sitemap URLs:</strong> {limits.max_sitemap_urls}</p></section><section><h2>Future assessment depth</h2>{form}</section>"""
+    return _page(f"{project.name} crawl profile", body)
+
+
+@router.post("/projects/{project_id}/crawl-profile")
+async def save_project_crawl_profile(project_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    store, project = _load(request, identity, project_id)
+    body = await request.body()
+    try:
+        selected = CrawlProfileName(_single(body, "crawl_profile"))
+        if selected is CrawlProfileName.custom:
+            raise ValueError("Custom crawl values are not available in this workflow.")
+        resolve_crawl_profile(selected)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Crawl profile is invalid.") from exc
+    replacement = ClientProject.model_validate(
+        project.model_copy(
+            update={
+                "crawl_profile": selected,
+                "crawl_max_pages": None,
+                "crawl_max_depth": None,
+                "crawl_max_total_bytes": None,
+                "crawl_per_page_bytes": None,
+                "crawl_timeout": None,
+                "crawl_max_sitemaps": None,
+                "crawl_max_sitemap_urls": None,
+            }
+        )
+    )
+    try:
+        store.replace(identity, store.ref(identity, project_id), replacement)
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
+    return RedirectResponse(
+        f"/agency/projects/{project_id}/crawl-profile?{urlencode({'saved': 'true'})}",
+        status_code=303,
+    )

--- a/src/veridra/agency_crawl_profile_web.py
+++ b/src/veridra/agency_crawl_profile_web.py
@@ -61,7 +61,7 @@ def _options(selected: CrawlProfileName) -> str:
     return "".join(
         "<option value='{value}'{selected}>{label}</option>".format(
             value=profile.value,
-            selected=" selected" if profile is selected else "",
+            selected=" selected" if profile == selected else "",
             label=html.escape(label),
         )
         for profile, label in labels.items()
@@ -99,7 +99,7 @@ async def save_project_crawl_profile(project_id: str, request: Request) -> Redir
     body = await request.body()
     try:
         selected = CrawlProfileName(_single(body, "crawl_profile"))
-        if selected is CrawlProfileName.custom:
+        if selected == CrawlProfileName.custom:
             raise ValueError("Custom crawl values are not available in this workflow.")
         resolve_crawl_profile(selected)
     except ValueError as exc:

--- a/src/veridra/agency_project_index_web.py
+++ b/src/veridra/agency_project_index_web.py
@@ -33,7 +33,7 @@ def agency_projects(request: Request) -> str:
     entries = TenantProjectStore(_root(request)).list(identity)
     if entries:
         cards = "".join(
-            "<article class='card'><p class='muted'>{client}</p><h2>{name}</h2><p><strong>Website:</strong> {target}<br><strong>Crawl:</strong> {crawl}<br><strong>Monitoring:</strong> {monitoring}</p><div class='actions'><a class='button' href='/agency/projects/{identifier}'>Open project</a><a class='button secondary' href='/agency/projects/{identifier}/reports'>Reports</a><a class='button secondary' href='/agency/projects/{identifier}/monitoring'>Monitoring</a></div></article>".format(
+            "<article class='card'><p class='muted'>{client}</p><h2>{name}</h2><p><strong>Website:</strong> {target}<br><strong>Crawl:</strong> {crawl}<br><strong>Monitoring:</strong> {monitoring}</p><div class='actions'><a class='button' href='/agency/projects/{identifier}'>Open project</a><a class='button secondary' href='/agency/projects/{identifier}/crawl-profile'>Crawl profile</a><a class='button secondary' href='/agency/projects/{identifier}/reports'>Reports</a><a class='button secondary' href='/agency/projects/{identifier}/monitoring'>Monitoring</a></div></article>".format(
                 client=html.escape(entry.client_label or "Client not labelled"),
                 name=html.escape(entry.name),
                 target=html.escape(entry.target_url),

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -6,6 +6,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from . import app as app_module
 from . import public_web
 from .agency_conversion_web import router as agency_conversion_router
+from .agency_crawl_profile_web import router as agency_crawl_profile_router
 from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
 from .agency_project_index_web import router as agency_project_index_router
@@ -115,6 +116,7 @@ app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)
 app.include_router(agency_project_index_router)
 app.include_router(agency_conversion_router)
+app.include_router(agency_crawl_profile_router)
 app.include_router(agency_lead_router)
 app.include_router(agency_task_router)
 app.include_router(agency_monitoring_router)

--- a/tests/test_agency_crawl_profile_web.py
+++ b/tests/test_agency_crawl_profile_web.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from veridra import tenant_monitoring_api, tenant_monitoring_execution
+from veridra.agency_crawl_profile_web import router
+from veridra.core import Assessment, demo_assessment
+from veridra.crawl_profiles import CrawlProfile, CrawlProfileName
+from veridra.identity_middleware import VerifiedIdentityMiddleware
+from veridra.identity_tenancy import (
+    AccountStatus,
+    AuthenticatedUser,
+    AuthSession,
+    RequestIdentity,
+    Tenant,
+    TenantMembership,
+    TenantRole,
+)
+from veridra.project_store import ClientProject
+from veridra.session_cookie import SecureSessionCookieExtractor
+from veridra.session_identity_adapter import ServerSideSessionIdentityAdapter
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 7, 27, 19, 0, tzinfo=UTC)
+OWNER_CREDENTIAL = "crawl-profile-owner-session-000001"
+VIEWER_CREDENTIAL = "crawl-profile-viewer-session-00001"
+
+
+def _active_user(email: str) -> AuthenticatedUser:
+    return AuthenticatedUser.build(email=email, display_name=email, now=NOW).model_copy(
+        update={"status": AccountStatus.active, "email_verified_at": NOW}
+    )
+
+
+def _save_identity(
+    store: SQLiteIdentityRecordStore,
+    *,
+    tenant: Tenant,
+    user: AuthenticatedUser,
+    role: TenantRole,
+    credential: str,
+    session_id: str,
+) -> None:
+    store.save_tenant(tenant)
+    store.save_user(user)
+    store.save_membership(
+        TenantMembership(
+            tenant_id=tenant.id,
+            user_id=user.id,
+            role=role,
+            created_at=NOW,
+        )
+    )
+    store.save_session(
+        credential=credential,
+        tenant_id=tenant.id,
+        session=AuthSession(
+            id=session_id,
+            user_id=user.id,
+            issued_at=NOW,
+            expires_at=NOW + timedelta(hours=8),
+        ),
+    )
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, RequestIdentity, RequestIdentity, Path]:
+    store = SQLiteIdentityRecordStore(tmp_path / "identity.sqlite3")
+    store.initialize()
+    tenant = Tenant.build(slug="crawl-profile-tenant", display_name="Crawl Profile", now=NOW)
+    owner = _active_user("owner@example.com")
+    viewer = _active_user("viewer@example.com")
+    _save_identity(
+        store,
+        tenant=tenant,
+        user=owner,
+        role=TenantRole.owner,
+        credential=OWNER_CREDENTIAL,
+        session_id="crawl-profile-owner-session",
+    )
+    _save_identity(
+        store,
+        tenant=tenant,
+        user=viewer,
+        role=TenantRole.viewer,
+        credential=VIEWER_CREDENTIAL,
+        session_id="crawl-profile-viewer-session",
+    )
+    root = tmp_path / "tenants"
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+    adapter = ServerSideSessionIdentityAdapter(
+        extractor=SecureSessionCookieExtractor(),
+        store=store,
+        clock=lambda: NOW + timedelta(minutes=1),
+    )
+    app.add_middleware(VerifiedIdentityMiddleware, adapter=adapter)
+    app.include_router(router)
+    owner_identity = RequestIdentity(
+        user_id=owner.id,
+        tenant_id=tenant.id,
+        membership_role=TenantRole.owner,
+        session_id="crawl-profile-owner-session",
+        authenticated_at=NOW,
+    )
+    viewer_identity = RequestIdentity(
+        user_id=viewer.id,
+        tenant_id=tenant.id,
+        membership_role=TenantRole.viewer,
+        session_id="crawl-profile-viewer-session",
+        authenticated_at=NOW,
+    )
+    return TestClient(app), owner_identity, viewer_identity, root
+
+
+def _save_project(root: Path, identity: RequestIdentity, profile: str = "deep") -> str:
+    return TenantProjectStore(root).save(
+        identity,
+        ClientProject.build(
+            name="Profile project",
+            target_url="https://example.com",
+            crawl_profile=profile,
+        ),
+    )
+
+
+def test_owner_can_change_named_profile_without_changing_project_id(tmp_path: Path) -> None:
+    client, owner, _, root = _client(tmp_path)
+    project_id = _save_project(root, owner)
+    client.cookies.set("veridra_session", OWNER_CREDENTIAL)
+
+    page = client.get(f"/agency/projects/{project_id}/crawl-profile")
+    response = client.post(
+        f"/agency/projects/{project_id}/crawl-profile",
+        data={"crawl_profile": "standard"},
+        follow_redirects=False,
+    )
+
+    assert page.status_code == 200
+    assert "Deep" in page.text
+    assert "Effective pages:</strong> 100" in page.text
+    assert "Sitemap URLs:</strong> 1000" in page.text
+    assert response.status_code == 303
+    assert response.headers["location"].startswith(
+        f"/agency/projects/{project_id}/crawl-profile?"
+    )
+    stored = TenantProjectStore(root).load(
+        owner,
+        TenantProjectStore(root).ref(owner, project_id),
+    )
+    assert stored.crawl_profile is CrawlProfileName.standard
+    assert stored.resolved_crawl_profile().limits.max_pages == 25
+
+
+def test_viewer_can_inspect_but_cannot_change_profile(tmp_path: Path) -> None:
+    client, owner, viewer, root = _client(tmp_path)
+    project_id = _save_project(root, owner)
+    client.cookies.set("veridra_session", VIEWER_CREDENTIAL)
+
+    page = client.get(f"/agency/projects/{project_id}/crawl-profile")
+    response = client.post(
+        f"/agency/projects/{project_id}/crawl-profile",
+        data={"crawl_profile": "quick"},
+    )
+
+    assert page.status_code == 200
+    assert "cannot change it" in page.text
+    assert "Save crawl profile" not in page.text
+    assert response.status_code == 403
+    stored = TenantProjectStore(root).load(
+        viewer,
+        TenantProjectStore(root).ref(viewer, project_id),
+    )
+    assert stored.crawl_profile is CrawlProfileName.deep
+
+
+def test_custom_and_unknown_browser_values_are_rejected(tmp_path: Path) -> None:
+    client, owner, _, root = _client(tmp_path)
+    project_id = _save_project(root, owner)
+    client.cookies.set("veridra_session", OWNER_CREDENTIAL)
+
+    custom = client.post(
+        f"/agency/projects/{project_id}/crawl-profile",
+        data={"crawl_profile": "custom"},
+    )
+    unknown = client.post(
+        f"/agency/projects/{project_id}/crawl-profile",
+        data={"crawl_profile": "unbounded"},
+    )
+
+    assert custom.status_code == 400
+    assert unknown.status_code == 400
+
+
+def _request(root: Path) -> Request:
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/",
+            "headers": [],
+            "app": app,
+        }
+    )
+
+
+def test_manual_and_worker_monitoring_use_the_saved_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, owner, _, root = _client(tmp_path)
+    project_id = _save_project(root, owner, "standard")
+    captured: list[CrawlProfile] = []
+
+    def fake_assess(
+        _url: str,
+        *,
+        crawl_profile: CrawlProfile,
+    ) -> Assessment:
+        captured.append(crawl_profile)
+        return demo_assessment()
+
+    monkeypatch.setattr(tenant_monitoring_api, "assess_url", fake_assess)
+    monkeypatch.setattr(tenant_monitoring_execution, "assess_url", fake_assess)
+
+    tenant_monitoring_api.run_monitoring_assessment(
+        project_id,
+        _request(root),
+        owner,
+    )
+    tenant_monitoring_execution.execute_tenant_monitoring(
+        root=root,
+        tenant_id=owner.tenant_id,
+        project_id=project_id,
+    )
+
+    assert [profile.name for profile in captured] == [
+        CrawlProfileName.standard,
+        CrawlProfileName.standard,
+    ]
+    assert all(profile.limits.max_pages == 25 for profile in captured)


### PR DESCRIPTION
Final bounded completion candidate for issue #60 from `main` at `cb67a6ac534a9f4c5710baa8e8d5aca5b08eab3d`.

- adds a tenant-qualified project crawl-profile page;
- lets `manage_projects` roles switch future runs among Quick, Standard and Deep;
- keeps viewers read-only;
- rejects Custom and unknown browser values server-side;
- preserves stable tenant project identity and all attached history, tasks, reports and monitoring relationships;
- displays every effective crawl ceiling, including pages, depth, bytes, timeout and sitemap limits;
- links the editor from the authoritative project index;
- proves both manual monitoring and the durable worker resolve the saved project profile before assessment;
- preserves the hard 100-page and depth-3 ceiling.

This does not add higher tiers, free-form custom browser controls, concurrency or unbounded crawling.

Closes #60 only after exact-head Ruff, strict mypy, pytest, deterministic audit, Chromium audit and evidence upload pass.