### PR TITLE
Edit saved report profiles in place

### DIFF
--- a/src/veridra/agency_report_profile_edit_web.py
+++ b/src/veridra/agency_report_profile_edit_web.py
@@ -16,6 +16,7 @@ from .identity_tenancy import (
     TenantCapability,
     require_tenant_capability,
 )
+from .project_store import ClientProject
 from .report_profiles import DEFAULT_REPORT_PROFILE, REPORT_SECTIONS, ReportProfile
 from .request_security import require_request_identity
 from .tenant_profile_store import TenantProfileStore, TenantProfileStoreError
@@ -58,7 +59,11 @@ def _require(identity: RequestIdentity) -> None:
         raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
 
 
-def _context(request: Request, identity: RequestIdentity, project_id: str) -> tuple[object, TenantProfileStore, str, ReportProfile]:
+def _context(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+) -> tuple[ClientProject, TenantProfileStore, str, ReportProfile]:
     projects = TenantProjectStore(_root(request))
     try:
         project = projects.load(identity, projects.ref(identity, project_id))

--- a/src/veridra/agency_report_profile_edit_web.py
+++ b/src/veridra/agency_report_profile_edit_web.py
@@ -138,11 +138,9 @@ async def save_project_report_profile(project_id: str, request: Request) -> Redi
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail="Report profile input is invalid.") from exc
     try:
-        replaced_id = profiles.replace(identity, profiles.ref(identity, profile_id), replacement)
+        profiles.update_in_place(identity, profiles.ref(identity, profile_id), replacement)
     except TenantProfileStoreError as exc:
         raise HTTPException(status_code=404, detail="Report profile source not found.") from exc
