### PR TITLE
Harden commercial crawl evidence before prospect audits

### DIFF
--- a/src/veridra/crawl.py
+++ b/src/veridra/crawl.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
-from collections import defaultdict, deque
+from collections import Counter, defaultdict, deque
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import StrEnum
 from html.parser import HTMLParser
+from time import perf_counter
 from urllib.parse import urljoin, urlparse, urlunparse
 from xml.etree import ElementTree
 
 from .collector import CollectionError, PageEvidence, collect_page
 from .core import Finding, Status, UnsafeTargetError
+from .robots import robots_allows_url
 
 
 @dataclass(frozen=True)
@@ -26,6 +29,7 @@ class CrawlLimits:
 class CrawledPage:
     evidence: PageEvidence
     depth: int
+    fetch_mode: str = "STATIC_STANDARD"
 
 
 @dataclass(frozen=True)
@@ -34,6 +38,50 @@ class BrokenInternalLink:
     source_urls: tuple[str, ...]
     status_code: int | None
     collection_failed: bool
+
+
+class FetchMode(StrEnum):
+    static_standard = "STATIC_STANDARD"
+    blocked = "BLOCKED"
+    failed = "FAILED"
+
+
+@dataclass(frozen=True)
+class CrawlAttempt:
+    requested_url: str
+    final_url: str | None
+    depth: int
+    fetch_mode: FetchMode
+    status_code: int | None = None
+    response_bytes: int = 0
+    included_html: bool = False
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class CrawlSummary:
+    attempted_pages: int = 0
+    successful_pages: int = 0
+    blocked_pages: int = 0
+    failed_pages: int = 0
+    skipped_pages: int = 0
+    total_downloaded_bytes: int = 0
+    status_counts: dict[int, int] = field(default_factory=dict)
+    fetch_mode_counts: dict[str, int] = field(default_factory=dict)
+    duration_seconds: float = 0.0
+
+    def evidence(self) -> dict[str, object]:
+        return {
+            "attempted_pages": self.attempted_pages,
+            "successful_pages": self.successful_pages,
+            "blocked_pages": self.blocked_pages,
+            "failed_pages": self.failed_pages,
+            "skipped_pages": self.skipped_pages,
+            "total_downloaded_bytes": self.total_downloaded_bytes,
+            "status_counts": self.status_counts,
+            "fetch_mode_counts": self.fetch_mode_counts,
+            "duration_seconds": self.duration_seconds,
+        }
 
 
 @dataclass(frozen=True)
@@ -45,6 +93,10 @@ class CrawlResult:
     sitemap_urls: tuple[str, ...] = ()
     sitemap_failures: tuple[str, ...] = ()
     broken_internal_links: tuple[BrokenInternalLink, ...] = ()
+    attempts: tuple[CrawlAttempt, ...] = ()
+    blocked_urls: tuple[str, ...] = ()
+    failed_urls: tuple[str, ...] = ()
+    summary: CrawlSummary = field(default_factory=CrawlSummary)
 
 
 PageCollector = Callable[..., PageEvidence]
@@ -121,7 +173,8 @@ def _xml_locations(body: str) -> tuple[str, list[str]]:
     locations = [
         (element.text or "").strip()
         for element in root.iter()
-        if element.tag.rsplit("}", 1)[-1].lower() == "loc" and (element.text or "").strip()
+        if element.tag.rsplit("}", 1)[-1].lower() == "loc"
+        and (element.text or "").strip()
     ]
     return kind, locations
 
