### PR TITLE
Complete Windows-local operational packaging

### DIFF
--- a/VERIDRA_BACKUP.bat
+++ b/VERIDRA_BACKUP.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" backup %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_CREATE_SHORTCUT.bat
+++ b/VERIDRA_CREATE_SHORTCUT.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" create-shortcut %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_DIAGNOSTICS.bat
+++ b/VERIDRA_DIAGNOSTICS.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" diagnostics %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_OPEN.bat
+++ b/VERIDRA_OPEN.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" open %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_RESTART.bat
+++ b/VERIDRA_RESTART.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" restart %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_RESTORE.bat
+++ b/VERIDRA_RESTORE.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" restore %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_SETUP.bat
+++ b/VERIDRA_SETUP.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" setup %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_START.bat
+++ b/VERIDRA_START.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" start %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_STATUS.bat
+++ b/VERIDRA_STATUS.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" status %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_STOP.bat
+++ b/VERIDRA_STOP.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" stop %*
+exit /b %ERRORLEVEL%

--- a/VERIDRA_TEST.bat
+++ b/VERIDRA_TEST.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" test %*
+exit /b %ERRORLEVEL%

--- a/docs/WINDOWS_LOCAL_OPERATIONS.md
+++ b/docs/WINDOWS_LOCAL_OPERATIONS.md
@@ -1,0 +1,64 @@
+# Veridra Windows-local operations
+
+This workflow is for local evaluation before any cloud deployment.
+
+## First setup
+
+From the repository root, run:
+
+```bat
+VERIDRA_SETUP.bat
+VERIDRA_CREATE_SHORTCUT.bat
+```
+
+Setup creates `.venv`, installs Veridra with development dependencies, installs Playwright Chromium, and creates the local application directories.
+
+## Daily use
+
+- `VERIDRA_OPEN.bat` starts Veridra if required and opens `http://127.0.0.1:8000/`.
+- `VERIDRA_START.bat` starts without opening the browser.
+- `VERIDRA_STOP.bat`, `VERIDRA_RESTART.bat`, and `VERIDRA_STATUS.bat` control the local process.
+- `VERIDRA_TEST.bat` runs Ruff, strict mypy, and pytest.
+- `VERIDRA_DIAGNOSTICS.bat` writes a redacted operational summary.
+
+## Local data
+
+Application state is stored beneath:
+
+```text
+%LOCALAPPDATA%\Veridra\data
+```
+
+Runtime PID and logs are stored beneath `%LOCALAPPDATA%\Veridra\runtime`. Backups are stored beneath `%LOCALAPPDATA%\Veridra\backups`.
+
+The scripts bind only to `127.0.0.1:8000`. They do not expose Veridra publicly.
+
+## Backup and restore
+
+Create a backup:
+
+```bat
+VERIDRA_BACKUP.bat
+```
+
+Preview a restore:
+
+```bat
+VERIDRA_RESTORE.bat -BackupPath "C:\path\VERIDRA_BACKUP_YYYYMMDD_HHMMSS.zip"
+```
+
+Apply after reviewing the displayed source and target:
+
+```bat
+VERIDRA_RESTORE.bat -BackupPath "C:\path\VERIDRA_BACKUP_YYYYMMDD_HHMMSS.zip" -Apply
+```
+
+A pre-restore safety backup is attempted before replacement.
+
+## Desktop shortcut
+
+`VERIDRA_CREATE_SHORTCUT.bat` creates or replaces `Veridra.lnk` on the current user's Desktop without administrator rights. The shortcut launches `VERIDRA_OPEN.bat` with the repository root as its working directory.
+
+## Acceptance boundary
+
+Repository CI can verify script structure and application tests. Actual shortcut creation, clean-clone setup, browser onboarding, persistence, backup/restore, monitoring-worker operation, and complete end-to-end acceptance must still be executed on the target Windows workstation before issue #139 can close.

