### PR TITLE
Add tenant-native lead qualification management

### DIFF
--- a/src/veridra/agency_lead_web.py
+++ b/src/veridra/agency_lead_web.py
@@ -18,13 +18,14 @@ from .identity_tenancy import (
 )
 from .lead_project_conversion_api import LeadProjectConversion, convert_lead_to_project
 from .lead_project_link_store import LeadProjectLinkError, LeadProjectLinkStore
+from .lead_store import AuditLead, LeadStatus
 from .request_security import require_request_identity
 from .tenant_lead_store import TenantLeadStore, TenantLeadStoreError
 
 router = APIRouter(prefix="/agency", tags=["agency-leads"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1050px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}label{display:block;font-weight:700;margin:12px 0 5px}input{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:700px){.row{grid-template-columns:1fr}table{display:block;overflow:auto}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1050px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.danger{background:#a23333}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.actions{display:flex;gap:8px;flex-wrap:wrap}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:110px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:700px){.row{grid-template-columns:1fr}table{display:block;overflow:auto}}
 """
 
 
@@ -47,6 +48,13 @@ def _single(body: bytes, name: str) -> str:
     return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
 
 
+def _require_manage_leads(identity: RequestIdentity) -> None:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+
+
 def _require_conversion_capabilities(identity: RequestIdentity) -> None:
     try:
         require_tenant_capability(identity, TenantCapability.manage_leads)
@@ -55,13 +63,27 @@ def _require_conversion_capabilities(identity: RequestIdentity) -> None:
         raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
 
 
+def _load_lead(request: Request, identity: RequestIdentity, lead_id: str) -> AuditLead:
+    leads = TenantLeadStore(_root(request))
+    try:
+        return leads.load(identity, leads.ref(identity, lead_id))
+    except TenantLeadStoreError as exc:
+        raise HTTPException(status_code=404, detail="Lead not found.") from exc
+
+
+def _datetime_local(value: object) -> str:
+    if value is None:
+        return ""
+    isoformat = getattr(value, "isoformat", None)
+    if not callable(isoformat):
+        return ""
+    return str(isoformat(timespec="minutes")).replace("+00:00", "")
+
+
 @router.get("/leads", response_class=HTMLResponse)
 def agency_leads(request: Request) -> str:
     identity = require_request_identity(request)
-    try:
-        require_tenant_capability(identity, TenantCapability.manage_leads)
-    except IdentityBoundaryError as exc:
-        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    _require_manage_leads(identity)
     leads = TenantLeadStore(_root(request))
     try:
         entries = leads.list(identity)
@@ -74,24 +96,95 @@ def agency_leads(request: Request) -> str:
             link = link_store.load(lead_id)
         except LeadProjectLinkError as exc:
             raise HTTPException(status_code=404, detail="Lead data not found.") from exc
-        action = (
+        primary = (
             f"<a class='button secondary' href='/agency/projects/{html.escape(link.project_id, quote=True)}'>Open project</a>"
             if link is not None
             else f"<a class='button' href='/agency/leads/{html.escape(lead_id, quote=True)}/convert'>Convert to client project</a>"
         )
+        action = (
+            f"<div class='actions'><a class='button secondary' href='/agency/leads/{html.escape(lead_id, quote=True)}'>Open lead</a>{primary}</div>"
+        )
         rows.append(
-            f"<tr><td>{html.escape(lead.name)}<br><span class='muted'>{html.escape(lead.company or 'No company')}</span></td><td>{html.escape(str(lead.website))}</td><td>{html.escape(str(lead.email))}</td><td>{html.escape(lead.status.value)}</td><td>{action}</td></tr>"
+            f"<tr><td>{html.escape(lead.name)}<br><span class='muted'>{html.escape(lead.company or 'No company')}</span></td><td>{html.escape(str(lead.website))}</td><td>{html.escape(str(lead.email))}</td><td>{html.escape(lead.status.value)}</td><td>{html.escape(lead.next_action or '—')}</td><td>{action}</td></tr>"
         )
     table = (
-        "<table><thead><tr><th>Prospect</th><th>Website</th><th>Email</th><th>Status</th><th>Next action</th></tr></thead><tbody>"
+        "<table><thead><tr><th>Prospect</th><th>Website</th><th>Email</th><th>Status</th><th>Planned follow-up</th><th>Actions</th></tr></thead><tbody>"
         + "".join(rows)
         + "</tbody></table>"
         if rows
         else "<p class='notice'>No tenant audit leads are available yet.</p>"
     )
     navigation = agency_navigation(identity, current="leads")
-    body = f"{navigation}<section><p><a href='/agency'>Agency home</a></p><h1>Audit leads</h1><p class='muted'>Convert a qualified captured audit into persistent client work without re-entering its website or assessment.</p>{table}</section>"
+    body = f"{navigation}<section><p><a href='/agency'>Agency home</a></p><h1>Audit leads</h1><p class='muted'>Qualify captured prospects, record follow-up work and convert qualified audits into persistent client projects.</p>{table}</section>"
     return _page("Audit leads", body)
+
+
+@router.get("/leads/{lead_id}", response_class=HTMLResponse)
+def agency_lead_detail(lead_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    _require_manage_leads(identity)
+    lead = _load_lead(request, identity, lead_id)
+    try:
+        link = _links(request, identity).load(lead_id)
+    except LeadProjectLinkError as exc:
+        raise HTTPException(status_code=404, detail="Lead data not found.") from exc
+    status_options = "".join(
+        "<option value='{value}'{selected}>{label}</option>".format(
+            value=item.value,
+            selected=" selected" if item == lead.status else "",
+            label=html.escape(item.value.replace("_", " ").title()),
+        )
+        for item in LeadStatus
+    )
+    project_action = (
+        f"<a class='button secondary' href='/agency/projects/{html.escape(link.project_id, quote=True)}'>Open client project</a>"
+        if link is not None
+        else f"<a class='button' href='/agency/leads/{html.escape(lead_id, quote=True)}/convert'>Convert to client project</a>"
+    )
+    navigation = agency_navigation(identity, current="leads")
+    body = f"""{navigation}<section><p><a href='/agency'>Agency home</a> · <a href='/agency/leads'>Audit leads</a></p><h1>{html.escape(lead.name)}</h1><p><strong>Company:</strong> {html.escape(lead.company or 'Not supplied')}<br><strong>Email:</strong> {html.escape(str(lead.email))}<br><strong>Phone:</strong> {html.escape(lead.phone or 'Not supplied')}<br><strong>Website:</strong> {html.escape(str(lead.website))}<br><strong>Assessment:</strong> <code>{html.escape(lead.assessment_id)}</code><br><strong>Consent:</strong> {html.escape(lead.consent_text)}<br><strong>Consented at:</strong> {html.escape(lead.consented_at.isoformat())}</p><div class='actions'>{project_action}</div></section><section><h2>Qualification and follow-up</h2><form method='post' action='/agency/leads/{html.escape(lead_id, quote=True)}'><div class='row'><div><label for='status'>Status</label><select id='status' name='status'>{status_options}</select></div><div><label for='assigned_owner'>Owner</label><input id='assigned_owner' name='assigned_owner' maxlength='120' value='{html.escape(lead.assigned_owner, quote=True)}'></div><div><label for='last_contacted_at'>Last contacted</label><input id='last_contacted_at' name='last_contacted_at' type='datetime-local' value='{html.escape(_datetime_local(lead.last_contacted_at), quote=True)}'></div><div><label for='next_follow_up_at'>Next follow-up</label><input id='next_follow_up_at' name='next_follow_up_at' type='datetime-local' value='{html.escape(_datetime_local(lead.next_follow_up_at), quote=True)}'></div></div><label for='next_action'>Next action</label><input id='next_action' name='next_action' maxlength='500' value='{html.escape(lead.next_action, quote=True)}'><label for='notes'>Notes</label><textarea id='notes' name='notes' maxlength='5000'>{html.escape(lead.notes)}</textarea><p><button type='submit'>Save lead</button></p></form><form method='post' action='/agency/leads/{html.escape(lead_id, quote=True)}/delete'><button class='danger' type='submit'>Delete lead</button></form></section>"""
+    return _page("Lead detail", body)
+
+
+@router.post("/leads/{lead_id}")
+async def save_agency_lead(lead_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    _require_manage_leads(identity)
+    lead = _load_lead(request, identity, lead_id)
+    body = await request.body()
+    data = lead.model_dump(mode="python")
+    data.update(
+        {
+            "status": _single(body, "status"),
+            "notes": _single(body, "notes"),
+            "assigned_owner": _single(body, "assigned_owner"),
+            "next_action": _single(body, "next_action"),
+            "last_contacted_at": _single(body, "last_contacted_at") or None,
+            "next_follow_up_at": _single(body, "next_follow_up_at") or None,
+        }
+    )
+    try:
+        updated = AuditLead.model_validate(data)
+        TenantLeadStore(_root(request)).replace(
+            identity,
+            TenantLeadStore.ref(identity, lead_id),
+            updated,
+        )
+    except (ValidationError, ValueError, TenantLeadStoreError) as exc:
+        raise HTTPException(status_code=400, detail="Lead update is invalid.") from exc
+    return RedirectResponse(f"/agency/leads/{lead_id}", status_code=303)
+
+
+@router.post("/leads/{lead_id}/delete")
+def delete_agency_lead(lead_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    _require_manage_leads(identity)
+    leads = TenantLeadStore(_root(request))
+    try:
+        leads.delete(identity, leads.ref(identity, lead_id))
+    except TenantLeadStoreError as exc:
+        raise HTTPException(status_code=404, detail="Lead not found.") from exc
+    return RedirectResponse("/agency/leads", status_code=303)
 
 
 @router.get(
@@ -116,7 +209,7 @@ def lead_conversion_confirmation(
     project_name = lead.company or f"{lead.name} website"
     client_label = lead.company or lead.name
     navigation = agency_navigation(identity, current="leads")
-    body = f"""{navigation}<section><p><a href='/agency'>Agency home</a> · <a href='/agency/leads'>Audit leads</a></p><h1>Convert lead to client project</h1><p class='notice'><strong>Prospect:</strong> {html.escape(lead.name)}<br><strong>Website:</strong> {html.escape(str(lead.website))}<br><strong>Assessment:</strong> {html.escape(lead.assessment_id)}</p><p>The website, assessment and tenant report profile are resolved server-side from this tenant-owned lead. Opening this page creates nothing.</p><form method='post' action='/agency/leads/{html.escape(lead_id, quote=True)}/convert'><div class='row'><div><label for='project_name'>Project name</label><input id='project_name' name='project_name' maxlength='120' value='{html.escape(project_name, quote=True)}' required></div><div><label for='client_label'>Client label</label><input id='client_label' name='client_label' maxlength='120' value='{html.escape(client_label, quote=True)}'></div></div><p><button type='submit'>Create client project</button> <a class='button secondary' href='/agency/leads'>Cancel</a></p></form></section>"""
+    body = f"""{navigation}<section><p><a href='/agency'>Agency home</a> · <a href='/agency/leads'>Audit leads</a> · <a href='/agency/leads/{html.escape(lead_id, quote=True)}'>Lead detail</a></p><h1>Convert lead to client project</h1><p class='notice'><strong>Prospect:</strong> {html.escape(lead.name)}<br><strong>Website:</strong> {html.escape(str(lead.website))}<br><strong>Assessment:</strong> {html.escape(lead.assessment_id)}</p><p>The website, assessment and tenant report profile are resolved server-side from this tenant-owned lead. Opening this page creates nothing.</p><form method='post' action='/agency/leads/{html.escape(lead_id, quote=True)}/convert'><div class='row'><div><label for='project_name'>Project name</label><input id='project_name' name='project_name' maxlength='120' value='{html.escape(project_name, quote=True)}' required></div><div><label for='client_label'>Client label</label><input id='client_label' name='client_label' maxlength='120' value='{html.escape(client_label, quote=True)}'></div></div><p><button type='submit'>Create client project</button> <a class='button secondary' href='/agency/leads/{html.escape(lead_id, quote=True)}'>Cancel</a></p></form></section>"""
     return _page("Convert lead", body)
 
 

--- a/tests/test_agency_lead_web.py
+++ b/tests/test_agency_lead_web.py
@@ -15,7 +15,7 @@ from veridra.core import demo_assessment
 from veridra.history import HistoryStore
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.lead_project_link_store import LeadProjectLink, LeadProjectLinkStore
-from veridra.lead_store import AuditLead, LeadFormConfig
+from veridra.lead_store import AuditLead, LeadFormConfig, LeadStatus
 from veridra.request_security import bind_verified_request_identity
 from veridra.tenant_lead_form_store import TenantLeadFormStore
 from veridra.tenant_lead_store import TenantLeadStore
@@ -91,6 +91,7 @@ def test_lead_inbox_requires_identity_and_escapes_content(
     assert response.status_code == 200
     assert "Alex &lt;Client&gt;" in response.text
     assert "Alex <Client>" not in response.text
+    assert f"/agency/leads/{lead_id}" in response.text
     assert f"/agency/leads/{lead_id}/convert" in response.text
     assert "aria-label='Agency navigation'" in response.text
     assert "href='/agency/leads' aria-current='page'" in response.text
@@ -109,6 +110,107 @@ def test_viewer_cannot_open_lead_inbox(
     response = client.get("/agency/leads", headers={"x-test-role": "viewer"})
 
     assert response.status_code == 403
+
+
+def test_lead_detail_exposes_qualification_fields_and_denies_viewer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, lead_id = _client(tmp_path, monkeypatch)
+
+    viewer = client.get(
+        f"/agency/leads/{lead_id}",
+        headers={"x-test-role": "viewer"},
+    )
+    owner = client.get(
+        f"/agency/leads/{lead_id}",
+        headers={"x-test-role": "owner"},
+    )
+
+    assert viewer.status_code == 403
+    assert owner.status_code == 200
+    assert "Alex &lt;Client&gt;" in owner.text
+    assert "Qualification and follow-up" in owner.text
+    assert "name='status'" in owner.text
+    assert "name='assigned_owner'" in owner.text
+    assert "name='next_action'" in owner.text
+    assert "name='next_follow_up_at'" in owner.text
+    assert "name='notes'" in owner.text
+    assert f"/agency/leads/{lead_id}/convert" in owner.text
+
+
+def test_lead_update_preserves_id_and_qualification_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, lead_id = _client(tmp_path, monkeypatch)
+    root = tmp_path / "tenants"
+
+    response = client.post(
+        f"/agency/leads/{lead_id}",
+        headers={"x-test-role": "owner"},
+        data={
+            "status": "qualified",
+            "assigned_owner": "Rafael",
+            "last_contacted_at": "2026-08-20T10:30",
+            "next_follow_up_at": "2026-08-22T09:00",
+            "next_action": "Send proposal",
+            "notes": "Qualified after discovery call.",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == f"/agency/leads/{lead_id}"
+    entries = TenantLeadStore(root).list(OWNER)
+    assert [entry_id for entry_id, _ in entries] == [lead_id]
+    lead = entries[0][1]
+    assert lead.status == LeadStatus.qualified
+    assert lead.assigned_owner == "Rafael"
+    assert lead.next_action == "Send proposal"
+    assert lead.notes == "Qualified after discovery call."
+    assert lead.last_contacted_at is not None
+    assert lead.next_follow_up_at is not None
+    assert lead.last_contacted_at.isoformat().startswith("2026-08-20T10:30")
+    assert lead.next_follow_up_at.isoformat().startswith("2026-08-22T09:00")
+
+
+def test_invalid_lead_update_is_rejected_without_mutation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, lead_id = _client(tmp_path, monkeypatch)
+    root = tmp_path / "tenants"
+    store = TenantLeadStore(root)
+    before = store.load(OWNER, store.ref(OWNER, lead_id))
+
+    response = client.post(
+        f"/agency/leads/{lead_id}",
+        headers={"x-test-role": "owner"},
+        data={"status": "not-a-status", "notes": "Should not save"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert store.load(OWNER, store.ref(OWNER, lead_id)) == before
+
+
+def test_lead_delete_removes_tenant_lead(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, lead_id = _client(tmp_path, monkeypatch)
+    root = tmp_path / "tenants"
+
+    response = client.post(
+        f"/agency/leads/{lead_id}/delete",
+        headers={"x-test-role": "owner"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/agency/leads"
+    assert TenantLeadStore(root).list(OWNER) == []
 
 
 def test_confirmation_is_read_only_and_viewer_is_denied(
@@ -135,6 +237,7 @@ def test_confirmation_is_read_only_and_viewer_is_denied(
     assert "href='/agency/leads' aria-current='page'" in owner.text
     assert "<a href='/agency'>Agency home</a>" in owner.text
     assert "<a href='/agency/leads'>Audit leads</a>" in owner.text
+    assert f"<a href='/agency/leads/{lead_id}'>Lead detail</a>" in owner.text
     assert lead_path.read_bytes() == before
     assert not (root / OWNER.tenant_id / "lead-project-links").exists()
 
@@ -177,6 +280,10 @@ def test_existing_conversion_opens_project(
     )
 
     inbox = client.get("/agency/leads", headers={"x-test-role": "owner"})
+    detail = client.get(
+        f"/agency/leads/{lead_id}",
+        headers={"x-test-role": "owner"},
+    )
     confirmation = client.get(
         f"/agency/leads/{lead_id}/convert",
         headers={"x-test-role": "owner"},
@@ -184,5 +291,6 @@ def test_existing_conversion_opens_project(
     )
 
     assert f"/agency/projects/{'b' * 24}" in inbox.text
+    assert f"/agency/projects/{'b' * 24}" in detail.text
     assert confirmation.status_code == 303
     assert confirmation.headers["location"] == f"/agency/projects/{'b' * 24}"


### PR DESCRIPTION
Makes captured tenant leads manageable through the normal authenticated agency workflow instead of limiting the agency inbox to listing and conversion.

What changes:
- add an Open lead action from `/agency/leads`;
- add tenant-scoped `/agency/leads/{lead_id}` detail and qualification UI;
- manage status, notes, owner label, last-contacted time, next follow-up and next action;
- preserve the same tenant lead ID when updating;
- keep conversion to client project as a separate explicit action;
- keep converted leads linked to their existing project;
- add explicit tenant lead deletion;
- preserve authorization, escaping and validation boundaries;
- add focused regression tests for viewer denial, stable-ID updates, invalid updates, deletion and project-linked leads.

No new lead storage model or CRM integration is introduced; this uses the existing AuditLead/TenantLeadStore contract.

Do not merge until exact-head CI passes.