### PR TITLE
Add commercial Playwright acceptance runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
           mkdir -p artifacts/ci
           set -o pipefail
           python tools/browser_audit.py 2>&1 | tee artifacts/ci/browser-audit.log
+      - name: Commercial acceptance
+        shell: bash
+        run: |
+          mkdir -p artifacts/ci
+          set -o pipefail
+          python tools/commercial_acceptance.py 2>&1 | tee artifacts/ci/commercial-acceptance.log
       - name: Upload verification evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/VERIDRA_COMMERCIAL_ACCEPTANCE.bat
+++ b/VERIDRA_COMMERCIAL_ACCEPTANCE.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+if not exist ".venv\Scripts\python.exe" (
+  echo [Veridra] Local environment is not installed. Run VERIDRA_SETUP.bat first.
+  exit /b 1
+)
+echo [Veridra] Running isolated commercial acceptance...
+".venv\Scripts\python.exe" tools\commercial_acceptance.py %*
+exit /b %ERRORLEVEL%

--- a/tests/test_commercial_acceptance_runner.py
+++ b/tests/test_commercial_acceptance_runner.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = (ROOT / "tools" / "commercial_acceptance.py").read_text(encoding="utf-8")
+LAUNCHER = (ROOT / "VERIDRA_COMMERCIAL_ACCEPTANCE.bat").read_text(encoding="utf-8")
+
+
+def test_runner_uses_isolated_composed_runtime() -> None:
+    assert '"-m", "veridra.runtime"' in RUNNER
+    assert "TemporaryDirectory" in RUNNER
+    assert '"VERIDRA_IDENTITY_DB"' in RUNNER
+    assert '"VERIDRA_TENANT_DATA_ROOT"' in RUNNER
+    assert '"VERIDRA_TRUSTED_ORIGIN"' in RUNNER
+
+
+def test_runner_drives_commercial_agency_journey() -> None:
+    assert 'page.goto(f"{base_url}/onboarding"' in RUNNER
+    assert 'page.wait_for_url(f"{base_url}/agency")' in RUNNER
+    assert '"Create client project"' in RUNNER
+    assert '"Prepare branded report"' in RUNNER
+    assert '"Enable monitoring"' in RUNNER
+    assert '"standard"' in RUNNER
+
+
+def test_runner_captures_reviewable_evidence() -> None:
+    assert "page.screenshot" in RUNNER
+    assert "page.content()" in RUNNER
+    assert '"console_errors"' in RUNNER
+    assert '"request_failures"' in RUNNER
+    assert '"commercial-acceptance.json"' in RUNNER
+    assert "shutil.make_archive" in RUNNER
+
+
+def test_real_target_mode_is_explicit_and_optional() -> None:
+    assert 'parser.add_argument(' in RUNNER
+    assert '"--target"' in RUNNER
+    assert '"mode": "real-target" if target else "isolated-demo"' in RUNNER
+
+
+def test_windows_launcher_requires_existing_setup() -> None:
+    assert '.venv\\Scripts\\python.exe' in LAUNCHER
+    assert "VERIDRA_SETUP.bat" in LAUNCHER
+    assert "tools\\commercial_acceptance.py %*" in LAUNCHER

