### PR TITLE
Complete white-label PDF identity

### DIFF
--- a/src/veridra/pdf_reports.py
+++ b/src/veridra/pdf_reports.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from html import escape, unescape
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
@@ -10,6 +11,8 @@ from playwright.sync_api import sync_playwright
 _MAX_HTML_BYTES = 5_000_000
 _MAX_PDF_BYTES = 20_000_000
 _RENDER_TIMEOUT_MS = 20_000
+_TITLE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_REPORT_TITLE_SUFFIX = " assessment report"
 
 
 class PdfRenderError(RuntimeError):
@@ -22,16 +25,31 @@ class PdfDocument:
     filename: str
 
 
-def safe_pdf_filename(target: str) -> str:
-    cleaned = re.sub(r"[^a-zA-Z0-9._-]+", "-", target).strip("-.")
-    stem = cleaned[:120] or "website"
-    return f"veridra-{stem}-assessment.pdf"
+def report_brand_from_html(report_html: str) -> str:
+    match = _TITLE.search(report_html)
+    if match is None:
+        return "Veridra"
+    title = unescape(re.sub(r"\s+", " ", match.group(1))).strip()
+    if title.lower().endswith(_REPORT_TITLE_SUFFIX):
+        title = title[: -len(_REPORT_TITLE_SUFFIX)].strip()
+    return title[:120] or "Veridra"
+
+
+def safe_pdf_filename(target: str, *, brand: str = "Veridra") -> str:
+    cleaned_brand = re.sub(r"[^a-zA-Z0-9._-]+", "-", brand).strip("-.")
+    cleaned_target = re.sub(r"[^a-zA-Z0-9._-]+", "-", target).strip("-.")
+    prefix = cleaned_brand[:60] or "report"
+    target_stem = cleaned_target[:60] or "website"
+    return f"{prefix}-{target_stem}-assessment.pdf"
 
 
 def render_pdf(html: str, *, target: str) -> PdfDocument:
     encoded = html.encode("utf-8")
     if len(encoded) > _MAX_HTML_BYTES:
         raise PdfRenderError("Report HTML exceeded the bounded PDF input size.")
+
+    brand = report_brand_from_html(html)
+    footer_brand = escape(brand)
 
     try:
         with sync_playwright() as playwright:
@@ -57,7 +75,7 @@ def render_pdf(html: str, *, target: str) -> PdfDocument:
                     footer_template=(
                         "<div style='font-size:8px;width:100%;padding:0 12mm;"
                         "color:#667085;display:flex;justify-content:space-between'>"
-                        "<span>Veridra website assessment</span>"
+                        f"<span>{footer_brand} website assessment</span>"
                         "<span><span class='pageNumber'></span> / "
                         "<span class='totalPages'></span></span></div>"
                     ),
@@ -72,4 +90,7 @@ def render_pdf(html: str, *, target: str) -> PdfDocument:
         raise PdfRenderError("The PDF renderer returned an invalid document.")
     if len(content) > _MAX_PDF_BYTES:
         raise PdfRenderError("Generated PDF exceeded the bounded output size.")
-    return PdfDocument(content=content, filename=safe_pdf_filename(target))
+    return PdfDocument(
+        content=content,
+        filename=safe_pdf_filename(target, brand=brand),
+    )

--- a/tests/test_pdf_reports.py
+++ b/tests/test_pdf_reports.py
@@ -4,7 +4,13 @@ import fastapi.testclient
 import pytest
 
 import veridra.pdf_web as pdf_web
-from veridra.pdf_reports import PdfDocument, PdfRenderError, render_pdf, safe_pdf_filename
+from veridra.pdf_reports import (
+    PdfDocument,
+    PdfRenderError,
+    render_pdf,
+    report_brand_from_html,
+    safe_pdf_filename,
+)
 from veridra.runtime import app
 
 client = fastapi.testclient.TestClient(app)
@@ -18,13 +24,45 @@ def test_safe_pdf_filename_is_bounded_and_sanitized() -> None:
     assert len(filename) < 160
 
 
+def test_safe_pdf_filename_uses_white_label_brand() -> None:
+    filename = safe_pdf_filename(
+        "https://example.com",
+        brand="Agency One",
+    )
+    assert filename.startswith("Agency-One-")
+    assert "Veridra" not in filename
+
+
+def test_report_brand_comes_from_report_title() -> None:
+    assert (
+        report_brand_from_html(
+            "<!doctype html><html><head><title>Agency One assessment report</title></head></html>"
+        )
+        == "Agency One"
+    )
+
+
+def test_report_brand_decodes_and_bounds_title() -> None:
+    brand = report_brand_from_html(
+        "<html><head><title>Agency &amp; Partners assessment report</title></head></html>"
+    )
+    assert brand == "Agency & Partners"
+
+
+def test_report_brand_falls_back_for_missing_title() -> None:
+    assert report_brand_from_html("<html><body>No title</body></html>") == "Veridra"
+
+
 def test_real_chromium_pdf_smoke() -> None:
     document = render_pdf(
-        "<!doctype html><html><body><h1>Veridra PDF smoke</h1></body></html>",
+        "<!doctype html><html><head><title>Agency One assessment report</title></head>"
+        "<body><h1>Branded PDF smoke</h1></body></html>",
         target="https://example.com",
     )
     assert document.content.startswith(b"%PDF-")
     assert len(document.content) > 1_000
+    assert document.filename.startswith("Agency-One-")
+    assert "Veridra" not in document.filename
 
 
 def test_pdf_route_returns_download(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Commercial white-label reporting hardening from current `main`.

What changed:
- derive the PDF brand from the rendered report `<title>`;
- strip the standard `assessment report` suffix to recover the agency/report brand;
- use that brand in the PDF footer instead of hard-coded `Veridra`;
- use that brand in the downloaded PDF filename while retaining target provenance;
- preserve the existing Veridra fallback when a report has no usable title;
- add deterministic tests for branded filenames, entity decoding, fallback behavior and the real Chromium PDF smoke path.

Why:
A tenant report profile can already replace the visible HTML branding, but generated PDFs still leaked the Veridra name in the footer and filename. That breaks the white-label promise even though the rest of the report is branded.

Scope is intentionally bounded. This PR does not change report-profile storage, routes, assessment data, PDF network isolation, size limits or tenant authorization.

Do not merge until exact-head CI passes.