### PR TITLE
Expand commercial acceptance across agency workflows

### DIFF
--- a/tests/test_commercial_acceptance_runner.py
+++ b/tests/test_commercial_acceptance_runner.py
@@ -33,6 +33,32 @@ def test_runner_drives_commercial_agency_journey() -> None:
     assert '"standard"' in RUNNER
 
 
+def test_runner_exercises_tenant_lead_generation_and_qualification() -> None:
+    assert 'page.goto(f"{base_url}/agency/lead-forms"' in RUNNER
+    assert '"Create lead form"' in RUNNER
+    assert 'checks["tenant_lead_form_created"]' in RUNNER
+    assert 'checks["tenant_lead_form_bound"]' in RUNNER
+    assert 'checks["lead_form_public_preview"]' in RUNNER
+    assert "fetch('/api/tenant/leads'" in RUNNER
+    assert 'ACCEPTANCE_LEAD_NAME = "Acceptance Prospect"' in RUNNER
+    assert 'page.goto(f"{base_url}/agency/leads"' in RUNNER
+    assert '"Open lead"' in RUNNER
+    assert 'select_option("qualified")' in RUNNER
+    assert 'checks["lead_qualified_in_ui"]' in RUNNER
+    assert 'checks["lead_follow_up_saved"]' in RUNNER
+
+
+def test_runner_exercises_tenant_remediation_management() -> None:
+    assert '"Create remediation tasks"' in RUNNER
+    assert '"Create task"' in RUNNER
+    assert '"Confirm task creation"' in RUNNER
+    assert 'checks["remediation_task_created"]' in RUNNER
+    assert '"Open task"' in RUNNER
+    assert 'select_option("in_progress")' in RUNNER
+    assert 'checks["remediation_task_managed"]' in RUNNER
+    assert '"2026-08-25"' in RUNNER
+
+
 def test_runner_verifies_white_label_report_identity() -> None:
     assert 'ACCEPTANCE_BRAND = "Acceptance Agency"' in RUNNER
     assert 'ACCEPTANCE_COVER_TITLE = "Demo SMB Website Review"' in RUNNER
@@ -61,6 +87,9 @@ def test_runner_captures_reviewable_evidence() -> None:
     assert '"commercial-acceptance.json"' in RUNNER
     assert 'report["pdf"]' in RUNNER
     assert "download.save_as(pdf_path)" in RUNNER
+    assert '"06-tenant-lead-form"' in RUNNER
+    assert '"08-qualified-lead"' in RUNNER
+    assert '"10-remediation-task-managed"' in RUNNER
     assert "shutil.make_archive" in RUNNER
 
 