--- a/tools/commercial_acceptance.py
+++ b/tools/commercial_acceptance.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.parse import quote
+from urllib.request import urlopen
+
+from playwright.sync_api import Page, sync_playwright
+
+OUTPUT_ROOT = Path("artifacts/commercial-acceptance")
+PASSWORD = "veridra-commercial-acceptance"
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_ready(base_url: str, timeout: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(f"{base_url}/health", timeout=1) as response:
+                if response.status == 200:
+                    return
+        except OSError:
+            time.sleep(0.25)
+    raise RuntimeError("Veridra composed runtime did not become ready.")
+
+
+def _capture(page: Page, output: Path, name: str) -> dict[str, object]:
+    screenshot = output / f"{name}.png"
+    html_file = output / f"{name}.html"
+    page.screenshot(path=screenshot, full_page=True)
+    html_file.write_text(page.content(), encoding="utf-8")
+    return {
+        "name": name,
+        "url": page.url,
+        "title": page.title(),
+        "screenshot": screenshot.name,
+        "html": html_file.name,
+        "main_text": page.locator("main").inner_text() if page.locator("main").count() else "",
+    }
+
+
+def _onboard(page: Page, base_url: str) -> None:
+    page.goto(f"{base_url}/onboarding", wait_until="networkidle")
+    page.get_by_label("Agency or organisation name").fill("Webify Acceptance")
+    page.get_by_label("Workspace slug").fill("webify-acceptance")
+    page.get_by_label("Your name").fill("Acceptance Operator")
+    page.get_by_label("Email").fill("acceptance@example.com")
+    page.get_by_label("Password", exact=True).fill(PASSWORD)
+    page.get_by_label("Repeat password").fill(PASSWORD)
+    page.get_by_role("button", name="Create agency workspace").click()
+    page.wait_for_url(f"{base_url}/agency")
+
+
+def _create_demo_project(page: Page, base_url: str) -> None:
+    page.goto(
+        f"{base_url}/agency/convert?demo=true&url={quote('https://example.com/', safe='')}",
+        wait_until="networkidle",
+    )
+    page.get_by_label("Project name").fill("Commercial Acceptance Demo")
+    page.get_by_label("Client label").fill("Demo SMB")
+    page.get_by_label("Project crawl profile").select_option("standard")
+    page.get_by_role("button", name="Create client project").click()
+    page.wait_for_url("**/agency/projects/**")
+
+
+def _run_real_quick_audit(page: Page, base_url: str, target: str) -> None:
+    page.goto(f"{base_url}/agency", wait_until="networkidle")
+    page.get_by_label("Public website").fill(target)
+    page.get_by_role("button", name="Start quick audit").click()
+    page.wait_for_url("**/agency/audit?**", timeout=90_000)
+    page.wait_for_load_state("networkidle", timeout=90_000)
+
+
+def run(target: str | None = None) -> Path:
+    OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+    run_dir = OUTPUT_ROOT / time.strftime("%Y%m%d_%H%M%S")
+    run_dir.mkdir(parents=True, exist_ok=False)
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    events: dict[str, list[str]] = {"console_errors": [], "request_failures": []}
+    report: dict[str, object] = {
+        "passed": False,
+        "mode": "real-target" if target else "isolated-demo",
+        "target": target,
+        "base_url": base_url,
+        "steps": [],
+        "events": events,
+    }
+
+    with tempfile.TemporaryDirectory(prefix="veridra-commercial-") as temporary:
+        state = Path(temporary)
+        env = os.environ.copy()
+        env.update(
+            {
+                "VERIDRA_ENV": "development",
+                "VERIDRA_BIND_HOST": "127.0.0.1",
+                "VERIDRA_BIND_PORT": str(port),
+                "VERIDRA_ALLOWED_HOSTS": "127.0.0.1,localhost",
+                "VERIDRA_TRUSTED_ORIGIN": base_url,
+                "VERIDRA_IDENTITY_DB": str((state / "identity" / "veridra.sqlite3").resolve()),
+                "VERIDRA_TENANT_DATA_ROOT": str((state / "tenants").resolve()),
+            }
+        )
+        stdout_path = run_dir / "runtime.stdout.log"
+        stderr_path = run_dir / "runtime.stderr.log"
+        with stdout_path.open("w", encoding="utf-8") as stdout, stderr_path.open(
+            "w", encoding="utf-8"
+        ) as stderr:
+            process = subprocess.Popen(
+                [sys.executable, "-m", "veridra.runtime"],
+                env=env,
+                stdout=stdout,
+                stderr=stderr,
+            )
+            try:
+                _wait_ready(base_url)
+                with sync_playwright() as playwright:
+                    browser = playwright.chromium.launch()
+                    page = browser.new_page(viewport={"width": 1440, "height": 1000})
+                    page.on(
+                        "console",
+                        lambda message: events["console_errors"].append(message.text)
+                        if message.type == "error"
+                        else None,
+                    )
+                    page.on(
+                        "requestfailed",
+                        lambda request: events["request_failures"].append(
+                            f"{request.method} {request.url}: {request.failure}"
+                        ),
+                    )
+                    _onboard(page, base_url)
+                    report["steps"].append(_capture(page, run_dir, "01-agency-home"))
+
+                    if target:
+                        _run_real_quick_audit(page, base_url, target)
+                        report["steps"].append(_capture(page, run_dir, "02-real-quick-audit"))
+                    else:
+                        _create_demo_project(page, base_url)
+                        report["steps"].append(_capture(page, run_dir, "02-project-overview"))
+                        page.get_by_role("link", name="Prepare branded report").click()
+                        page.wait_for_load_state("networkidle")
+                        report["steps"].append(_capture(page, run_dir, "03-report-hub"))
+                        page.go_back(wait_until="networkidle")
+                        page.get_by_role("link", name="Enable monitoring").click()
+                        page.wait_for_load_state("networkidle")
+                        report["steps"].append(_capture(page, run_dir, "04-monitoring"))
+                    browser.close()
+                report["passed"] = not events["request_failures"]
+            except Exception as exc:
+                report["error"] = str(exc)
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+
+    report_path = run_dir / "commercial-acceptance.json"
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+    archive = shutil.make_archive(str(run_dir), "zip", root_dir=run_dir)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    print(f"Evidence bundle: {archive}")
+    if not report["passed"]:
+        raise SystemExit(1)
+    return Path(archive)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run isolated Playwright acceptance against the composed Veridra runtime."
+    )
+    parser.add_argument(
+        "--target",
+        help="Optional real public website for the quick-audit path. Omit for isolated demo acceptance.",
+    )
+    args = parser.parse_args()
+    run(args.target)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/commercial_acceptance.py
+++ b/tools/commercial_acceptance.py
@@ -185,7 +185,10 @@ def main() -> None:
     )
     parser.add_argument(
         "--target",
-        help="Optional real public website for the quick-audit path. Omit for isolated demo acceptance.",
+        help=(
+            "Optional real public website for the quick-audit path. "
+            "Omit for isolated demo acceptance."
+        ),
     )
     args = parser.parse_args()
     run(args.target)


### PR DESCRIPTION
Commercial-alignment slice for validating the real Veridra operator journey before further feature work.

Adds:
- `tools/commercial_acceptance.py`, which launches the composed runtime against an isolated temporary identity DB and tenant root;
- first-owner onboarding through Playwright;
- safe demo-backed client-project creation using the Standard crawl profile;
- project overview, report-hub and monitoring navigation;
- screenshots, HTML snapshots, runtime stdout/stderr, browser console errors, failed requests and a JSON result;
- a ZIP evidence bundle under `artifacts/commercial-acceptance`;
- optional `--target` mode for a later real public SMB quick audit;
- `VERIDRA_COMMERCIAL_ACCEPTANCE.bat` for one-command Windows execution;
- deterministic contract tests.

This is an acceptance/evidence tool, not a new SaaS feature. It intentionally uses isolated demo mode by default so no real prospect or persistent local tenant data is touched during baseline validation.

Do not merge unless exact-head CI passes.