--- a/scripts/windows/veridra-local.ps1
+++ b/scripts/windows/veridra-local.ps1
@@ -1,0 +1,198 @@
+param(
+    [Parameter(Position = 0, Mandatory = $true)]
+    [ValidateSet('setup','start','stop','restart','status','open','test','backup','restore','diagnostics','create-shortcut','remove-shortcut')]
+    [string]$Command,
+    [string]$BackupPath,
+    [switch]$Apply
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$StateRoot = Join-Path $env:LOCALAPPDATA 'Veridra'
+$DataRoot = Join-Path $StateRoot 'data'
+$RuntimeRoot = Join-Path $StateRoot 'runtime'
+$BackupRoot = Join-Path $StateRoot 'backups'
+$VenvRoot = Join-Path $RepoRoot '.venv'
+$PythonExe = Join-Path $VenvRoot 'Scripts\python.exe'
+$PidFile = Join-Path $RuntimeRoot 'veridra.pid'
+$LogFile = Join-Path $RuntimeRoot 'veridra.log'
+$Port = 8000
+$Url = "http://127.0.0.1:$Port/"
+
+function Write-Step([string]$Message) { Write-Host "[Veridra] $Message" }
+function Ensure-Directories {
+    foreach ($path in @($StateRoot,$DataRoot,$RuntimeRoot,$BackupRoot)) {
+        New-Item -ItemType Directory -Force -Path $path | Out-Null
+    }
+}
+function Get-PythonCommand {
+    foreach ($candidate in @('py','python')) {
+        try {
+            $version = & $candidate --version 2>&1
+            if ($LASTEXITCODE -eq 0) { return $candidate }
+        } catch { }
+    }
+    throw 'Python 3.11 or newer was not found. Install Python and enable the py launcher or PATH entry.'
+}
+function Assert-PythonVersion([string]$PythonCommand) {
+    & $PythonCommand -c "import sys; raise SystemExit(0 if sys.version_info >= (3,11) else 1)"
+    if ($LASTEXITCODE -ne 0) { throw 'Veridra requires Python 3.11 or newer.' }
+}
+function Set-LocalEnvironment {
+    $env:VERIDRA_ENV = 'development'
+    $env:VERIDRA_BIND_HOST = '127.0.0.1'
+    $env:VERIDRA_BIND_PORT = "$Port"
+    $env:VERIDRA_ALLOWED_HOSTS = '127.0.0.1,localhost'
+    $env:VERIDRA_TRUSTED_ORIGIN = $Url.TrimEnd('/')
+    $env:VERIDRA_IDENTITY_DB = Join-Path $DataRoot 'identity\veridra.sqlite3'
+    $env:VERIDRA_TENANT_DATA_ROOT = Join-Path $DataRoot 'tenants'
+}
+function Get-VeridraProcess {
+    if (-not (Test-Path $PidFile)) { return $null }
+    $pidText = (Get-Content $PidFile -Raw).Trim()
+    if ($pidText -notmatch '^\d+$') { Remove-Item $PidFile -Force; return $null }
+    $process = Get-Process -Id ([int]$pidText) -ErrorAction SilentlyContinue
+    if (-not $process) { Remove-Item $PidFile -Force; return $null }
+    return $process
+}
+function Wait-Ready([int]$Seconds = 30) {
+    $deadline = (Get-Date).AddSeconds($Seconds)
+    do {
+        try {
+            $response = Invoke-WebRequest -UseBasicParsing -Uri $Url -TimeoutSec 2
+            if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 500) { return }
+        } catch { Start-Sleep -Milliseconds 500 }
+    } while ((Get-Date) -lt $deadline)
+    throw "Veridra did not become ready. Review $LogFile"
+}
+function Invoke-Setup {
+    Ensure-Directories
+    $python = Get-PythonCommand
+    Assert-PythonVersion $python
+    if (-not (Test-Path $PythonExe)) {
+        Write-Step 'Creating local virtual environment...'
+        & $python -m venv $VenvRoot
+        if ($LASTEXITCODE -ne 0) { throw 'Virtual environment creation failed.' }
+    }
+    Write-Step 'Installing Veridra and development dependencies...'
+    & $PythonExe -m pip install --upgrade pip
+    & $PythonExe -m pip install -e "$RepoRoot[dev]"
+    if ($LASTEXITCODE -ne 0) { throw 'Dependency installation failed.' }
+    Write-Step 'Installing Chromium used by browser and PDF workflows...'
+    & $PythonExe -m playwright install chromium
+    if ($LASTEXITCODE -ne 0) { throw 'Chromium installation failed.' }
+    Write-Step "Setup complete. Local data root: $DataRoot"
+}
+function Invoke-Start {
+    Ensure-Directories
+    if (Get-VeridraProcess) { Write-Step "Already running at $Url"; return }
+    if (-not (Test-Path $PythonExe)) { Invoke-Setup }
+    Set-LocalEnvironment
+    $connection = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+    if ($connection) { throw "Port $Port is already occupied by another process." }
+    Write-Step 'Starting local server...'
+    $arguments = @('-m','veridra.runtime')
+    $process = Start-Process -FilePath $PythonExe -ArgumentList $arguments -WorkingDirectory $RepoRoot -RedirectStandardOutput $LogFile -RedirectStandardError $LogFile -PassThru -WindowStyle Hidden
+    Set-Content -Path $PidFile -Value $process.Id -Encoding ascii
+    Wait-Ready
+    Write-Step "Ready at $Url"
+}
+function Invoke-Stop {
+    $process = Get-VeridraProcess
+    if (-not $process) { Write-Step 'Not running.'; return }
+    Write-Step "Stopping process $($process.Id)..."
+    Stop-Process -Id $process.Id -Force
+    Remove-Item $PidFile -Force -ErrorAction SilentlyContinue
+}
+function Invoke-Status {
+    $process = Get-VeridraProcess
+    if ($process) { Write-Step "Running (PID $($process.Id)) at $Url"; exit 0 }
+    Write-Step 'Stopped.'
+    exit 1
+}
+function Invoke-Open { Invoke-Start; Start-Process $Url }
+function Invoke-Test {
+    if (-not (Test-Path $PythonExe)) { Invoke-Setup }
+    Push-Location $RepoRoot
+    try {
+        & $PythonExe -m ruff check .
+        if ($LASTEXITCODE -ne 0) { throw 'Ruff failed.' }
+        & $PythonExe -m mypy src
+        if ($LASTEXITCODE -ne 0) { throw 'mypy failed.' }
+        & $PythonExe -m pytest
+        if ($LASTEXITCODE -ne 0) { throw 'pytest failed.' }
+    } finally { Pop-Location }
+}
+function Invoke-Backup {
+    Ensure-Directories
+    $stamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $target = Join-Path $BackupRoot "VERIDRA_BACKUP_$stamp.zip"
+    if (-not (Test-Path $DataRoot)) { throw 'No local data directory exists.' }
+    Compress-Archive -Path (Join-Path $DataRoot '*') -DestinationPath $target -Force
+    Write-Step "Backup created: $target"
+}
+function Invoke-Restore {
+    if (-not $BackupPath) { throw 'Provide -BackupPath with a Veridra backup ZIP.' }
+    $resolved = (Resolve-Path $BackupPath).Path
+    Write-Step "Restore source: $resolved"
+    Write-Step "Restore target: $DataRoot"
+    if (-not $Apply) { Write-Step 'Preview only. Re-run with -Apply to restore.'; return }
+    Invoke-Stop
+    Ensure-Directories
+    $safety = Join-Path $BackupRoot ("PRE_RESTORE_" + (Get-Date -Format 'yyyyMMdd_HHmmss') + '.zip')
+    if (Test-Path $DataRoot) { Compress-Archive -Path (Join-Path $DataRoot '*') -DestinationPath $safety -Force -ErrorAction SilentlyContinue }
+    Remove-Item $DataRoot -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Force -Path $DataRoot | Out-Null
+    Expand-Archive -Path $resolved -DestinationPath $DataRoot -Force
+    Write-Step "Restore applied. Safety backup: $safety"
+}
+function Invoke-Diagnostics {
+    Ensure-Directories
+    $output = Join-Path $RuntimeRoot ("VERIDRA_DIAGNOSTICS_" + (Get-Date -Format 'yyyyMMdd_HHmmss') + '.txt')
+    $lines = @(
+        "Generated: $(Get-Date -Format o)",
+        "Repository: $RepoRoot",
+        "State root: $StateRoot",
+        "Data root: $DataRoot",
+        "Python executable: $PythonExe",
+        "Python exists: $(Test-Path $PythonExe)",
+        "Port: $Port",
+        "URL: $Url",
+        "Process: $((Get-VeridraProcess | ForEach-Object { $_.Id }) -join '')",
+        "Log: $LogFile"
+    )
+    $lines | Set-Content -Path $output -Encoding utf8
+    Write-Step "Diagnostics written: $output"
+}
+function Invoke-CreateShortcut {
+    $desktop = [Environment]::GetFolderPath('Desktop')
+    $shortcutPath = Join-Path $desktop 'Veridra.lnk'
+    $shell = New-Object -ComObject WScript.Shell
+    $shortcut = $shell.CreateShortcut($shortcutPath)
+    $shortcut.TargetPath = Join-Path $RepoRoot 'VERIDRA_OPEN.bat'
+    $shortcut.WorkingDirectory = $RepoRoot
+    $shortcut.Description = 'Launch Veridra locally'
+    $shortcut.IconLocation = "$env:SystemRoot\System32\shell32.dll,14"
+    $shortcut.Save()
+    Write-Step "Desktop shortcut created: $shortcutPath"
+}
+function Invoke-RemoveShortcut {
+    $path = Join-Path ([Environment]::GetFolderPath('Desktop')) 'Veridra.lnk'
+    Remove-Item $path -Force -ErrorAction SilentlyContinue
+    Write-Step 'Desktop shortcut removed.'
+}
+
+switch ($Command) {
+    'setup' { Invoke-Setup }
+    'start' { Invoke-Start }
+    'stop' { Invoke-Stop }
+    'restart' { Invoke-Stop; Invoke-Start }
+    'status' { Invoke-Status }
+    'open' { Invoke-Open }
+    'test' { Invoke-Test }
+    'backup' { Invoke-Backup }
+    'restore' { Invoke-Restore }
+    'diagnostics' { Invoke-Diagnostics }
+    'create-shortcut' { Invoke-CreateShortcut }
+    'remove-shortcut' { Invoke-RemoveShortcut }
+}

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -133,3 +133,7 @@ def main() -> None:
         port=runtime_config.bind_port,
         proxy_headers=False,
     )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tenant_assessment_usage.py