@@ -173,6 +226,48 @@ def _discover_sitemap_urls(
     return discovered, sorted(failures)
 
 
+def _blocked_status(status_code: int) -> bool:
+    return status_code in {401, 403, 429}
+
+
+def _build_summary(
+    attempts: list[CrawlAttempt],
+    duration_seconds: float,
+) -> CrawlSummary:
+    status_counts = Counter(
+        attempt.status_code
+        for attempt in attempts
+        if attempt.status_code is not None
+    )
+    mode_counts = Counter(attempt.fetch_mode.value for attempt in attempts)
+    return CrawlSummary(
+        attempted_pages=len(attempts),
+        successful_pages=sum(
+            1
+            for attempt in attempts
+            if attempt.included_html
+            and attempt.status_code is not None
+            and 200 <= attempt.status_code < 400
+        ),
+        blocked_pages=sum(
+            1 for attempt in attempts if attempt.fetch_mode is FetchMode.blocked
+        ),
+        failed_pages=sum(
+            1 for attempt in attempts if attempt.fetch_mode is FetchMode.failed
+        ),
+        skipped_pages=sum(
+            1
+            for attempt in attempts
+            if attempt.fetch_mode is FetchMode.static_standard
+            and not attempt.included_html
+        ),
+        total_downloaded_bytes=sum(attempt.response_bytes for attempt in attempts),
+        status_counts=dict(sorted(status_counts.items())),
+        fetch_mode_counts=dict(sorted(mode_counts.items())),
+        duration_seconds=round(max(0.0, duration_seconds), 3),
+    )
+
+
 def crawl_site(
     start_url: str,
     *,
@@ -180,6 +275,7 @@ def crawl_site(
     collector: PageCollector = collect_page,
     robots_text: str = "",
 ) -> CrawlResult:
+    started = perf_counter()
     active_limits = limits or CrawlLimits()
     if (
         active_limits.max_pages < 1
@@ -200,6 +296,9 @@ def crawl_site(
     seen: set[str] = set()
     pages: list[CrawledPage] = []
     skipped: set[str] = set()
+    blocked_urls: set[str] = set()
+    failed_urls: set[str] = set()
+    attempts: list[CrawlAttempt] = []
     total_bytes = 0
     byte_limit = False
     link_sources: defaultdict[str, set[str]] = defaultdict(set)
@@ -211,32 +310,101 @@ def crawl_site(
         if normalized is None or normalized in seen:
             continue
         seen.add(normalized)
+
+        if not robots_allows_url(robots_text, "Veridra", normalized):
+            blocked_urls.add(normalized)
+            attempts.append(
+                CrawlAttempt(
+                    requested_url=normalized,
+                    final_url=None,
+                    depth=depth,
+                    fetch_mode=FetchMode.blocked,
+                    reason="robots.txt disallows this URL for the Veridra crawler",
+                )
+            )
+            continue
+
         try:
             page = collector(
                 normalized,
                 timeout=active_limits.timeout,
                 max_bytes=active_limits.per_page_bytes,
             )
-        except (CollectionError, UnsafeTargetError):
-            skipped.add(normalized)
-            if normalized in link_sources:
-                broken[normalized] = BrokenInternalLink(
-                    normalized,
-                    tuple(sorted(link_sources[normalized])),
-                    None,
-                    True,
+        except (CollectionError, UnsafeTargetError) as exc:
+            failed_urls.add(normalized)
+            attempts.append(
+                CrawlAttempt(
+                    requested_url=normalized,
+                    final_url=None,
+                    depth=depth,
+                    fetch_mode=FetchMode.failed,
+                    reason=str(exc),
                 )
+            )
             continue
+
+        body_bytes = len(page.body.encode("utf-8"))
+        if _blocked_status(page.status_code):
+            blocked_urls.add(page.final_url)
+            attempts.append(
+                CrawlAttempt(
+                    requested_url=normalized,
+                    final_url=page.final_url,
+                    depth=depth,
+                    fetch_mode=FetchMode.blocked,
+                    status_code=page.status_code,
+                    response_bytes=body_bytes,
+                    reason=f"HTTP {page.status_code} prevented normal assessment retrieval",
+                )
+            )
+            continue
+
         content_type = page.headers.get("content-type", "").lower()
         if "text/html" not in content_type:
             skipped.add(page.final_url)
+            attempts.append(
+                CrawlAttempt(
+                    requested_url=normalized,
+                    final_url=page.final_url,
+                    depth=depth,
+                    fetch_mode=FetchMode.static_standard,
+                    status_code=page.status_code,
+                    response_bytes=body_bytes,
+                    reason="non-HTML response",
+                )
+            )
             continue
-        body_bytes = len(page.body.encode("utf-8"))
+
         if total_bytes + body_bytes > active_limits.max_total_bytes:
             byte_limit = True
+            skipped.add(page.final_url)
+            attempts.append(
+                CrawlAttempt(
+                    requested_url=normalized,
+                    final_url=page.final_url,
+                    depth=depth,
+                    fetch_mode=FetchMode.static_standard,
+                    status_code=page.status_code,
+                    response_bytes=body_bytes,
+                    reason="crawl total-byte limit reached before including this page",
+                )
+            )
             break
+
         total_bytes += body_bytes
-        pages.append(CrawledPage(page, depth))
+        attempts.append(
+            CrawlAttempt(
+                requested_url=normalized,
+                final_url=page.final_url,
+                depth=depth,
+                fetch_mode=FetchMode.static_standard,
+                status_code=page.status_code,
+                response_bytes=body_bytes,
+                included_html=True,
+            )
+        )
+        pages.append(CrawledPage(page, depth, FetchMode.static_standard.value))
+
         if page.status_code >= 400 and normalized in link_sources:
             broken[normalized] = BrokenInternalLink(
                 normalized,
@@ -255,6 +423,7 @@ def crawl_site(
                 if candidate not in seen:
                     queue.append((candidate, depth + 1))
 
+    summary = _build_summary(attempts, perf_counter() - started)
     return CrawlResult(
         pages=tuple(pages),
         skipped_urls=tuple(sorted(skipped)),
@@ -263,6 +432,10 @@ def crawl_site(
         sitemap_urls=tuple(sitemap_urls),
         sitemap_failures=tuple(sitemap_failures),
         broken_internal_links=tuple(broken[url] for url in sorted(broken)),
+        attempts=tuple(attempts),
+        blocked_urls=tuple(sorted(blocked_urls)),
+        failed_urls=tuple(sorted(failed_urls)),
+        summary=summary,
     )
 
 
@@ -297,17 +470,25 @@ def analyze_crawl(result: CrawlResult) -> list[Finding]:
     common_evidence = {
         "crawled_pages": len(result.pages),
         "skipped_urls": list(result.skipped_urls),
+        "blocked_urls": list(result.blocked_urls),
+        "failed_urls": list(result.failed_urls),
         "page_limit_reached": result.exhausted_page_limit,
         "byte_limit_reached": result.exhausted_byte_limit,
         "sitemap_urls": list(result.sitemap_urls),
         "sitemap_failures": list(result.sitemap_failures),
+        "crawl_summary": result.summary.evidence(),
+        "fetch_mode": FetchMode.static_standard.value,
     }
     for identifier, (title, severity, affected) in checks.items():
         passed = not affected
         findings.append(
             Finding(
                 id=identifier,
-                area="Website health" if identifier in website_health_ids else "Search visibility",
+                area=(
+                    "Website health"
+                    if identifier in website_health_ids
+                    else "Search visibility"
+                ),
                 title=f"Multi-page {title.lower()}",
                 status=Status.passed if passed else Status.attention,
                 severity="info" if passed else severity,
@@ -339,7 +520,7 @@ def analyze_crawl(result: CrawlResult) -> list[Finding]:
             summary=(
                 "No broken internal links were observed in the bounded crawl."
                 if not broken
-                else f"{len(broken)} internal link targets failed or returned an error response."
+                else f"{len(broken)} internal link targets returned an error response."
             ),
             recommendation=(
                 None
@@ -361,6 +542,43 @@ def analyze_crawl(result: CrawlResult) -> list[Finding]:
                 ],
                 **common_evidence,
             },
+        )
+    )
+
+    incomplete = bool(
+        result.blocked_urls
+        or result.failed_urls
+        or result.exhausted_page_limit
+        or result.exhausted_byte_limit
+    )
+    findings.append(
+        Finding(
+            id="crawl.retrieval-coverage",
+            area="Website health",
+            title="Crawl retrieval coverage",
+            status=Status.unavailable if incomplete else Status.passed,
+            severity="info",
+            summary=(
+                (
+                    f"{len(result.pages)} HTML pages were analyzed, with "
+                    f"{len(result.blocked_urls)} blocked and "
+                    f"{len(result.failed_urls)} failed retrievals."
+                )
+                if incomplete
+                else (
+                    f"All {result.summary.attempted_pages} attempted crawl URLs were "
+                    "retrieved within the configured assessment boundaries."
+                )
+            ),
+            recommendation=(
+                (
+                    "Review blocked, failed or limit-truncated URLs before treating the "
+                    "absence of findings as proof that those pages are healthy."
+                )
+                if incomplete
+                else None
+            ),
+            evidence=common_evidence,
         )
     )
     return findings

--- a/src/veridra/robots.py
+++ b/src/veridra/robots.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
-from urllib.robotparser import RobotFileParser
+from urllib.parse import urlsplit
 
 
 @dataclass(frozen=True)
@@ -12,8 +13,7 @@ class RobotsPolicy:
     matched_group: bool
 
 
-def evaluate_robots_policy(robots_text: str, user_agent: str) -> RobotsPolicy:
-    target = user_agent.strip().lower()
+def _groups(robots_text: str) -> list[tuple[list[str], list[tuple[str, str]]]]:
     groups: list[tuple[list[str], list[tuple[str, str]]]] = []
     agents: list[str] = []
     directives: list[tuple[str, str]] = []
@@ -31,20 +31,31 @@ def evaluate_robots_policy(robots_text: str, user_agent: str) -> RobotsPolicy:
             continue
         key, value = (part.strip() for part in line.split(":", 1))
         key_lower = key.lower()
-        value_lower = value.lower()
         if key_lower == "user-agent":
             if directives:
                 flush()
-            agents.append(value_lower)
+            agents.append(value.lower())
         elif agents and key_lower in {"allow", "disallow"}:
             directives.append((key_lower, value))
-
     flush()
+    return groups
 
-    matching = [group for group in groups if target in group[0]]
-    if not matching:
-        matching = [group for group in groups if "*" in group[0]]
-    if not matching:
+
+def _matching_directives(
+    robots_text: str,
+    user_agent: str,
+) -> tuple[list[tuple[str, str]], bool]:
+    target = user_agent.strip().lower()
+    groups = _groups(robots_text)
+    specific = [group for group in groups if target in group[0]]
+    matching = specific or [group for group in groups if "*" in group[0]]
+    return [item for _, rules in matching for item in rules], bool(matching)
+
+
+def evaluate_robots_policy(robots_text: str, user_agent: str) -> RobotsPolicy:
+    target = user_agent.strip().lower()
+    directives, matched_group = _matching_directives(robots_text, target)
+    if not matched_group:
         return RobotsPolicy(
             user_agent=target,
             disallow_all=False,
@@ -52,10 +63,9 @@ def evaluate_robots_policy(robots_text: str, user_agent: str) -> RobotsPolicy:
             matched_group=False,
         )
 
-    group_directives = [item for _, rules in matching for item in rules]
     disallow_all = any(
         key == "disallow" and value.strip() == "/"
-        for key, value in group_directives
+        for key, value in directives
     )
     allow_all = not disallow_all
     return RobotsPolicy(
@@ -66,11 +76,42 @@ def evaluate_robots_policy(robots_text: str, user_agent: str) -> RobotsPolicy:
     )
 
 
+def _rule_matches(path: str, rule: str) -> bool:
+    anchored = rule.endswith("$")
+    pattern = rule[:-1] if anchored else rule
+    escaped = re.escape(pattern).replace(r"\*", ".*")
+    suffix = "$" if anchored else ""
+    return re.match(f"^{escaped}{suffix}", path) is not None
+
+
 def robots_allows_url(robots_text: str, user_agent: str, url: str) -> bool:
-    """Return whether the configured crawler may fetch a URL under robots.txt."""
+    """Apply deterministic longest-match robots rules to one public URL."""
 
     if not robots_text.strip():
         return True
-    parser = RobotFileParser()
-    parser.parse(robots_text.splitlines())
-    return parser.can_fetch(user_agent, url)
+    directives, matched_group = _matching_directives(robots_text, user_agent)
+    if not matched_group:
+        return True
+
+    parsed = urlsplit(url)
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+
+    matches: list[tuple[int, bool]] = []
+    for key, raw_rule in directives:
+        rule = raw_rule.strip()
+        if not rule:
+            continue
+        if _rule_matches(path, rule):
+            specificity = len(rule.rstrip("$").replace("*", ""))
+            matches.append((specificity, key == "allow"))
+    if not matches:
+        return True
+
+    best_specificity = max(specificity for specificity, _ in matches)
+    return any(
+        allowed
+        for specificity, allowed in matches
+        if specificity == best_specificity
+    )

--- a/src/veridra/robots.py
+++ b/src/veridra/robots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from urllib.robotparser import RobotFileParser
 
 
 @dataclass(frozen=True)
@@ -63,3 +64,13 @@ def evaluate_robots_policy(robots_text: str, user_agent: str) -> RobotsPolicy:
         allow_all=allow_all,
         matched_group=True,
     )
+
+
+def robots_allows_url(robots_text: str, user_agent: str, url: str) -> bool:
+    """Return whether the configured crawler may fetch a URL under robots.txt."""
+
+    if not robots_text.strip():
+        return True
+    parser = RobotFileParser()
+    parser.parse(robots_text.splitlines())
+    return parser.can_fetch(user_agent, url)

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 from veridra.collector import CollectionError, PageEvidence
 from veridra.core import Status
-from veridra.crawl import CrawlLimits, analyze_crawl, crawl_site
+from veridra.crawl import CrawlLimits, FetchMode, analyze_crawl, crawl_site
 
 
 def _page(
@@ -64,13 +64,15 @@ def test_crawl_is_same_origin_sequential_and_bounded() -> None:
     assert calls == ["https://example.com/", "https://example.com/about"]
     assert [page.evidence.final_url for page in result.pages] == calls
     assert result.exhausted_page_limit is False
+    assert result.summary.attempted_pages == 2
+    assert result.summary.successful_pages == 2
+    assert result.summary.fetch_mode_counts == {FetchMode.static_standard.value: 2}
 
 
 def test_crawl_reports_page_limit() -> None:
     pages = {
         "https://example.com/": _page(
-            "https://example.com/",
-            "<a href='/one'>One</a><a href='/two'>Two</a>",
+            "https://example.com/", "<a href='/one'>One</a><a href='/two'>Two</a>"
         ),
         "https://example.com/one": _page("https://example.com/one", "<p>One</p>"),
     }
@@ -92,6 +94,8 @@ def test_crawl_respects_total_byte_limit() -> None:
     )
     assert result.pages == ()
     assert result.exhausted_byte_limit is True
+    assert result.summary.attempted_pages == 1
+    assert result.summary.total_downloaded_bytes == 20
 
 
 def test_aggregate_findings_include_affected_urls() -> None:
@@ -121,6 +125,8 @@ def test_aggregate_findings_include_affected_urls() -> None:
     ]
     assert findings["crawl.mixed-content"].status == Status.attention
     assert findings["crawl.http-status"].status == Status.passed
+    assert findings["crawl.title"].evidence["fetch_mode"] == "STATIC_STANDARD"
+    assert findings["crawl.title"].evidence["crawl_summary"]["successful_pages"] == 2
 
 
 def test_non_html_pages_are_skipped_and_not_marked_broken() -> None:
@@ -142,6 +148,7 @@ def test_non_html_pages_are_skipped_and_not_marked_broken() -> None:
     assert len(result.pages) == 1
     assert result.skipped_urls == ("https://example.com/file.pdf",)
     assert result.broken_internal_links == ()
+    assert result.summary.skipped_pages == 1
 
 
 def test_sitemap_index_and_urlset_add_same_origin_pages() -> None:
@@ -186,7 +193,7 @@ def test_sitemap_index_and_urlset_add_same_origin_pages() -> None:
     assert "https://external.example/out.xml" not in calls
 
 
-def test_broken_internal_links_include_bounded_source_pages() -> None:
+def test_broken_internal_links_exclude_failed_retrievals() -> None:
     pages = {
         "https://example.com/": _page(
             "https://example.com/",
@@ -207,18 +214,75 @@ def test_broken_internal_links_include_bounded_source_pages() -> None:
     assert broken.status == Status.attention
     assert broken.evidence["broken_targets"] == [
         {
-            "target_url": "https://example.com/failed",
-            "source_urls": ["https://example.com/"],
-            "status_code": None,
-            "collection_failed": True,
-        },
-        {
             "target_url": "https://example.com/missing",
             "source_urls": ["https://example.com/"],
             "status_code": 404,
             "collection_failed": False,
-        },
+        }
     ]
+    assert result.failed_urls == ("https://example.com/failed",)
+    assert result.summary.failed_pages == 1
+
+
+def test_blocked_http_response_is_not_analyzed_as_page_quality_failure() -> None:
+    complete = (
+        "<html><head><title>Home</title><meta name='description' content='Good'>"
+        "<link rel='canonical' href='https://example.com/'></head>"
+        "<body><h1>Home</h1><a href='/blocked'>Blocked</a></body></html>"
+    )
+    pages = {
+        "https://example.com/": _page("https://example.com/", complete),
+        "https://example.com/blocked": _page(
+            "https://example.com/blocked",
+            "Access denied",
+            status_code=403,
+        ),
+    }
+    result = crawl_site(
+        "https://example.com/",
+        limits=CrawlLimits(max_pages=3, max_depth=1, max_sitemaps=0),
+        collector=_collector(pages, []),
+    )
+    findings = {finding.id: finding for finding in analyze_crawl(result)}
+
+    assert len(result.pages) == 1
+    assert result.blocked_urls == ("https://example.com/blocked",)
+    assert result.summary.blocked_pages == 1
+    assert result.summary.status_counts[403] == 1
+    assert findings["crawl.title"].status == Status.passed
+    assert findings["crawl.h1"].status == Status.passed
+    assert findings["crawl.retrieval-coverage"].status == Status.unavailable
+
+
+def test_robots_disallowed_page_is_recorded_without_fetching_it() -> None:
+    pages = {
+        "https://example.com/": _page(
+            "https://example.com/",
+            "<a href='/public'>Public</a><a href='/private/secret'>Private</a>",
+        ),
+        "https://example.com/public": _page(
+            "https://example.com/public", "<h1>Public</h1>"
+        ),
+    }
+    calls: list[str] = []
+    result = crawl_site(
+        "https://example.com/",
+        limits=CrawlLimits(max_pages=5, max_depth=1, max_sitemaps=0),
+        collector=_collector(pages, calls),
+        robots_text="User-agent: *\nDisallow: /private/\n",
+    )
+
+    assert calls == ["https://example.com/", "https://example.com/public"]
+    assert result.blocked_urls == ("https://example.com/private/secret",)
+    assert result.summary.blocked_pages == 1
+    blocked = [
+        attempt
+        for attempt in result.attempts
+        if attempt.fetch_mode is FetchMode.blocked
+    ]
+    assert len(blocked) == 1
+    assert blocked[0].status_code is None
+    assert "robots.txt" in (blocked[0].reason or "")
 
 
 def test_invalid_sitemap_is_recorded_without_crashing() -> None:

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -1,4 +1,4 @@
-from veridra.robots import evaluate_robots_policy
+from veridra.robots import evaluate_robots_policy, robots_allows_url
 
 
 def test_specific_group_takes_precedence_over_wildcard() -> None:
@@ -30,3 +30,22 @@ def test_missing_group_defaults_to_allowed() -> None:
     policy = evaluate_robots_policy("", "Google-Extended")
     assert policy.matched_group is False
     assert policy.allow_all is True
+
+
+def test_path_level_robots_policy_blocks_disallowed_url() -> None:
+    robots = "User-agent: *\nDisallow: /private/\nAllow: /private/public/\n"
+
+    assert robots_allows_url(
+        robots,
+        "Veridra",
+        "https://example.com/private/secret",
+    ) is False
+    assert robots_allows_url(
+        robots,
+        "Veridra",
+        "https://example.com/private/public/info",
+    ) is True
+
+
+def test_empty_robots_policy_allows_crawl() -> None:
+    assert robots_allows_url("", "Veridra", "https://example.com/page") is True


### PR DESCRIPTION
Commercial-readiness slice derived from the crawl implementation handoff and current `main` gap analysis.

This intentionally does **not** add Scrapy, Scrapling, browser-profile impersonation, JS rendering, or larger crawl tiers.

What was already present and is preserved:
- bounded same-origin multi-page crawling;
- sitemap discovery;
- SSRF/private-network protection and redirect revalidation;
- page/depth/byte/time limits;
- affected-URL aggregation;
- broken-link source provenance;
- duplicate metadata, accessibility, page-quality and passive-security findings.

This PR closes the commercially material evidence gaps found before the first real LEADS prospect:
- path-level robots.txt enforcement for the Veridra crawler;
- explicit STATIC_STANDARD / BLOCKED / FAILED retrieval provenance;
- blocked HTTP responses (401/403/429) no longer enter page-quality analyzers and create false missing-title/H1/meta findings;
- collection failures are reported as failed retrievals rather than asserted as broken links;
- crawl summary exposes attempted/successful/blocked/failed/skipped counts, status counts, downloaded bytes, fetch-mode counts and duration;
- crawl findings expose blocked/failed URLs and coverage evidence;
- an explicit retrieval-coverage finding warns operators when scan coverage is incomplete;
- regression tests cover robots allow/disallow precedence, HTTP 403 boundaries and failed-link handling.

Do not merge unless exact-head CI, browser audit and commercial Playwright acceptance all pass.