--- a/tools/commercial_acceptance.py
+++ b/tools/commercial_acceptance.py
@@ -189,7 +189,10 @@ def _exercise_lead_form(
     page.wait_for_load_state("networkidle")
     form_id = parse_qs(urlparse(page.url).query).get("created", [""])[0]
     checks["tenant_lead_form_created"] = len(form_id) == 24
-    checks["tenant_lead_form_bound"] = "Lead form created and tenant-bound." in page.locator("main").inner_text()
+    checks["tenant_lead_form_bound"] = (
+        "Lead form created and tenant-bound."
+        in page.locator("main").inner_text()
+    )
     steps.append(_capture(page, output, "06-tenant-lead-form"))
 
     page.get_by_role("link", name="Preview").click()
@@ -258,8 +261,13 @@ def _exercise_lead_qualification(
     page.get_by_role("button", name="Save lead").click()
     page.wait_for_url(f"{base_url}/agency/leads/{lead_id}")
     page.wait_for_load_state("networkidle")
-    checks["lead_qualified_in_ui"] = page.get_by_label("Status").input_value() == "qualified"
-    checks["lead_follow_up_saved"] = page.get_by_label("Next action").input_value() == "Send acceptance proposal"
+    checks["lead_qualified_in_ui"] = (
+        page.get_by_label("Status").input_value() == "qualified"
+    )
+    checks["lead_follow_up_saved"] = (
+        page.get_by_label("Next action").input_value()
+        == "Send acceptance proposal"
+    )
     steps.append(_capture(page, output, "08-qualified-lead"))
 
 
@@ -279,7 +287,9 @@ def _exercise_remediation(
     page.get_by_role("button", name="Confirm task creation").click()
     page.wait_for_url("**/agency/projects/**/tasks?task_created=*")
     page.wait_for_load_state("networkidle")
-    checks["remediation_task_created"] = "remediation tasks" in page.locator("main").inner_text().casefold()
+    checks["remediation_task_created"] = (
+        "remediation tasks" in page.locator("main").inner_text().casefold()
+    )
     steps.append(_capture(page, output, "09-remediation-task-list"))
 
     page.get_by_role("link", name="Open task").first.click()

--- a/tools/commercial_acceptance.py
+++ b/tools/commercial_acceptance.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote, urlparse
 from urllib.request import urlopen
 
 from playwright.sync_api import Page, sync_playwright
@@ -20,6 +20,7 @@ PASSWORD = "veridra-commercial-acceptance"
 ACCEPTANCE_BRAND = "Acceptance Agency"
 ACCEPTANCE_COVER_TITLE = "Demo SMB Website Review"
 ACCEPTANCE_SUMMARY = "Acceptance-authored executive summary."
+ACCEPTANCE_LEAD_NAME = "Acceptance Prospect"
 
 
 def _free_port() -> int:
@@ -53,6 +54,20 @@ def _capture(page: Page, output: Path, name: str) -> dict[str, object]:
         "html": html_file.name,
         "main_text": page.locator("main").inner_text() if page.locator("main").count() else "",
     }
+
+
+def _checks(report: dict[str, object]) -> dict[str, object]:
+    checks = report.setdefault("checks", {})
+    if not isinstance(checks, dict):
+        raise RuntimeError("Commercial acceptance checks must be a mapping.")
+    return checks
+
+
+def _steps(report: dict[str, object]) -> list[object]:
+    steps = report.setdefault("steps", [])
+    if not isinstance(steps, list):
+        raise RuntimeError("Commercial acceptance steps must be a list.")
+    return steps
 
 
 def _onboard(page: Page, base_url: str) -> None:
@@ -109,12 +124,11 @@ def _verify_branded_report(
     output: Path,
     report: dict[str, object],
 ) -> None:
-    checks = report.setdefault("checks", {})
-    if not isinstance(checks, dict):
-        raise RuntimeError("Commercial acceptance checks must be a mapping.")
+    checks = _checks(report)
+    steps = _steps(report)
 
     checks["profile_created"] = ACCEPTANCE_BRAND in page.locator("main").inner_text()
-    report["steps"].append(_capture(page, output, "04-branded-report-hub"))
+    steps.append(_capture(page, output, "04-branded-report-hub"))
 
     page.get_by_role("link", name="Preview branded HTML").click()
     page.wait_for_load_state("networkidle")
@@ -123,7 +137,7 @@ def _verify_branded_report(
     checks["html_cover_title_visible"] = ACCEPTANCE_COVER_TITLE in body_text
     checks["html_summary_visible"] = ACCEPTANCE_SUMMARY in body_text
     checks["html_veridra_not_visible"] = "Veridra" not in body_text
-    report["steps"].append(_capture(page, output, "05-branded-report-preview"))
+    steps.append(_capture(page, output, "05-branded-report-preview"))
 
     page.go_back(wait_until="networkidle")
     with page.expect_download(timeout=60_000) as download_info:
@@ -154,6 +168,136 @@ def _verify_branded_report(
                     and "/report.pdf: net::ERR_ABORTED" in failure
                 )
             ]
+
+
+def _exercise_lead_form(
+    page: Page,
+    base_url: str,
+    output: Path,
+    report: dict[str, object],
+) -> str:
+    checks = _checks(report)
+    steps = _steps(report)
+    page.goto(f"{base_url}/agency/lead-forms", wait_until="networkidle")
+    page.get_by_label("Organisation label").fill(ACCEPTANCE_BRAND)
+    page.get_by_label("Public heading").fill("Get your acceptance website review")
+    page.get_by_label("Required consent wording").fill(
+        "I agree that Acceptance Agency may contact me about this website audit."
+    )
+    page.get_by_role("button", name="Create lead form").click()
+    page.wait_for_url("**/agency/lead-forms?created=*")
+    page.wait_for_load_state("networkidle")
+    form_id = parse_qs(urlparse(page.url).query).get("created", [""])[0]
+    checks["tenant_lead_form_created"] = len(form_id) == 24
+    checks["tenant_lead_form_bound"] = "Lead form created and tenant-bound." in page.locator("main").inner_text()
+    steps.append(_capture(page, output, "06-tenant-lead-form"))
+
+    page.get_by_role("link", name="Preview").click()
+    page.wait_for_load_state("networkidle")
+    public_text = page.locator("main").inner_text()
+    checks["lead_form_public_preview"] = (
+        ACCEPTANCE_BRAND in public_text
+        and "Get your acceptance website review" in public_text
+        and "Website" in public_text
+    )
+    steps.append(_capture(page, output, "07-lead-form-preview"))
+    return form_id
+
+
+def _seed_tenant_lead_fixture(page: Page, form_id: str) -> str:
+    payload = {
+        "form_id": form_id,
+        "website": "https://example.com/",
+        "name": ACCEPTANCE_LEAD_NAME,
+        "email": "prospect@example.com",
+        "company": "Acceptance Prospect Ltd",
+        "phone": "+34 600 000 000",
+        "consent_text": "Acceptance fixture consent",
+        "consented_at": "2026-08-20T10:00:00Z",
+        "assessment_id": "c" * 24,
+    }
+    result = page.evaluate(
+        """async (payload) => {
+            const response = await fetch('/api/tenant/leads', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(payload),
+            });
+            return {status: response.status, body: await response.json()};
+        }""",
+        payload,
+    )
+    if not isinstance(result, dict) or result.get("status") != 201:
+        raise RuntimeError(f"Could not seed tenant lead fixture: {result!r}")
+    body = result.get("body")
+    if not isinstance(body, dict):
+        raise RuntimeError("Tenant lead fixture response was not a mapping.")
+    lead_id = str(body.get("id", ""))
+    if len(lead_id) != 24:
+        raise RuntimeError("Tenant lead fixture did not return a valid lead ID.")
+    return lead_id
+
+
+def _exercise_lead_qualification(
+    page: Page,
+    base_url: str,
+    lead_id: str,
+    output: Path,
+    report: dict[str, object],
+) -> None:
+    checks = _checks(report)
+    steps = _steps(report)
+    page.goto(f"{base_url}/agency/leads", wait_until="networkidle")
+    checks["seeded_lead_visible"] = ACCEPTANCE_LEAD_NAME in page.locator("main").inner_text()
+    page.get_by_role("link", name="Open lead").click()
+    page.wait_for_url(f"{base_url}/agency/leads/{lead_id}")
+    page.get_by_label("Status").select_option("qualified")
+    page.get_by_label("Owner").fill("Acceptance Operator")
+    page.get_by_label("Next action").fill("Send acceptance proposal")
+    page.get_by_label("Notes").fill("Qualified in deterministic commercial acceptance.")
+    page.get_by_role("button", name="Save lead").click()
+    page.wait_for_url(f"{base_url}/agency/leads/{lead_id}")
+    page.wait_for_load_state("networkidle")
+    checks["lead_qualified_in_ui"] = page.get_by_label("Status").input_value() == "qualified"
+    checks["lead_follow_up_saved"] = page.get_by_label("Next action").input_value() == "Send acceptance proposal"
+    steps.append(_capture(page, output, "08-qualified-lead"))
+
+
+def _exercise_remediation(
+    page: Page,
+    project_url: str,
+    output: Path,
+    report: dict[str, object],
+) -> None:
+    checks = _checks(report)
+    steps = _steps(report)
+    page.goto(project_url, wait_until="networkidle")
+    page.get_by_role("link", name="Create remediation tasks").click()
+    page.wait_for_load_state("networkidle")
+    page.get_by_role("link", name="Create task").first.click()
+    page.wait_for_load_state("networkidle")
+    page.get_by_role("button", name="Confirm task creation").click()
+    page.wait_for_url("**/agency/projects/**/tasks?task_created=*")
+    page.wait_for_load_state("networkidle")
+    checks["remediation_task_created"] = "remediation tasks" in page.locator("main").inner_text().casefold()
+    steps.append(_capture(page, output, "09-remediation-task-list"))
+
+    page.get_by_role("link", name="Open task").first.click()
+    page.wait_for_load_state("networkidle")
+    page.get_by_label("Status").select_option("in_progress")
+    page.get_by_label("Owner").fill("Acceptance Operator")
+    page.get_by_label("Due date").fill("2026-08-25")
+    page.get_by_label("Notes").fill("Acceptance remediation work started.")
+    page.get_by_role("button", name="Save task").click()
+    page.wait_for_url("**/agency/projects/**/tasks")
+    page.wait_for_load_state("networkidle")
+    task_text = page.locator("main").inner_text()
+    checks["remediation_task_managed"] = (
+        "in progress" in task_text.casefold()
+        and "Acceptance Operator" in task_text
+        and "2026-08-25" in task_text
+    )
+    steps.append(_capture(page, output, "10-remediation-task-managed"))
 
 
 def _run_real_quick_audit(page: Page, base_url: str, target: str) -> None:
@@ -224,29 +368,39 @@ def run(target: str | None = None) -> Path:
                         ),
                     )
                     _onboard(page, base_url)
