### PR TITLE
Review saved tenant findings from projects

### DIFF
--- a/src/veridra/agency_conversion_web.py
+++ b/src/veridra/agency_conversion_web.py
@@ -168,14 +168,13 @@ def tenant_project_next_actions(
         assessments = history.list(identity, project_id)
     except (TenantProjectStoreError, TenantHistoryStoreError) as exc:
         raise HTTPException(status_code=404, detail="Project not found.") from exc
-    query = urlencode({"url": project.target_url, **({"profile": project.profile_id} if project.profile_id else {})})
     latest = assessments[0] if assessments else None
     latest_text = html.escape(latest.generated_at) if latest else "Not available"
     limits = project.resolved_crawl_profile().limits
-    remediation = (
-        f"<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/assessments/{html.escape(latest.id, quote=True)}/findings'>Create remediation tasks</a>"
+    findings_action = (
+        f"<a class='button' href='/agency/projects/{html.escape(project_id, quote=True)}/assessments/{html.escape(latest.id, quote=True)}/findings'>Review saved findings</a>"
         if latest is not None
-        else "<span class='muted'>Save an assessment before creating remediation tasks.</span>"
+        else "<span class='muted'>Save an assessment before reviewing findings.</span>"
     )
     created_notice = (
         f"<p class='notice success'><strong>Remediation task created:</strong> {html.escape(task_created)}</p>"
@@ -183,5 +182,5 @@ def tenant_project_next_actions(
         else ""
     )
     navigation = agency_navigation(identity, current="projects")
-    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a></p><h1>{html.escape(project.name)}</h1>{created_notice}<p><strong>Client:</strong> {html.escape(project.client_label or 'Not set')}<br><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Crawl profile:</strong> {html.escape(project.crawl_profile.value.title())} — up to {limits.max_pages} pages, depth {limits.max_depth}<br><strong>Saved assessment:</strong> {latest_text}</p><div class='actions'><a class='button' href='/?{html.escape(query, quote=True)}'>Review assessment</a><a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Prepare branded report</a>{remediation}<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/monitoring'>Enable monitoring</a></div></section><section><h2>Recommended next step</h2><p>Review the saved evidence, choose the client-facing report output, then convert actionable findings into assigned remediation work before enabling recurring monitoring.</p></section>"""
+    body = f"""{navigation}<section><p><a href='/agency/projects'>Client projects</a></p><h1>{html.escape(project.name)}</h1>{created_notice}<p><strong>Client:</strong> {html.escape(project.client_label or 'Not set')}<br><strong>Website:</strong> {html.escape(project.target_url)}<br><strong>Crawl profile:</strong> {html.escape(project.crawl_profile.value.title())} — up to {limits.max_pages} pages, depth {limits.max_depth}<br><strong>Saved assessment:</strong> {latest_text}</p><div class='actions'>{findings_action}<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/reports'>Prepare branded report</a><a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/monitoring'>Enable monitoring</a></div></section><section><h2>Recommended next step</h2><p>Review the saved evidence, choose the client-facing report output, then convert actionable findings into assigned remediation work before enabling recurring monitoring.</p></section>"""
     return _page(project.name, body)

--- a/tests/test_agency_conversion_web.py
+++ b/tests/test_agency_conversion_web.py
@@ -178,7 +178,10 @@ def test_owner_confirms_deep_conversion_and_reaches_tenant_next_actions(
     assert "&lt;b&gt;Example project&lt;/b&gt;" in detail.text
     assert "<b>Example project</b>" not in detail.text
     assert "Deep — up to 100 pages, depth 3" in detail.text
-    assert "Create remediation tasks" in detail.text
+    assert "Review saved findings" in detail.text
+    assert f"/agency/projects/{project_id}/assessments/" in detail.text
+    assert "/findings" in detail.text
+    assert "href='/?" not in detail.text
     assert "Enable monitoring" in detail.text
 
 

--- a/tests/test_agency_project_overview_navigation.py
+++ b/tests/test_agency_project_overview_navigation.py
@@ -74,6 +74,21 @@ def test_owner_project_overview_has_authorized_navigation(tmp_path: Path) -> Non
     assert "<a href='/agency/projects'>Client projects</a>" in response.text
 
 
+def test_project_without_saved_assessment_does_not_offer_review_link(tmp_path: Path) -> None:
+    client, root = _client(tmp_path)
+    project_id = _project(root, OWNER, "Empty project")
+
+    response = client.get(
+        f"/agency/projects/{project_id}",
+        headers={"x-test-identity": "owner"},
+    )
+
+    assert response.status_code == 200
+    assert "Save an assessment before reviewing findings." in response.text
+    assert "Review saved findings" not in response.text
+    assert "href='/?" not in response.text
+
+
 def test_viewer_project_overview_hides_unavailable_navigation(tmp_path: Path) -> None:
     client, root = _client(tmp_path)
     project_id = _project(root, VIEWER, "Viewer project")

--- a/tests/test_commercial_acceptance_runner.py
+++ b/tests/test_commercial_acceptance_runner.py
@@ -49,7 +49,7 @@ def test_runner_exercises_tenant_lead_generation_and_qualification() -> None:
 
 
 def test_runner_exercises_tenant_remediation_management() -> None:
-    assert '"Create remediation tasks"' in RUNNER
+    assert '"Review saved findings"' in RUNNER
     assert '"Create task"' in RUNNER
     assert '"Confirm task creation"' in RUNNER
     assert 'checks["remediation_task_created"]' in RUNNER

--- a/tools/commercial_acceptance.py
+++ b/tools/commercial_acceptance.py
@@ -280,7 +280,7 @@ def _exercise_remediation(
     checks = _checks(report)
     steps = _steps(report)
     page.goto(project_url, wait_until="networkidle")
-    page.get_by_role("link", name="Create remediation tasks").click()
+    page.get_by_role("link", name="Review saved findings").click()
     page.wait_for_load_state("networkidle")
     page.get_by_role("link", name="Create task").first.click()
     page.wait_for_load_state("networkidle")


### PR DESCRIPTION
Keeps authenticated client-project review inside persisted tenant evidence instead of sending the operator back to the old root assessment console.

What changes:
- replace project overview `Review assessment` root-console link with `Review saved findings` for the exact latest saved assessment;
- reuse the tenant-qualified saved-findings route, which is also the finding-to-remediation entrypoint;
- remove the duplicate separate remediation action from the project overview;
- when no saved assessment exists, render an explicit non-action message instead of a review link;
- add regression coverage proving converted projects link to tenant saved findings and never render `href='/?...`;
- add no-assessment coverage proving review is unavailable until evidence is saved.

No assessment is rerun by opening a persisted project.

Do not merge until exact-head full CI succeeds.