### PR TITLE
Harden tenant lead-form binding lifecycle

### DIFF
--- a/src/veridra/agency_lead_form_web.py
+++ b/src/veridra/agency_lead_form_web.py
@@ -161,14 +161,25 @@ async def create_lead_form(request: Request) -> RedirectResponse:
     identity = require_request_identity(request)
     _require(identity)
     form = _payload(request, identity, _values(await request.body()))
-    form_id = TenantLeadFormStore(_root(request)).save(identity, form)
+    store = TenantLeadFormStore(_root(request))
+    binding_store = _binding_store(request)
+    existing_ids = {form_id for form_id, _ in store.list(identity)}
+    form_id = store.save(identity, form)
     try:
-        _binding_store(request).bind(
+        binding_store.bind(
             form_id=form_id,
             tenant_id=identity.tenant_id,
             created_by_user_id=identity.user_id,
         )
     except LeadFormTenantBindingError as exc:
+        if form_id not in existing_ids:
+            try:
+                store.delete(identity, store.ref(identity, form_id))
+            except TenantLeadFormStoreError as rollback_exc:
+                raise HTTPException(
+                    status_code=500,
+                    detail="Lead form binding failed and the new form could not be rolled back.",
+                ) from rollback_exc
         raise HTTPException(status_code=409, detail="Lead form could not be tenant-bound.") from exc
     return RedirectResponse(f"/agency/lead-forms?{urlencode({'created': form_id})}", status_code=303)
 
@@ -215,12 +226,29 @@ def delete_lead_form(form_id: str, request: Request) -> RedirectResponse:
     identity = require_request_identity(request)
     _require(identity)
     store = TenantLeadFormStore(_root(request))
-    binding = _binding_store(request).resolve(form_id)
+    binding_store = _binding_store(request)
+    try:
+        current = store.load(identity, store.ref(identity, form_id))
+    except TenantLeadFormStoreError as exc:
+        raise HTTPException(status_code=404, detail="Lead form not found.") from exc
+    binding = binding_store.resolve(form_id)
     if binding is None or binding.tenant_id != identity.tenant_id:
         raise HTTPException(status_code=404, detail="Lead form binding not found.")
     try:
         store.delete(identity, store.ref(identity, form_id))
-        _binding_store(request).unbind(form_id=form_id, tenant_id=identity.tenant_id)
-    except (TenantLeadFormStoreError, LeadFormTenantBindingError) as exc:
+    except TenantLeadFormStoreError as exc:
         raise HTTPException(status_code=404, detail="Lead form not found.") from exc
+    try:
+        binding_store.unbind(form_id=form_id, tenant_id=identity.tenant_id)
+    except LeadFormTenantBindingError as exc:
+        restored_id = store.save(identity, current)
+        if restored_id != form_id:
+            raise HTTPException(
+                status_code=500,
+                detail="Lead form binding removal failed and form identity could not be restored.",
+            ) from exc
+        raise HTTPException(
+            status_code=409,
+            detail="Lead form binding could not be removed; the form was restored.",
+        ) from exc
     return RedirectResponse("/agency/lead-forms", status_code=303)

--- a/tests/test_agency_lead_form_web.py
+++ b/tests/test_agency_lead_form_web.py
@@ -5,12 +5,17 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient
 
 from veridra.agency_lead_form_web import router
 from veridra.identity_tenancy import RequestIdentity, TenantRole
-from veridra.lead_form_tenant_binding import SQLiteLeadFormTenantBindingStore
+from veridra.lead_form_tenant_binding import (
+    LeadFormTenantBindingError,
+    SQLiteLeadFormTenantBindingStore,
+)
+from veridra.lead_store import LeadFormConfig
 from veridra.report_profiles import ReportProfile
 from veridra.request_security import bind_verified_request_identity
 from veridra.tenant_lead_form_store import TenantLeadFormStore
@@ -31,6 +36,13 @@ VIEWER = RequestIdentity(
     session_id="agency-lead-form-viewer-00",
     authenticated_at=NOW,
 )
+OTHER_OWNER = RequestIdentity(
+    user_id=OWNER.user_id,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.owner,
+    session_id="agency-lead-form-other-0000",
+    authenticated_at=NOW,
+)
 
 
 def _client(tmp_path: Path) -> tuple[TestClient, Path, Path, str]:
@@ -42,6 +54,7 @@ def _client(tmp_path: Path) -> tuple[TestClient, Path, Path, str]:
         connection.execute("INSERT INTO users (id) VALUES (?)", (OWNER.user_id,))
         connection.execute("INSERT INTO users (id) VALUES (?)", (VIEWER.user_id,))
         connection.execute("INSERT INTO tenants (id) VALUES (?)", (OWNER.tenant_id,))
+        connection.execute("INSERT INTO tenants (id) VALUES (?)", (OTHER_OWNER.tenant_id,))
     profile_id = TenantProfileStore(root).save(
         OWNER,
         ReportProfile(organisation_name="Agency Profile"),
@@ -81,6 +94,21 @@ def _form_data(profile_id: str, *, organisation: str = "Agency One") -> dict[str
     }
 
 
+def _form_model(profile_id: str) -> LeadFormConfig:
+    return LeadFormConfig(
+        organisation_label="Agency One",
+        heading="Get your website review",
+        introduction="A bounded public website assessment.",
+        submit_label="Get report",
+        consent_text="I agree that Agency One may contact me about this audit.",
+        collect_company=True,
+        allowed_origins=("https://agency.example",),
+        profile_id=profile_id,
+        notification_email="leads@example.com",
+        cta_url="https://agency.example/contact",
+    )
+
+
 def test_lead_form_page_is_tenant_navigation_and_requires_permission(tmp_path: Path) -> None:
     client, _, _, profile_id = _client(tmp_path)
 
@@ -116,6 +144,34 @@ def test_create_lead_form_saves_tenant_form_and_binding(tmp_path: Path) -> None:
     binding = SQLiteLeadFormTenantBindingStore(database).resolve(form_id)
     assert binding is not None
     assert binding.tenant_id == OWNER.tenant_id
+
+
+def test_create_binding_conflict_rolls_back_only_new_tenant_form(tmp_path: Path) -> None:
+    client, root, database, profile_id = _client(tmp_path)
+    form_id = TenantLeadFormStore(root).save(OTHER_OWNER, _form_model(profile_id))
+    bindings = SQLiteLeadFormTenantBindingStore(database)
+    bindings.bind(
+        form_id=form_id,
+        tenant_id=OTHER_OWNER.tenant_id,
+        created_by_user_id=OTHER_OWNER.user_id,
+    )
+
+    response = client.post(
+        "/agency/lead-forms",
+        headers={"x-test-role": "owner"},
+        data=_form_data(profile_id),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 409
+    assert TenantLeadFormStore(root).list(OWNER) == []
+    assert TenantLeadFormStore(root).load(
+        OTHER_OWNER,
+        TenantLeadFormStore.ref(OTHER_OWNER, form_id),
+    ) == _form_model(profile_id)
+    binding = bindings.resolve(form_id)
+    assert binding is not None
+    assert binding.tenant_id == OTHER_OWNER.tenant_id
 
 
 def test_edit_lead_form_preserves_id_and_binding(tmp_path: Path) -> None:
@@ -164,3 +220,35 @@ def test_delete_lead_form_removes_form_and_binding(tmp_path: Path) -> None:
     assert response.status_code == 303
     assert TenantLeadFormStore(root).list(OWNER) == []
     assert SQLiteLeadFormTenantBindingStore(database).resolve(form_id) is None
+
+
+def test_delete_unbind_failure_restores_same_form(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, root, database, profile_id = _client(tmp_path)
+    client.post(
+        "/agency/lead-forms",
+        headers={"x-test-role": "owner"},
+        data=_form_data(profile_id),
+        follow_redirects=False,
+    )
+    store = TenantLeadFormStore(root)
+    form_id, before = store.list(OWNER)[0]
+
+    def fail_unbind(self: SQLiteLeadFormTenantBindingStore, *, form_id: str, tenant_id: str) -> None:
+        raise LeadFormTenantBindingError("simulated unbind failure")
+
+    monkeypatch.setattr(SQLiteLeadFormTenantBindingStore, "unbind", fail_unbind)
+    response = client.post(
+        f"/agency/lead-forms/{form_id}/delete",
+        headers={"x-test-role": "owner"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 409
+    entries = store.list(OWNER)
+    assert entries == [(form_id, before)]
+    binding = SQLiteLeadFormTenantBindingStore(database).resolve(form_id)
+    assert binding is not None
+    assert binding.tenant_id == OWNER.tenant_id

--- a/tests/test_agency_lead_form_web.py
+++ b/tests/test_agency_lead_form_web.py
@@ -236,7 +236,12 @@ def test_delete_unbind_failure_restores_same_form(
     store = TenantLeadFormStore(root)
     form_id, before = store.list(OWNER)[0]
 
-    def fail_unbind(self: SQLiteLeadFormTenantBindingStore, *, form_id: str, tenant_id: str) -> None:
+    def fail_unbind(
+        self: SQLiteLeadFormTenantBindingStore,
+        *,
+        form_id: str,
+        tenant_id: str,
+    ) -> None:
         raise LeadFormTenantBindingError("simulated unbind failure")
 
     monkeypatch.setattr(SQLiteLeadFormTenantBindingStore, "unbind", fail_unbind)


### PR DESCRIPTION
Hardens the tenant lead-form file-store and SQLite binding boundary so partial failures do not leave orphan forms or stale bindings.

What changes:
- resolve the binding store before creating a tenant form;
- track pre-existing deterministic form IDs before save;
- if tenant binding fails, roll back only a newly created local form and never delete a pre-existing identical form;
- on deletion, retain the exact saved form model before removal;
- if binding removal fails after file deletion, restore the form under the same deterministic ID and return a conflict instead of leaving a stale binding pointing at missing data;
- add failure-injection tests for cross-tenant binding conflicts and unbind rollback, alongside the existing happy-path create/edit/delete coverage.

No storage schema or public capture behavior changes.

Do not merge until exact-head CI passes.