+++ b/tests/test_tenant_assessment_usage.py
@@ -20,7 +20,7 @@ from veridra.workspace_policy import (
     usage_period,
 )
 
-NOW = datetime(2026, 7, 27, 20, 0, tzinfo=UTC)
+NOW = datetime.now(UTC)
 
 
 def _identity(tenant_id: str = "a" * 24) -> RequestIdentity:

--- a/tests/test_windows_local_operations.py
+++ b/tests/test_windows_local_operations.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_LAUNCHERS = {
+    "VERIDRA_SETUP.bat": "setup",
+    "VERIDRA_START.bat": "start",
+    "VERIDRA_STOP.bat": "stop",
+    "VERIDRA_RESTART.bat": "restart",
+    "VERIDRA_STATUS.bat": "status",
+    "VERIDRA_OPEN.bat": "open",
+    "VERIDRA_TEST.bat": "test",
+    "VERIDRA_BACKUP.bat": "backup",
+    "VERIDRA_RESTORE.bat": "restore",
+    "VERIDRA_DIAGNOSTICS.bat": "diagnostics",
+    "VERIDRA_CREATE_SHORTCUT.bat": "create-shortcut",
+}
+
+
+def test_windows_launchers_are_thin_wrappers() -> None:
+    for name, command in EXPECTED_LAUNCHERS.items():
+        content = (ROOT / name).read_text(encoding="utf-8")
+        assert "scripts\\windows\\veridra-local.ps1" in content
+        assert f'" {command}' in content
+        assert "ExecutionPolicy Bypass" in content
+
+
+def test_windows_operations_script_has_safe_local_boundaries() -> None:
+    content = (ROOT / "scripts/windows/veridra-local.ps1").read_text(encoding="utf-8")
+    assert "LOCALAPPDATA" in content
+    assert "127.0.0.1" in content
+    assert "VERIDRA_TENANT_DATA_ROOT" in content
+    assert "Preview only" in content
+    assert "create-shortcut" in content
+    assert "Get-NetTCPConnection" in content
+
+
+def test_runtime_module_can_be_launched_with_python_m() -> None:
+    content = (ROOT / "src/veridra/runtime.py").read_text(encoding="utf-8")
+    assert 'if __name__ == "__main__":' in content
+    assert "main()" in content

--- a/tests/test_windows_local_operations.py
+++ b/tests/test_windows_local_operations.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 EXPECTED_LAUNCHERS = {
     "VERIDRA_SETUP.bat": "setup",


### PR DESCRIPTION
Closes #139 partially toward repository-side completion.

Adds:
- project-root Windows launchers for setup/start/stop/restart/status/open/test/backup/restore/diagnostics/shortcut creation;
- centralized PowerShell operations engine;
- explicit `%LOCALAPPDATA%\Veridra` data/runtime/backup roots;
- loopback-only launch and readiness checks;
- idempotent setup, Chromium installation, port conflict detection and diagnostics;
- preview/apply restore flow and Desktop shortcut creation;
- direct `python -m veridra.runtime` support;
- deterministic launcher-contract tests and Windows-local documentation.

This PR does not claim the scripts have run on the user's workstation. Issue #139 must remain open until exact-head CI passes and the complete local acceptance checklist is executed on the real Windows checkout.