### PR TITLE
Add tenant-native remediation task management

### DIFF
--- a/src/veridra/agency_task_management_web.py
+++ b/src/veridra/agency_task_management_web.py
@@ -1,0 +1,169 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .agency_navigation import agency_navigation
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .project_store import ClientProject
+from .request_security import require_request_identity
+from .task_store import RemediationTask, TaskStatus
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+from .tenant_task_store import TenantTaskStore, TenantTaskStoreError
+
+router = APIRouter(prefix="/agency", tags=["agency-remediation-management"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1100px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.danger{background:#a23333}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.actions{display:flex;gap:8px;flex-wrap:wrap}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:120px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.pill{display:inline-block;border:1px solid #cfd4da;border-radius:999px;padding:3px 8px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:760px){.row{grid-template-columns:1fr}table{display:block;overflow:auto}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _one(body: bytes, name: str) -> str:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
+
+
+def _require_manage_tasks(identity: RequestIdentity) -> None:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_tasks)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+
+
+def _project(request: Request, identity: RequestIdentity, project_id: str) -> ClientProject:
+    store = TenantProjectStore(_root(request))
+    try:
+        return store.load(identity, store.ref(identity, project_id))
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+
+def _task(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+    task_id: str,
+) -> RemediationTask:
+    store = TenantTaskStore(_root(request))
+    try:
+        task = store.load(identity, store.ref(identity, task_id))
+    except TenantTaskStoreError as exc:
+        raise HTTPException(status_code=404, detail="Remediation task not found.") from exc
+    if task.project_id != project_id:
+        raise HTTPException(status_code=404, detail="Remediation task not found.")
+    return task
+
+
+def _status_options(selected: TaskStatus) -> str:
+    return "".join(
+        "<option value='{value}'{selected}>{label}</option>".format(
+            value=item.value,
+            selected=" selected" if item == selected else "",
+            label=html.escape(item.value.replace("_", " ").title()),
+        )
+        for item in TaskStatus
+    )
+
+
+@router.get("/projects/{project_id}/tasks", response_class=HTMLResponse)
+def project_tasks(project_id: str, request: Request, status: str | None = None) -> str:
+    identity = require_request_identity(request)
+    _require_manage_tasks(identity)
+    project = _project(request, identity, project_id)
+    selected: TaskStatus | None = None
+    if status:
+        try:
+            selected = TaskStatus(status)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="Unknown task status.") from exc
+    entries = TenantTaskStore(_root(request)).list(
+        identity,
+        project_id=project_id,
+        status=selected,
+    )
+    rows = "".join(
+        f"<tr><td><strong>{html.escape(task.title)}</strong><br><code>{html.escape(task.finding_id)}</code></td><td><span class='pill'>{html.escape(task.status.value.replace('_', ' '))}</span></td><td>{html.escape(task.owner_label or 'Unassigned')}</td><td>{html.escape(task.due_date or 'Not set')}</td><td><a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/tasks/{html.escape(task_id, quote=True)}'>Open task</a></td></tr>"
+        for task_id, task in entries
+    ) or "<tr><td colspan='5'>No remediation tasks match this view.</td></tr>"
+    filters = " ".join(
+        [f"<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/tasks'>All</a>"]
+        + [
+            f"<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/tasks?status={item.value}'>{html.escape(item.value.replace('_', ' ').title())}</a>"
+            for item in TaskStatus
+        ]
+    )
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a></p><h1>{html.escape(project.name)} remediation tasks</h1><p class='notice'>Task status is an explicit operator decision. “Fixed” does not mean independently verified; use “verification required” and “verified” deliberately after checking evidence.</p><div class='actions'>{filters}</div></section><section><table><thead><tr><th>Task / finding</th><th>Status</th><th>Owner</th><th>Due</th><th>Action</th></tr></thead><tbody>{rows}</tbody></table></section>"""
+    return _page("Remediation tasks", body)
+
+
+@router.get("/projects/{project_id}/tasks/{task_id}", response_class=HTMLResponse)
+def task_detail(project_id: str, task_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    _require_manage_tasks(identity)
+    project = _project(request, identity, project_id)
+    task = _task(request, identity, project_id, task_id)
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}/tasks'>Remediation tasks</a></p><h1>{html.escape(task.title)}</h1><p><strong>Project:</strong> {html.escape(project.name)}<br><strong>Finding:</strong> {html.escape(task.finding_id)}<br><strong>Source assessment:</strong> <code>{html.escape(task.source_assessment_id)}</code></p><p class='notice'>Project, finding and source-assessment identity are immutable here. This page manages the work record only.</p></section><section><h2>Manage task</h2><form method='post' action='/agency/projects/{html.escape(project_id, quote=True)}/tasks/{html.escape(task_id, quote=True)}'><div class='row'><div><label for='status'>Status</label><select id='status' name='status'>{_status_options(task.status)}</select></div><div><label for='owner_label'>Owner</label><input id='owner_label' name='owner_label' maxlength='120' value='{html.escape(task.owner_label, quote=True)}'></div><div><label for='due_date'>Due date</label><input id='due_date' name='due_date' maxlength='40' value='{html.escape(task.due_date, quote=True)}'></div></div><label for='notes'>Notes</label><textarea id='notes' name='notes' maxlength='5000'>{html.escape(task.notes)}</textarea><p><button type='submit'>Save task</button></p></form><form method='post' action='/agency/projects/{html.escape(project_id, quote=True)}/tasks/{html.escape(task_id, quote=True)}/delete'><button class='danger' type='submit'>Delete task</button></form></section>"""
+    return _page("Remediation task", body)
+
+
+@router.post("/projects/{project_id}/tasks/{task_id}")
+async def save_task(project_id: str, task_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    _require_manage_tasks(identity)
+    _project(request, identity, project_id)
+    current = _task(request, identity, project_id, task_id)
+    body = await request.body()
+    try:
+        replacement = RemediationTask.model_validate(
+            current.model_copy(
+                update={
+                    "status": TaskStatus(_one(body, "status")),
+                    "notes": _one(body, "notes"),
+                    "owner_label": _one(body, "owner_label"),
+                    "due_date": _one(body, "due_date"),
+                }
+            )
+        )
+        TenantTaskStore(_root(request)).replace(
+            identity,
+            TenantTaskStore.ref(identity, task_id),
+            replacement,
+        )
+    except (ValidationError, ValueError, TenantTaskStoreError) as exc:
+        raise HTTPException(status_code=400, detail="Task update is invalid.") from exc
+    return RedirectResponse(f"/agency/projects/{project_id}/tasks", status_code=303)
+
+
+@router.post("/projects/{project_id}/tasks/{task_id}/delete")
+def delete_task(project_id: str, task_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    _require_manage_tasks(identity)
+    _project(request, identity, project_id)
+    _task(request, identity, project_id, task_id)
+    store = TenantTaskStore(_root(request))
+    try:
+        store.delete(identity, store.ref(identity, task_id))
+    except TenantTaskStoreError as exc:
+        raise HTTPException(status_code=404, detail="Remediation task not found.") from exc
+    return RedirectResponse(f"/agency/projects/{project_id}/tasks", status_code=303)

--- a/src/veridra/agency_task_web.py
+++ b/src/veridra/agency_task_web.py
@@ -88,7 +88,9 @@ def saved_findings(
     for finding in assessment.findings:
         key = (assessment_id, finding.id)
         existing = task_keys.get(key)
-        if existing is not None:
+        if existing is not None and can_create:
+            action = f"<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/tasks/{html.escape(existing, quote=True)}'>Open task</a>"
+        elif existing is not None:
             action = f"<span class='pill'>Task {html.escape(existing)}</span>"
         elif can_create:
             query = html.escape(
@@ -108,7 +110,12 @@ def saved_findings(
             f"<tr><td><span class='pill'>{html.escape(finding.status.value)}</span></td><td>{html.escape(finding.area)}</td><td><strong>{html.escape(finding.title)}</strong><br><span class='muted'>{html.escape(finding.summary)}</span></td><td>{action}</td></tr>"
         )
     navigation = agency_navigation(identity, current="projects")
-    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a></p><h1>Saved findings for {html.escape(project.name)}</h1><p class='notice'>Tasks are created one finding at a time after explicit confirmation. Creating a task records remediation work; it does not prove the finding is fixed.</p><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Remediation</th></tr></thead><tbody>{''.join(rows)}</tbody></table></section>"""
+    manage_link = (
+        f" · <a href='/agency/projects/{html.escape(project_id, quote=True)}/tasks'>Remediation tasks</a>"
+        if can_create
+        else ""
+    )
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a>{manage_link}</p><h1>Saved findings for {html.escape(project.name)}</h1><p class='notice'>Tasks are created one finding at a time after explicit confirmation. Creating a task records remediation work; it does not prove the finding is fixed.</p><table><thead><tr><th>Status</th><th>Area</th><th>Finding</th><th>Remediation</th></tr></thead><tbody>{''.join(rows)}</tbody></table></section>"""
     return _page(f"{project.name} findings", body)
 
 
@@ -136,7 +143,7 @@ def confirm_finding_task(
     recommendation = finding.recommendation or "Review the supporting evidence."
     navigation = agency_navigation(identity, current="projects")
     findings_url = f"/agency/projects/{html.escape(project_id, quote=True)}/assessments/{html.escape(assessment_id, quote=True)}/findings"
-    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a> · <a href='{findings_url}'>Saved findings</a></p><h1>Create remediation task</h1><p class='notice'><strong>Project:</strong> {html.escape(project.name)}<br><strong>Finding:</strong> {html.escape(finding.title)}</p><p><strong>Area:</strong> {html.escape(finding.area)}<br><strong>Severity:</strong> {html.escape(finding.severity)}<br><strong>Observation:</strong> {html.escape(finding.summary)}<br><strong>Recommended fix:</strong> {html.escape(recommendation)}</p><form method='post' action='/agency/tasks/from-finding'>{hidden}<button type='submit'>Confirm task creation</button> <a class='button secondary' href='{findings_url}'>Cancel</a></form></section>"""
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}'>Project overview</a> · <a href='{findings_url}'>Saved findings</a> · <a href='/agency/projects/{html.escape(project_id, quote=True)}/tasks'>Remediation tasks</a></p><h1>Create remediation task</h1><p class='notice'><strong>Project:</strong> {html.escape(project.name)}<br><strong>Finding:</strong> {html.escape(finding.title)}</p><p><strong>Area:</strong> {html.escape(finding.area)}<br><strong>Severity:</strong> {html.escape(finding.severity)}<br><strong>Observation:</strong> {html.escape(finding.summary)}<br><strong>Recommended fix:</strong> {html.escape(recommendation)}</p><form method='post' action='/agency/tasks/from-finding'>{hidden}<button type='submit'>Confirm task creation</button> <a class='button secondary' href='{findings_url}'>Cancel</a></form></section>"""
     return _page("Create remediation task", body)
 
 
@@ -155,4 +162,7 @@ async def submit_finding_task(request: Request) -> RedirectResponse:
     )
     created = create_task_from_finding(payload, request, identity)
     query = urlencode({"task_created": created.task_id})
-    return RedirectResponse(f"/agency/projects/{payload.project_id}?{query}", status_code=303)
+    return RedirectResponse(
+        f"/agency/projects/{payload.project_id}/tasks?{query}",
+        status_code=303,
+    )

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -14,6 +14,7 @@ from .agency_project_index_web import router as agency_project_index_router
 from .agency_report_profile_edit_web import router as agency_report_profile_edit_router
 from .agency_report_profile_web import router as agency_report_profile_router
 from .agency_report_web import router as agency_report_router
+from .agency_task_management_web import router as agency_task_management_router
 from .agency_task_web import router as agency_task_router
 from .agency_workflow_web import router as agency_workflow_router
 from .application_identity import configure_identity_middleware
@@ -122,6 +123,7 @@ app.include_router(agency_crawl_profile_router)
 app.include_router(agency_lead_router)
 app.include_router(agency_lead_form_router)
 app.include_router(agency_task_router)
+app.include_router(agency_task_management_router)
 app.include_router(agency_monitoring_router)
 app.include_router(agency_report_profile_router)
 app.include_router(agency_report_profile_edit_router)

--- a/tests/test_agency_task_management_web.py
+++ b/tests/test_agency_task_management_web.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_task_management_web import router
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.task_store import RemediationTask, TaskStatus
+from veridra.tenant_project_store import TenantProjectStore
+from veridra.tenant_task_store import TenantTaskStore
+
+NOW = datetime(2026, 8, 20, 10, 30, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="agency-task-manage-owner-01",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="agency-task-manage-viewer1",
+    authenticated_at=NOW,
+)
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Path, str, str]:
+    root = tmp_path / "tenants"
+    project_id = TenantProjectStore(root).save(
+        OWNER,
+        ClientProject.build(
+            name="Example <Client>",
+            target_url="https://example.com/",
+        ),
+    )
+    task_id = TenantTaskStore(root).save(
+        OWNER,
+        RemediationTask(
+            project_id=project_id,
+            finding_id="finding-1",
+            title="Fix <title> metadata",
+            source_assessment_id="b" * 24,
+        ),
+    )
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "owner":
+            bind_verified_request_identity(request, OWNER)
+        elif role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app), root, project_id, task_id
+
+
+def test_task_list_is_tenant_scoped_escaped_and_permissioned(tmp_path: Path) -> None:
+    client, _, project_id, task_id = _client(tmp_path)
+
+    owner = client.get(
+        f"/agency/projects/{project_id}/tasks",
+        headers={"x-test-role": "owner"},
+    )
+    viewer = client.get(
+        f"/agency/projects/{project_id}/tasks",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert owner.status_code == 200
+    assert viewer.status_code == 403
+    assert "Example &lt;Client&gt;" in owner.text
+    assert "Example <Client>" not in owner.text
+    assert "Fix &lt;title&gt; metadata" in owner.text
+    assert f"/agency/projects/{project_id}/tasks/{task_id}" in owner.text
+    assert "verification required" in owner.text
+    assert "does not mean independently verified" in owner.text
+
+
+def test_task_list_rejects_unknown_status(tmp_path: Path) -> None:
+    client, _, project_id, _ = _client(tmp_path)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/tasks?status=bogus",
+        headers={"x-test-role": "owner"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_task_detail_keeps_source_identity_server_side(tmp_path: Path) -> None:
+    client, _, project_id, task_id = _client(tmp_path)
+
+    response = client.get(
+        f"/agency/projects/{project_id}/tasks/{task_id}",
+        headers={"x-test-role": "owner"},
+    )
+
+    assert response.status_code == 200
+    assert "Fix &lt;title&gt; metadata" in response.text
+    assert "finding-1" in response.text
+    assert "b" * 24 in response.text
+    assert "name='project_id'" not in response.text
+    assert "name='finding_id'" not in response.text
+    assert "name='source_assessment_id'" not in response.text
+    assert "name='status'" in response.text
+    assert "name='owner_label'" in response.text
+    assert "name='due_date'" in response.text
+    assert "name='notes'" in response.text
+
+
+def test_task_update_changes_only_work_fields(tmp_path: Path) -> None:
+    client, root, project_id, task_id = _client(tmp_path)
+    store = TenantTaskStore(root)
+    before = store.load(OWNER, store.ref(OWNER, task_id))
+
+    response = client.post(
+        f"/agency/projects/{project_id}/tasks/{task_id}",
+        headers={"x-test-role": "owner"},
+        data={
+            "status": "in_progress",
+            "owner_label": "Rafael",
+            "due_date": "2026-08-25",
+            "notes": "Work started.",
+            "project_id": "f" * 24,
+            "finding_id": "tampered",
+            "source_assessment_id": "e" * 24,
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == f"/agency/projects/{project_id}/tasks"
+    entries = store.list(OWNER, project_id=project_id)
+    assert len(entries) == 1
+    _, updated = entries[0]
+    assert updated.project_id == before.project_id
+    assert updated.finding_id == before.finding_id
+    assert updated.source_assessment_id == before.source_assessment_id
+    assert updated.status == TaskStatus.in_progress
+    assert updated.owner_label == "Rafael"
+    assert updated.due_date == "2026-08-25"
+    assert updated.notes == "Work started."
+
+
+def test_invalid_task_update_does_not_mutate(tmp_path: Path) -> None:
+    client, root, project_id, task_id = _client(tmp_path)
+    store = TenantTaskStore(root)
+    before = store.list(OWNER, project_id=project_id)
+
+    response = client.post(
+        f"/agency/projects/{project_id}/tasks/{task_id}",
+        headers={"x-test-role": "owner"},
+        data={"status": "automatic_magic_fix"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert store.list(OWNER, project_id=project_id) == before
+
+
+def test_task_delete_removes_only_selected_project_task(tmp_path: Path) -> None:
+    client, root, project_id, task_id = _client(tmp_path)
+
+    response = client.post(
+        f"/agency/projects/{project_id}/tasks/{task_id}/delete",
+        headers={"x-test-role": "owner"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == f"/agency/projects/{project_id}/tasks"
+    assert TenantTaskStore(root).list(OWNER, project_id=project_id) == []

--- a/tests/test_agency_task_web.py
+++ b/tests/test_agency_task_web.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient
 
 from veridra.agency_conversion_web import router as project_router
+from veridra.agency_task_management_web import router as management_router
 from veridra.agency_task_web import router as task_router
 from veridra.core import demo_assessment
 from veridra.identity_tenancy import RequestIdentity, TenantRole
@@ -59,6 +60,7 @@ def _client(tmp_path: Path) -> tuple[TestClient, str, str, str]:
 
     app.include_router(project_router)
     app.include_router(task_router)
+    app.include_router(management_router)
     return TestClient(app), project_id, assessment_id, finding_id
 
 
@@ -87,6 +89,7 @@ def test_saved_findings_get_does_not_create_tasks_and_escapes_project(tmp_path: 
     assert "aria-label='Agency navigation'" in response.text
     assert "href='/agency/projects' aria-current='page'" in response.text
     assert f"href='/agency/projects/{project_id}'" in response.text
+    assert f"href='/agency/projects/{project_id}/tasks'" in response.text
     assert not (tmp_path / "tenants" / OWNER.tenant_id / "tasks").exists()
 
 
@@ -110,13 +113,14 @@ def test_viewer_can_review_but_not_open_confirmation(tmp_path: Path) -> None:
     assert listing.status_code == 200
     assert "Task permission required" in listing.text
     assert "href='/agency/projects' aria-current='page'" in listing.text
+    assert f"href='/agency/projects/{project_id}/tasks'" not in listing.text
     assert "href='/agency/leads'" not in listing.text
     assert "href='/workspace'" not in listing.text
     assert "href='/workspace/members'" not in listing.text
     assert confirmation.status_code == 403
 
 
-def test_owner_confirms_task_and_project_shows_status(tmp_path: Path) -> None:
+def test_owner_confirms_task_and_opens_management(tmp_path: Path) -> None:
     client, project_id, assessment_id, finding_id = _client(tmp_path)
 
     confirmation = client.get(
@@ -148,17 +152,24 @@ def test_owner_confirms_task_and_project_shows_status(tmp_path: Path) -> None:
         f"href='/agency/projects/{project_id}/assessments/{assessment_id}/findings'"
         in confirmation.text
     )
+    assert f"href='/agency/projects/{project_id}/tasks'" in confirmation.text
     assert created.status_code == 303
-    assert created.headers["location"].startswith(f"/agency/projects/{project_id}?task_created=")
+    assert created.headers["location"].startswith(
+        f"/agency/projects/{project_id}/tasks?task_created="
+    )
     task_id = created.headers["location"].split("task_created=", 1)[1]
-    project_page = client.get(created.headers["location"], headers={"x-test-role": "owner"})
+    task_page = client.get(
+        f"/agency/projects/{project_id}/tasks/{task_id}",
+        headers={"x-test-role": "owner"},
+    )
     listing = client.get(
         f"/agency/projects/{project_id}/assessments/{assessment_id}/findings",
         headers={"x-test-role": "owner"},
     )
-    assert project_page.status_code == 200
-    assert f"Remediation task created:</strong> {task_id}" in project_page.text
-    assert f"Task {task_id}" in listing.text
+    assert task_page.status_code == 200
+    assert "Manage task" in task_page.text
+    assert f"/agency/projects/{project_id}/tasks/{task_id}" in listing.text
+    assert "Open task" in listing.text
 
 
 def test_repeated_confirmation_is_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
Completes the normal agency remediation workflow by adding tenant-native task management under each client project.

What changes:
- add `/agency/projects/{project_id}/tasks` with explicit status filtering;
- add task detail/edit/delete for tenant-owned remediation work;
- expose mutable work fields only: status, notes, owner label and due date;
- keep project, finding and source-assessment identity server-side and immutable;
- preserve the explicit distinction between fixed, verification-required and verified states;
- make existing tasks clickable from saved findings;
- link saved findings and task confirmation to the project task manager;
- redirect successful finding-to-task creation into the new task-management flow;
- mount the routes in the composed runtime;
- add tenant-store regression coverage for permissions, escaping, filters, immutable source identity, updates, invalid updates and deletion.

This reuses TenantTaskStore and the existing finding-to-task conversion. It does not create a second task store or infer verification automatically.

Do not merge until exact-head CI passes.