-                    report["steps"].append(_capture(page, run_dir, "01-agency-home"))
+                    _steps(report).append(_capture(page, run_dir, "01-agency-home"))
 
                     if target:
                         _run_real_quick_audit(page, base_url, target)
-                        report["steps"].append(_capture(page, run_dir, "02-real-quick-audit"))
+                        _steps(report).append(_capture(page, run_dir, "02-real-quick-audit"))
                     else:
                         _enable_professional_plan(page, base_url)
-                        checks = report["checks"]
-                        if not isinstance(checks, dict):
-                            raise RuntimeError("Commercial acceptance checks must be a mapping.")
+                        checks = _checks(report)
                         checks["professional_plan_enabled"] = (
                             "Plan: Professional" in page.locator("main").inner_text()
                         )
                         _create_demo_project(page, base_url)
                         project_url = page.url
-                        report["steps"].append(_capture(page, run_dir, "02-project-overview"))
+                        _steps(report).append(_capture(page, run_dir, "02-project-overview"))
                         _configure_branded_report(page)
-                        report["steps"].append(_capture(page, run_dir, "03-report-profile-created"))
+                        _steps(report).append(_capture(page, run_dir, "03-report-profile-created"))
                         _verify_branded_report(page, run_dir, report)
+
+                        form_id = _exercise_lead_form(page, base_url, run_dir, report)
+                        lead_id = _seed_tenant_lead_fixture(page, form_id)
+                        _exercise_lead_qualification(
+                            page,
+                            base_url,
+                            lead_id,
+                            run_dir,
+                            report,
+                        )
+                        _exercise_remediation(page, project_url, run_dir, report)
+
                         page.goto(project_url, wait_until="networkidle")
                         page.get_by_role("link", name="Enable monitoring").click()
                         page.wait_for_load_state("networkidle")
-                        report["steps"].append(_capture(page, run_dir, "06-monitoring"))
+                        _steps(report).append(_capture(page, run_dir, "11-monitoring"))
                     browser.close()
                 checks = report.get("checks", {})
                 checks_passed = all(checks.values()) if checks else target is not None


### PR DESCRIPTION
Extends the isolated Playwright commercial acceptance runner beyond reporting and monitoring so CI proves the newly completed tenant-native agency workflows.

What changes:
- keep onboarding, Professional entitlement, demo project, branded HTML/PDF and monitoring checks;
- create and tenant-bind an embedded lead form through the normal agency UI;
- preview the public embedded form and capture evidence;
- seed one deterministic tenant lead through the authenticated tenant API as fixture data, avoiding flaky external assessment/network dependency;
- qualify that lead through the normal agency UI and verify follow-up persistence;
- create a remediation task from a saved project finding through the normal UI;
- manage task status, owner, due date and notes through the tenant-native task UI;
- capture screenshots/HTML for the new workflow stages;
- add source-contract tests for the expanded acceptance journey.

The fixture lead is used only to make the acceptance run deterministic; public tenant-bound capture remains covered by its dedicated tests. The acceptance runner still fails on request failures or any false commercial check.

Do not merge until exact-head CI passes.