### PR TITLE
Keep agency home tenant-native

### DIFF
--- a/src/veridra/agency_workflow_web.py
+++ b/src/veridra/agency_workflow_web.py
@@ -54,14 +54,13 @@ def agency_workflow_home() -> str:
       <p>Open persistent tenant projects for saved evidence, branded reports, remediation, monitoring and comparison.</p>
       <div class='actions'><a class='button' href='/agency/projects'>Open client projects</a></div></section>
     </div>
-    <section><h2>Agency operations</h2><p class='muted'>Project-attached work uses the tenant-qualified agency journey. Remaining compatibility operations are being consolidated separately.</p>
+    <section><h2>Agency operations</h2><p class='muted'>Normal agency work stays inside tenant-qualified project, lead and workspace routes.</p>
     <div class='links'>
-      <a href='/agency/projects'><strong>Client projects</strong><br><span class='muted'>Open saved assessments, reports, remediation and monitoring.</span></a>
-      <a href='/agency/leads'><strong>Leads</strong><br><span class='muted'>Review captured prospects and convert qualified audits into client projects.</span></a>
+      <a href='/agency/projects'><strong>Client projects</strong><br><span class='muted'>Open saved assessments, branded report profiles and outputs, remediation and monitoring.</span></a>
+      <a href='/agency/leads'><strong>Leads</strong><br><span class='muted'>Review captured prospects, qualify follow-up and convert accepted work into client projects.</span></a>
       <a href='/agency/lead-forms'><strong>Lead forms</strong><br><span class='muted'>Configure tenant-owned embedded capture.</span></a>
-      <a href='/profiles'><strong>Report profile library</strong><br><span class='muted'>Manage reusable compatibility profiles; project profiles are configured from each report hub.</span></a>
-      <a href='/commercial'><strong>Commercial operations</strong><br><span class='muted'>Follow-up and bounded engagement evidence.</span></a>
       <a href='/workspace'><strong>Workspace controls</strong><br><span class='muted'>Review plan, usage, permissions and plan-change history.</span></a>
+      <a href='/workspace/members'><strong>Team</strong><br><span class='muted'>Manage tenant members and roles.</span></a>
     </div></section>
     <p class='notice'><strong>Boundary:</strong> A quick audit is temporary until an operator explicitly creates a client project. Veridra does not infer a tenant, client or project from a submitted URL. Persistent work should continue from the tenant-qualified client-project index.</p>
     """

--- a/tests/test_agency_workflow_web.py
+++ b/tests/test_agency_workflow_web.py
@@ -21,10 +21,24 @@ def test_agency_home_explains_quick_and_persistent_workflows() -> None:
     assert "Client projects" in response.text
     assert "does not create a project or save data automatically" in response.text
     assert "Veridra does not infer a tenant, client or project" in response.text
-    assert "href='/profiles'" in response.text
+    assert "tenant-qualified project, lead and workspace routes" in response.text
     assert "href='/agency/projects'" in response.text
+    assert "href='/agency/leads'" in response.text
+    assert "href='/agency/lead-forms'" in response.text
+    assert "href='/workspace'" in response.text
+    assert "href='/workspace/members'" in response.text
+
+
+def test_agency_home_does_not_expose_global_compatibility_routes() -> None:
+    response = _client().get("/agency")
+
+    assert response.status_code == 200
+    assert "href='/profiles'" not in response.text
+    assert "href='/commercial'" not in response.text
     assert "href='/projects'" not in response.text
     assert "href='/monitoring'" not in response.text
+    assert "href='/leads'" not in response.text
+    assert "href='/lead-forms'" not in response.text
 
 
 def test_quick_audit_handoff_redirects_to_completed_agency_result() -> None:


### PR DESCRIPTION
Removes the remaining normal-user links from `/agency` into legacy global compatibility surfaces.

What changes:
- remove `/profiles` and `/commercial` from Agency operations;
- keep report profile work attached to each tenant project report hub;
- keep lead qualification/follow-up in tenant-native `/agency/leads`;
- add a tenant Team entry alongside Workspace controls;
- update copy so the agency home explicitly describes the tenant-qualified route boundary;
- strengthen tests to require tenant-native project/lead/lead-form/workspace routes and forbid global compatibility links.

Compatibility routes remain mounted; this only removes them from the normal agency workflow.

Do not merge until exact-head full CI succeeds.