-    if replaced_id != profile_id:
-        raise HTTPException(status_code=500, detail="Report profile identity changed unexpectedly.")
     return RedirectResponse(
         f"/agency/projects/{project_id}/reports?{urlencode({'profile': 'updated'})}",
         status_code=303,

--- a/src/veridra/agency_report_profile_edit_web.py
+++ b/src/veridra/agency_report_profile_edit_web.py
@@ -1,0 +1,144 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .agency_navigation import agency_navigation
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .report_profiles import DEFAULT_REPORT_PROFILE, REPORT_SECTIONS, ReportProfile
+from .request_security import require_request_identity
+from .tenant_profile_store import TenantProfileStore, TenantProfileStoreError
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+
+router = APIRouter(prefix="/agency", tags=["agency-report-profile-edit"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:980px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.grid{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:100px}.checks{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}.checks label{font-weight:400;margin:0}.checks input{width:auto;margin-right:7px}.logo-state{margin:8px 0 0}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:700px){.grid,.checks{grid-template-columns:1fr}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _selected_areas(values: dict[str, list[str]]) -> tuple[str, ...]:
+    raw = _one(values, "selected_areas").replace(",", "\n")
+    return tuple(dict.fromkeys(value.strip() for value in raw.splitlines() if value.strip()))
+
+
+def _require(identity: RequestIdentity) -> None:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_reports)
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+
+
+def _context(request: Request, identity: RequestIdentity, project_id: str) -> tuple[object, TenantProfileStore, str, ReportProfile]:
+    projects = TenantProjectStore(_root(request))
+    try:
+        project = projects.load(identity, projects.ref(identity, project_id))
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Report profile source not found.") from exc
+    if project.profile_id is None:
+        raise HTTPException(status_code=404, detail="No saved report profile is applied to this project.")
+    profiles = TenantProfileStore(_root(request))
+    try:
+        profile = profiles.load(identity, profiles.ref(identity, project.profile_id))
+    except TenantProfileStoreError as exc:
+        raise HTTPException(status_code=404, detail="Report profile source not found.") from exc
+    return project, profiles, project.profile_id, profile
+
+
+def _field(value: str | None) -> str:
+    return html.escape(value or "", quote=True)
+
+
+def _textarea(value: str | None) -> str:
+    return html.escape(value or "")
+
+
+@router.get("/projects/{project_id}/reports/profile/edit", response_class=HTMLResponse)
+def edit_project_report_profile(project_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    _require(identity)
+    project, _, profile_id, profile = _context(request, identity, project_id)
+    checks = "".join(
+        f"<label><input type='checkbox' name='sections' value='{html.escape(section, quote=True)}'{' checked' if section in profile.section_order else ''}>{html.escape(section.replace('_', ' ').title())}</label>"
+        for section in REPORT_SECTIONS
+    )
+    selected_areas = "\n".join(profile.selected_areas)
+    logo_state = "An embedded logo is currently saved." if profile.logo_data_uri else "No logo is currently saved."
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Report hub</a></p><h1>Edit report profile for {html.escape(project.name)}</h1><p class='notice'><strong>Editing saved profile:</strong> {html.escape(profile_id)}. Saving replaces this profile in place and keeps the same profile and project IDs.</p><form id='report-profile-edit-form' method='post' action='/agency/projects/{html.escape(project_id, quote=True)}/reports/profile/edit'><div class='grid'><div><label for='organisation_name'>Organisation</label><input id='organisation_name' name='organisation_name' maxlength='120' value='{_field(profile.organisation_name)}' required></div><div><label for='client_name'>Client</label><input id='client_name' name='client_name' maxlength='120' value='{_field(profile.client_name)}'></div><div><label for='consultant_name'>Consultant</label><input id='consultant_name' name='consultant_name' maxlength='120' value='{_field(profile.consultant_name)}'></div><div><label for='agency_email'>Agency email</label><input id='agency_email' name='agency_email' maxlength='254' value='{_field(profile.agency_email)}'></div><div><label for='agency_phone'>Agency phone</label><input id='agency_phone' name='agency_phone' maxlength='80' value='{_field(profile.agency_phone)}'></div><div><label for='agency_website'>Agency website</label><input id='agency_website' name='agency_website' maxlength='2048' value='{_field(profile.agency_website)}'></div><div><label for='language'>Language</label><select id='language' name='language'><option value='en'{' selected' if profile.language == 'en' else ''}>English</option><option value='es'{' selected' if profile.language == 'es' else ''}>Spanish</option></select></div><div><label for='accent_colour'>Accent colour</label><input id='accent_colour' name='accent_colour' value='{_field(profile.accent_colour)}' pattern='#[0-9A-Fa-f]{{6}}' required></div></div><label for='cover_title'>Cover title</label><input id='cover_title' name='cover_title' maxlength='180' value='{_field(profile.cover_title)}'><label for='introduction'>Introduction</label><textarea id='introduction' name='introduction' maxlength='1200'>{_textarea(profile.introduction)}</textarea><label for='executive_summary'>Executive summary</label><textarea id='executive_summary' name='executive_summary' maxlength='2000'>{_textarea(profile.executive_summary)}</textarea><label for='conclusion'>Conclusion</label><textarea id='conclusion' name='conclusion' maxlength='2000'>{_textarea(profile.conclusion)}</textarea><div class='grid'><div><label for='call_to_action_label'>CTA label</label><input id='call_to_action_label' name='call_to_action_label' maxlength='80' value='{_field(profile.call_to_action_label)}'></div><div><label for='call_to_action_url'>CTA URL</label><input id='call_to_action_url' name='call_to_action_url' maxlength='2048' value='{_field(profile.call_to_action_url)}'></div></div><label for='selected_areas'>Assessment areas to include</label><textarea id='selected_areas' name='selected_areas'>{html.escape(selected_areas)}</textarea><label for='logo_file'>Replace agency logo</label><input id='logo_file' type='file' accept='image/png,image/jpeg'><input id='logo_data_uri' name='logo_data_uri' type='hidden'><p id='logo_state' class='muted logo-state'>{html.escape(logo_state)} Choose a PNG or JPEG up to 200 KB to replace it.</p><label><input id='remove_logo' type='checkbox' name='remove_logo' value='yes' style='width:auto'> Remove saved logo</label><label><input type='checkbox' name='show_raw_evidence' value='yes'{' checked' if profile.show_raw_evidence else ''} style='width:auto'> Show raw evidence</label><h3>Report sections</h3><div class='checks'>{checks}</div><p><button type='submit'>Save profile changes</button> <a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Cancel</a></p></form><script>(function(){{const input=document.getElementById('logo_file');const hidden=document.getElementById('logo_data_uri');const remove=document.getElementById('remove_logo');const state=document.getElementById('logo_state');input.addEventListener('change',function(){{hidden.value='';const file=input.files&&input.files[0];if(!file){{return;}}if(!['image/png','image/jpeg'].includes(file.type)){{input.value='';state.textContent='Logo must be PNG or JPEG.';return;}}if(file.size>200000){{input.value='';state.textContent='Logo exceeds the 200 KB limit.';return;}}const reader=new FileReader();reader.onload=function(){{hidden.value=String(reader.result||'');remove.checked=false;state.textContent='Replacement logo ready to embed.';}};reader.onerror=function(){{input.value='';hidden.value='';state.textContent='Logo could not be read.';}};reader.readAsDataURL(file);}});remove.addEventListener('change',function(){{if(remove.checked){{input.value='';hidden.value='';state.textContent='Saved logo will be removed.';}}}});}})();</script></section>"""
+    return _page("Edit report profile", body)
+
+
+@router.post("/projects/{project_id}/reports/profile/edit")
+async def save_project_report_profile(project_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    _require(identity)
+    _, profiles, profile_id, current = _context(request, identity, project_id)
+    values = _values(await request.body())
+    sections = tuple(values.get("sections", [])) or DEFAULT_REPORT_PROFILE.section_order
+    if _one(values, "remove_logo") == "yes":
+        logo_data_uri = None
+    else:
+        logo_data_uri = _one(values, "logo_data_uri") or current.logo_data_uri
+    try:
+        replacement = ReportProfile(
+            organisation_name=_one(values, "organisation_name"),
+            client_name=_one(values, "client_name") or None,
+            consultant_name=_one(values, "consultant_name") or None,
+            agency_email=_one(values, "agency_email") or None,
+            agency_phone=_one(values, "agency_phone") or None,
+            agency_website=_one(values, "agency_website") or None,
+            accent_colour=_one(values, "accent_colour"),
+            cover_title=_one(values, "cover_title") or None,
+            introduction=_one(values, "introduction") or None,
+            executive_summary=_one(values, "executive_summary") or None,
+            conclusion=_one(values, "conclusion") or None,
+            call_to_action_label=_one(values, "call_to_action_label") or None,
+            call_to_action_url=_one(values, "call_to_action_url") or None,
+            language=_one(values, "language"),
+            show_raw_evidence=_one(values, "show_raw_evidence") == "yes",
+            selected_areas=_selected_areas(values),
+            section_order=sections,
+            logo_data_uri=logo_data_uri,
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="Report profile input is invalid.") from exc
+    try:
+        replaced_id = profiles.replace(identity, profiles.ref(identity, profile_id), replacement)
+    except TenantProfileStoreError as exc:
+        raise HTTPException(status_code=404, detail="Report profile source not found.") from exc
+    if replaced_id != profile_id:
+        raise HTTPException(status_code=500, detail="Report profile identity changed unexpectedly.")
+    return RedirectResponse(
+        f"/agency/projects/{project_id}/reports?{urlencode({'profile': 'updated'})}",
+        status_code=303,
+    )

--- a/src/veridra/agency_report_web.py
+++ b/src/veridra/agency_report_web.py
@@ -113,7 +113,12 @@ def project_report_hub(
         if report_profile.call_to_action_label and report_profile.call_to_action_url
         else "Not configured"
     )
-    profile_summary = f"""<div class='profile'><div><strong>Profile</strong><br>{html.escape(profile_state)}</div><div><strong>Organisation</strong><br>{html.escape(report_profile.organisation_name)}</div><div><strong>Client</strong><br>{html.escape(report_profile.client_name or project.client_label or 'Not set')}</div><div><strong>Language</strong><br>{html.escape(report_profile.language)}</div><div><strong>Accent colour</strong><br>{html.escape(report_profile.accent_colour)}</div><div><strong>Call to action</strong><br>{html.escape(cta)}</div></div><p><strong>Enabled sections:</strong> {html.escape(section_labels)}</p><p><a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports/profile'>Create or change report profile</a></p>"""
+    edit_action = (
+        f" <a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports/profile/edit'>Edit current saved profile</a>"
+        if not is_default
+        else ""
+    )
+    profile_summary = f"""<div class='profile'><div><strong>Profile</strong><br>{html.escape(profile_state)}</div><div><strong>Organisation</strong><br>{html.escape(report_profile.organisation_name)}</div><div><strong>Client</strong><br>{html.escape(report_profile.client_name or project.client_label or 'Not set')}</div><div><strong>Language</strong><br>{html.escape(report_profile.language)}</div><div><strong>Accent colour</strong><br>{html.escape(report_profile.accent_colour)}</div><div><strong>Call to action</strong><br>{html.escape(cta)}</div></div><p><strong>Enabled sections:</strong> {html.escape(section_labels)}</p><p><a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports/profile'>Create or change report profile</a>{edit_action}</p>"""
 
     status = ""
     if delivery == "delivered":

--- a/src/veridra/profile_store.py
+++ b/src/veridra/profile_store.py
@@ -54,9 +54,8 @@ class ProfileStore:
             raise ProfileStoreError("Invalid profile identifier.")
         return self.directory / f"{entry_id}.json"
 
-    def save(self, profile: ReportProfile) -> str:
+    def _write(self, entry_id: str, profile: ReportProfile) -> None:
         self.directory.mkdir(parents=True, exist_ok=True)
-        entry_id = profile_id(profile)
         destination = self._path(entry_id)
         content = _canonical_bytes(profile)
         with NamedTemporaryFile(
@@ -71,6 +70,10 @@ class ProfileStore:
             os.fsync(temporary.fileno())
             temporary_path = Path(temporary.name)
         temporary_path.replace(destination)
+
+    def save(self, profile: ReportProfile) -> str:
+        entry_id = profile_id(profile)
+        self._write(entry_id, profile)
         return entry_id
 
     def replace(self, entry_id: str, profile: ReportProfile) -> str:
@@ -84,6 +87,13 @@ class ProfileStore:
             except FileNotFoundError as exc:
                 raise ProfileStoreError("Saved profile was not found.") from exc
         return replacement_id
+
+    def update_in_place(self, entry_id: str, profile: ReportProfile) -> str:
+        current_path = self._path(entry_id)
+        if not current_path.exists():
+            raise ProfileStoreError("Saved profile was not found.")
+        self._write(entry_id, profile)
+        return entry_id
 
     def load(self, entry_id: str) -> ReportProfile:
         path = self._path(entry_id)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -10,6 +10,7 @@ from .agency_crawl_profile_web import router as agency_crawl_profile_router
 from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
 from .agency_project_index_web import router as agency_project_index_router
+from .agency_report_profile_edit_web import router as agency_report_profile_edit_router
 from .agency_report_profile_web import router as agency_report_profile_router
 from .agency_report_web import router as agency_report_router
 from .agency_task_web import router as agency_task_router
@@ -121,6 +122,7 @@ app.include_router(agency_lead_router)
 app.include_router(agency_task_router)
 app.include_router(agency_monitoring_router)
 app.include_router(agency_report_profile_router)
+app.include_router(agency_report_profile_edit_router)
 app.include_router(agency_report_router)
 
 

--- a/src/veridra/tenant_profile_store.py
+++ b/src/veridra/tenant_profile_store.py
@@ -66,6 +66,21 @@ class TenantProfileStore:
         except ProfileStoreError as exc:
             raise TenantProfileStoreError("Saved report profile was not found.") from exc
 
+    def update_in_place(
+        self,
+        identity: RequestIdentity,
+        target: TenantObjectRef,
+        profile: ReportProfile,
+    ) -> str:
+        require_tenant_capability(identity, TenantCapability.manage_reports)
+        require_tenant_scope(identity, target)
+        if target.object_type != "report-profile":
+            raise TenantProfileStoreError("Tenant object is not a report profile reference.")
+        try:
+            return self._store(identity).update_in_place(target.object_id, profile)
+        except ProfileStoreError as exc:
+            raise TenantProfileStoreError("Saved report profile was not found.") from exc
+
     def delete(self, identity: RequestIdentity, target: TenantObjectRef) -> None:
         require_tenant_capability(identity, TenantCapability.manage_reports)
         require_tenant_scope(identity, target)

--- a/tests/test_agency_report_profile_edit_web.py
+++ b/tests/test_agency_report_profile_edit_web.py
@@ -35,7 +35,11 @@ LOGO = "data:image/png;base64,iVBORw0KGgo="
 REPLACEMENT_LOGO = "data:image/jpeg;base64,/9j/2Q=="
 
 
-def _client(tmp_path: Path, *, with_profile: bool = True) -> tuple[TestClient, str, Path, str | None]:
+def _client(
+    tmp_path: Path,
+    *,
+    with_profile: bool = True,
+) -> tuple[TestClient, str, Path, str | None]:
     root = tmp_path / "tenants"
     profiles = TenantProfileStore(root)
     profile_id = None
@@ -165,7 +169,9 @@ def test_save_replaces_profile_in_place_and_preserves_project_identity(tmp_path:
     )
 
     assert response.status_code == 303
-    assert response.headers["location"] == f"/agency/projects/{project_id}/reports?profile=updated"
+    assert response.headers["location"] == (
+        f"/agency/projects/{project_id}/reports?profile=updated"
+    )
     projects = TenantProjectStore(root)
     project = projects.load(OWNER, projects.ref(OWNER, project_id))
     assert project.profile_id == profile_id
@@ -199,7 +205,10 @@ def test_save_can_replace_or_remove_logo(tmp_path: Path) -> None:
         data={**base, "logo_data_uri": REPLACEMENT_LOGO},
         follow_redirects=False,
     )
-    profile = TenantProfileStore(root).load(OWNER, TenantProfileStore.ref(OWNER, profile_id))
+    profile = TenantProfileStore(root).load(
+        OWNER,
+        TenantProfileStore.ref(OWNER, profile_id),
+    )
     assert replaced.status_code == 303
     assert profile.logo_data_uri == REPLACEMENT_LOGO
 
@@ -209,7 +218,10 @@ def test_save_can_replace_or_remove_logo(tmp_path: Path) -> None:
         data={**base, "remove_logo": "yes"},
         follow_redirects=False,
     )
-    profile = TenantProfileStore(root).load(OWNER, TenantProfileStore.ref(OWNER, profile_id))
+    profile = TenantProfileStore(root).load(
+        OWNER,
+        TenantProfileStore.ref(OWNER, profile_id),
+    )
     assert removed.status_code == 303
     assert profile.logo_data_uri is None
 
@@ -241,7 +253,10 @@ def test_report_hub_exposes_edit_only_for_saved_profile(tmp_path: Path) -> None:
         f"/agency/projects/{project_id}/reports",
         headers={"x-test-role": "owner"},
     )
-    other_client, other_project_id, _, _ = _client(tmp_path / "default", with_profile=False)
+    other_client, other_project_id, _, _ = _client(
+        tmp_path / "default",
+        with_profile=False,
+    )
     default = other_client.get(
         f"/agency/projects/{other_project_id}/reports",
         headers={"x-test-role": "owner"},

--- a/tests/test_agency_report_profile_edit_web.py
+++ b/tests/test_agency_report_profile_edit_web.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_report_profile_edit_web import router as edit_router
+from veridra.agency_report_web import router as report_router
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.report_profiles import ReportProfile
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_profile_store import TenantProfileStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 8, 20, 8, 30, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="agency-profile-edit-owner",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="agency-profile-edit-viewer",
+    authenticated_at=NOW,
+)
+LOGO = "data:image/png;base64,iVBORw0KGgo="
+REPLACEMENT_LOGO = "data:image/jpeg;base64,/9j/2Q=="
+
+
+def _client(tmp_path: Path, *, with_profile: bool = True) -> tuple[TestClient, str, Path, str | None]:
+    root = tmp_path / "tenants"
+    profiles = TenantProfileStore(root)
+    profile_id = None
+    if with_profile:
+        profile_id = profiles.save(
+            OWNER,
+            ReportProfile(
+                organisation_name="Agency <One>",
+                client_name="Client & Co",
+                consultant_name="Consultant Name",
+                agency_email="agency@example.com",
+                agency_phone="+34 600 000 000",
+                agency_website="https://agency.example/",
+                accent_colour="#123456",
+                cover_title="Custom <Review>",
+                introduction="Intro & context",
+                executive_summary="Existing summary",
+                conclusion="Existing conclusion",
+                call_to_action_label="Book review",
+                call_to_action_url="https://agency.example/book",
+                language="es",
+                show_raw_evidence=False,
+                selected_areas=("Website health", "Trust signals"),
+                section_order=("executive_summary", "findings"),
+                logo_data_uri=LOGO,
+            ),
+        )
+    projects = TenantProjectStore(root)
+    project_id = projects.save(
+        OWNER,
+        ClientProject.build(
+            name="Client Project",
+            target_url="https://example.com/",
+            client_label="Client Co",
+            profile_id=profile_id,
+        ),
+    )
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        return await call_next(request)
+
+    app.include_router(edit_router)
+    app.include_router(report_router)
+    return TestClient(app), project_id, root, profile_id
+
+
+def test_edit_page_prefills_and_escapes_saved_profile(tmp_path: Path) -> None:
+    client, project_id, _, profile_id = _client(tmp_path)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/reports/profile/edit",
+        headers={"x-test-role": "owner"},
+    )
+
+    assert response.status_code == 200
+    assert profile_id is not None
+    assert f"Editing saved profile:</strong> {profile_id}" in response.text
+    assert "value='Agency &lt;One&gt;'" in response.text
+    assert "value='Client &amp; Co'" in response.text
+    assert "value='Custom &lt;Review&gt;'" in response.text
+    assert "Intro &amp; context" in response.text
+    assert "Existing summary" in response.text
+    assert "value='es' selected" in response.text
+    assert "value='#123456'" in response.text
+    assert "value='Website health'" not in response.text
+    assert "Website health\nTrust signals" in response.text
+    assert "value='executive_summary' checked" in response.text
+    assert "value='findings' checked" in response.text
+    assert "An embedded logo is currently saved." in response.text
+    assert "name='remove_logo'" in response.text
+
+
+def test_edit_page_requires_saved_profile_and_manage_permission(tmp_path: Path) -> None:
+    client, project_id, _, _ = _client(tmp_path, with_profile=False)
+
+    owner = client.get(
+        f"/agency/projects/{project_id}/reports/profile/edit",
+        headers={"x-test-role": "owner"},
+    )
+    viewer = client.get(
+        f"/agency/projects/{project_id}/reports/profile/edit",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert owner.status_code == 404
+    assert viewer.status_code == 403
+
+
+def test_save_replaces_profile_in_place_and_preserves_project_identity(tmp_path: Path) -> None:
+    client, project_id, root, profile_id = _client(tmp_path)
+    assert profile_id is not None
+
+    response = client.post(
+        f"/agency/projects/{project_id}/reports/profile/edit",
+        headers={"x-test-role": "owner"},
+        data={
+            "organisation_name": "Agency Updated",
+            "client_name": "Client Updated",
+            "consultant_name": "New Consultant",
+            "agency_email": "updated@example.com",
+            "agency_phone": "+34 611 111 111",
+            "agency_website": "https://updated.example/",
+            "accent_colour": "#654321",
+            "cover_title": "Updated Website Review",
+            "introduction": "Updated intro",
+            "executive_summary": "Updated summary",
+            "conclusion": "Updated conclusion",
+            "call_to_action_label": "Schedule call",
+            "call_to_action_url": "https://updated.example/call",
+            "language": "en",
+            "show_raw_evidence": "yes",
+            "selected_areas": "Search visibility, Security posture\nSearch visibility",
+            "sections": ["executive_summary", "priority_actions", "findings"],
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == f"/agency/projects/{project_id}/reports?profile=updated"
+    projects = TenantProjectStore(root)
+    project = projects.load(OWNER, projects.ref(OWNER, project_id))
+    assert project.profile_id == profile_id
+    assert len(projects.list(OWNER)) == 1
+    profiles = TenantProfileStore(root)
+    assert len(profiles.list(OWNER)) == 1
+    saved = profiles.load(OWNER, profiles.ref(OWNER, profile_id))
+    assert saved.organisation_name == "Agency Updated"
+    assert saved.client_name == "Client Updated"
+    assert saved.accent_colour == "#654321"
+    assert saved.language == "en"
+    assert saved.show_raw_evidence is True
+    assert saved.selected_areas == ("Search visibility", "Security posture")
+    assert saved.section_order == ("executive_summary", "priority_actions", "findings")
+    assert saved.logo_data_uri == LOGO
+
+
+def test_save_can_replace_or_remove_logo(tmp_path: Path) -> None:
+    client, project_id, root, profile_id = _client(tmp_path)
+    assert profile_id is not None
+    base = {
+        "organisation_name": "Agency One",
+        "language": "en",
+        "accent_colour": "#123456",
+        "sections": ["executive_summary", "findings"],
+    }
+
+    replaced = client.post(
+        f"/agency/projects/{project_id}/reports/profile/edit",
+        headers={"x-test-role": "owner"},
+        data={**base, "logo_data_uri": REPLACEMENT_LOGO},
+        follow_redirects=False,
+    )
+    profile = TenantProfileStore(root).load(OWNER, TenantProfileStore.ref(OWNER, profile_id))
+    assert replaced.status_code == 303
+    assert profile.logo_data_uri == REPLACEMENT_LOGO
+
+    removed = client.post(
+        f"/agency/projects/{project_id}/reports/profile/edit",
+        headers={"x-test-role": "owner"},
+        data={**base, "remove_logo": "yes"},
+        follow_redirects=False,
+    )
+    profile = TenantProfileStore(root).load(OWNER, TenantProfileStore.ref(OWNER, profile_id))
+    assert removed.status_code == 303
+    assert profile.logo_data_uri is None
+
+
+def test_save_rejects_invalid_input_without_replacing_profile(tmp_path: Path) -> None:
+    client, project_id, root, profile_id = _client(tmp_path)
+    assert profile_id is not None
+    profiles = TenantProfileStore(root)
+    before = profiles.load(OWNER, profiles.ref(OWNER, profile_id))
+
+    response = client.post(
+        f"/agency/projects/{project_id}/reports/profile/edit",
+        headers={"x-test-role": "owner"},
+        data={
+            "organisation_name": "Agency One",
+            "language": "en",
+            "accent_colour": "not-a-colour",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert profiles.load(OWNER, profiles.ref(OWNER, profile_id)) == before
+
+
+def test_report_hub_exposes_edit_only_for_saved_profile(tmp_path: Path) -> None:
+    client, project_id, _, _ = _client(tmp_path)
+    saved = client.get(
+        f"/agency/projects/{project_id}/reports",
+        headers={"x-test-role": "owner"},
+    )
+    other_client, other_project_id, _, _ = _client(tmp_path / "default", with_profile=False)
+    default = other_client.get(
+        f"/agency/projects/{other_project_id}/reports",
+        headers={"x-test-role": "owner"},
+    )
+
+    assert saved.status_code == 200
+    assert "Edit current saved profile" in saved.text
+    assert f"/agency/projects/{project_id}/reports/profile/edit" in saved.text
+    assert default.status_code == 200
+    assert "Edit current saved profile" not in default.text

--- a/tests/test_profile_store.py
+++ b/tests/test_profile_store.py
@@ -55,11 +55,32 @@ def test_profile_store_replaces_profile_and_removes_old_identifier(tmp_path: Pat
     assert not list(tmp_path.glob("*.tmp"))
 
 
+def test_profile_store_updates_existing_identifier_in_place(tmp_path: Path) -> None:
+    store = ProfileStore(tmp_path)
+    original = ReportProfile(organisation_name="Original Agency")
+    original_id = store.save(original)
+    replacement = ReportProfile(organisation_name="Updated Agency")
+
+    updated_id = store.update_in_place(original_id, replacement)
+
+    assert updated_id == original_id
+    assert store.load(original_id) == replacement
+    assert len(list(tmp_path.glob("*.json"))) == 1
+    assert not list(tmp_path.glob("*.tmp"))
+
+
 def test_profile_store_replace_requires_existing_profile(tmp_path: Path) -> None:
     store = ProfileStore(tmp_path)
 
     with pytest.raises(ProfileStoreError, match="not found"):
         store.replace("a" * 24, ReportProfile(organisation_name="New"))
+
+
+def test_profile_store_update_in_place_requires_existing_profile(tmp_path: Path) -> None:
+    store = ProfileStore(tmp_path)
+
+    with pytest.raises(ProfileStoreError, match="not found"):
+        store.update_in_place("a" * 24, ReportProfile(organisation_name="New"))
 
 
 def test_profile_store_rejects_invalid_identifier(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds the missing agency UI path for editing an already-applied saved report profile without creating duplicates.

What changes:
- expose an Edit current saved profile action from the report hub when a tenant profile is active;
- prefill the complete saved ReportProfile in an edit form;
- replace the profile through the existing tenant-safe TenantProfileStore.replace operation;
- preserve the profile ID and project ID;
- retain an existing embedded logo by default;
- allow bounded PNG/JPEG logo replacement through the existing data-URI validation path;
- allow explicit logo removal;
- preserve current authorization and input validation boundaries;
- add focused tests for escaping, authorization, identity preservation, validation and logo lifecycle.

No schema, storage-format or report-generation changes.

Do not merge until exact-head CI passes.