### PR TITLE
Lock local plan overrides in production

### DIFF
--- a/src/veridra/workspace_web.py
+++ b/src/veridra/workspace_web.py
@@ -20,6 +20,7 @@ from .identity_tenancy import (
     require_tenant_capability,
 )
 from .request_security import require_request_identity
+from .runtime_config import RuntimeConfig, RuntimeEnvironment
 from .tenant_workspace_policy import TenantWorkspacePolicy, TenantWorkspacePolicyError
 from .workspace_policy import (
     PLAN_CATALOGUE,
@@ -47,7 +48,7 @@ label{display:block;font-weight:700;margin:10px 0 4px}input,select{width:100%;pa
 
 
 def _page(title: str, body: str) -> str:
-    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main><p><a href='/agency'>Agency workflow</a> · <a href='/workspace'>Workspace</a> · <a href='/commercial'>Commercial operations</a></p>{body}</main></body></html>"
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main><p><a href='/agency'>Agency workflow</a> · <a href='/workspace'>Workspace</a></p>{body}</main></body></html>"
 
 
 def _single(body: bytes, name: str) -> str:
@@ -57,6 +58,14 @@ def _single(body: bytes, name: str) -> str:
 def _root(request: Request) -> Path | None:
     value = getattr(request.app.state, "veridra_tenant_data_root", None)
     return value if isinstance(value, Path) else None
+
+
+def _local_plan_changes_allowed(request: Request) -> bool:
+    config = getattr(request.app.state, "veridra_runtime_config", None)
+    return not (
+        isinstance(config, RuntimeConfig)
+        and config.environment is RuntimeEnvironment.production
+    )
 
 
 def _tenant_policy(request: Request) -> TenantWorkspacePolicy:
@@ -102,12 +111,14 @@ def workspace_dashboard(request: Request) -> str:
         for _, event in reversed(changes[-10:])
     ) or "<tr><td colspan='4'>No plan changes recorded.</td></tr>"
     management = ""
-    if can_manage:
+    if can_manage and _local_plan_changes_allowed(request):
         options = "".join(
             f"<option value='{plan.value}'{' selected' if plan == workspace.plan else ''}>{plan.value.title()}</option>"
             for plan in PlanName
         )
         management = f"<section><h2>Preview or apply local entitlement policy</h2><form method='get' action='/workspace/plan-preview'><div class='row'><div><label>Plan</label><select name='plan'>{options}</select></div><div><label>Cycle anchor day</label><input type='number' min='1' max='28' name='cycle_anchor_day' value='{workspace.cycle_anchor_day}'></div></div><p><button>Preview plan</button></p></form></section>"
+    elif can_manage:
+        management = "<section><h2>Plan management</h2><p class='muted'>Local entitlement overrides are disabled in production. Plan changes must come from the configured billing or subscription authority.</p></section>"
     body = f"""<section><h1>{html.escape(workspace.display_name)}</h1><p><strong>Plan:</strong> {workspace.plan.value.title()} · <strong>Status:</strong> {workspace.status.value.title()}<br><strong>Tenant:</strong> {html.escape(identity.tenant_id)}<br><strong>Current cycle:</strong> {period.starts_at.isoformat()} to {period.ends_at.isoformat()}</p><p class='muted'>This is tenant-qualified local entitlement policy and usage evidence. It is not payment collection, an invoice, or proof of an active external subscription.</p><p><a class='button' href='/workspace/usage.csv'>Export usage CSV</a></p></section><section><h2>Current entitlements</h2><div class='grid'><article class='metric'>Projects<strong>{entitlement.max_projects}</strong></article><article class='metric'>Users<strong>{entitlement.max_users}</strong></article><article class='metric'>White label<strong>{'Yes' if entitlement.white_label else 'No'}</strong></article><article class='metric'>Embedded forms<strong>{'Yes' if entitlement.embedded_lead_forms else 'No'}</strong></article></div></section><section><h2>Usage and allowance</h2><table><thead><tr><th>Resource</th><th>Used</th><th>Limit</th><th>Remaining</th><th>Decision</th></tr></thead><tbody>{_summary_rows(policy, identity, workspace, now)}</tbody></table></section><section><h2>Recent plan changes</h2><table><thead><tr><th>Changed</th><th>Actor</th><th>Previous</th><th>New</th></tr></thead><tbody>{change_rows}</tbody></table></section>{management}"""
     return _page("Workspace usage", body)
 
@@ -145,13 +156,24 @@ def plan_preview(request: Request, plan: PlanName, cycle_anchor_day: int = 1) ->
             ("Users", str(entitlement.max_users)),
         )
     )
-    body = f"<section><h1>Plan preview: {proposed.plan.value.title()}</h1><p class='muted'>Applying this changes only Veridra's tenant-local entitlement policy. It does not charge a payment method or create an external subscription.</p><table><tbody>{rows}</tbody></table><form method='post' action='/workspace/plan'><input type='hidden' name='plan' value='{proposed.plan.value}'><input type='hidden' name='cycle_anchor_day' value='{proposed.cycle_anchor_day}'><p><button>Apply local policy</button></p></form></section>"
+    if _local_plan_changes_allowed(request):
+        action = f"<form method='post' action='/workspace/plan'><input type='hidden' name='plan' value='{proposed.plan.value}'><input type='hidden' name='cycle_anchor_day' value='{proposed.cycle_anchor_day}'><p><button>Apply local policy</button></p></form>"
+        note = "Applying this changes only Veridra's tenant-local entitlement policy. It does not charge a payment method or create an external subscription."
+    else:
+        action = ""
+        note = "This preview is informational. Local entitlement overrides are disabled in production; plan changes must come from the configured billing or subscription authority."
+    body = f"<section><h1>Plan preview: {proposed.plan.value.title()}</h1><p class='muted'>{html.escape(note)}</p><table><tbody>{rows}</tbody></table>{action}</section>"
     return _page("Plan preview", body)
 
 
 @router.post("/plan")
 async def apply_plan(request: Request) -> RedirectResponse:
     identity = require_request_identity(request)
+    if not _local_plan_changes_allowed(request):
+        raise HTTPException(
+            status_code=403,
+            detail="Local workspace plan changes are disabled in production.",
+        )
     policy = _tenant_policy(request)
     body = await request.body()
     try:

--- a/tests/test_workspace_web.py
+++ b/tests/test_workspace_web.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.request_security import bind_verified_request_identity
+from veridra.runtime_config import RuntimeConfig, RuntimeEnvironment
 from veridra.tenant_workspace_policy import TenantWorkspacePolicy
 from veridra.workspace_policy import PlanName, UsageEvent, UsageKind, WorkspaceConfig
 from veridra.workspace_web import router
@@ -37,10 +38,25 @@ OTHER_OWNER = RequestIdentity(
 )
 
 
-def _client(tmp_path: Path) -> tuple[TestClient, Path]:
+def _client(
+    tmp_path: Path,
+    *,
+    environment: RuntimeEnvironment = RuntimeEnvironment.test,
+) -> tuple[TestClient, Path]:
     root = tmp_path / "tenants"
     app = FastAPI()
     app.state.veridra_tenant_data_root = root
+    app.state.veridra_runtime_config = RuntimeConfig(
+        environment=environment,
+        identity_database=tmp_path / "identity.sqlite3",
+        tenant_data_root=root,
+        trusted_origin="https://veridra.example",
+        allowed_hosts=("veridra.example",),
+        trusted_proxy_ips=(),
+        max_request_body_bytes=1_000_000,
+        bind_host="127.0.0.1",
+        bind_port=8000,
+    )
 
     @app.middleware("http")
     async def identity(
@@ -71,6 +87,7 @@ def test_workspace_requires_identity_and_defaults_to_free(tmp_path: Path) -> Non
     assert "Plan:</strong> Free" in viewer.text
     assert "not payment collection" in viewer.text
     assert "Preview or apply" not in viewer.text
+    assert "href='/commercial'" not in viewer.text
     assert not (root / OWNER.tenant_id / "workspace" / "workspace.json").exists()
 
 
@@ -90,6 +107,7 @@ def test_owner_can_preview_and_apply_tenant_plan_with_audit(tmp_path: Path) -> N
 
     assert preview.status_code == 200
     assert "does not charge a payment method" in preview.text
+    assert "Apply local policy" in preview.text
     assert applied.status_code == 303
     policy = TenantWorkspacePolicy(root)
     workspace = policy.load(OWNER)
@@ -100,6 +118,33 @@ def test_owner_can_preview_and_apply_tenant_plan_with_audit(tmp_path: Path) -> N
     assert changes[0][1].actor_user_id == OWNER.user_id
     assert changes[0][1].previous_plan == PlanName.free
     assert changes[0][1].new_plan == PlanName.professional
+
+
+def test_production_owner_cannot_apply_local_plan_override(tmp_path: Path) -> None:
+    client, root = _client(tmp_path, environment=RuntimeEnvironment.production)
+
+    dashboard = client.get("/workspace", headers={"x-test-role": "owner"})
+    preview = client.get(
+        "/workspace/plan-preview?plan=professional&cycle_anchor_day=15",
+        headers={"x-test-role": "owner"},
+    )
+    applied = client.post(
+        "/workspace/plan",
+        headers={"x-test-role": "owner"},
+        data={"plan": "professional", "cycle_anchor_day": "15"},
+        follow_redirects=False,
+    )
+
+    assert dashboard.status_code == 200
+    assert "Local entitlement overrides are disabled in production." in dashboard.text
+    assert "Preview plan" not in dashboard.text
+    assert preview.status_code == 200
+    assert "informational" in preview.text
+    assert "Apply local policy" not in preview.text
+    assert applied.status_code == 403
+    policy = TenantWorkspacePolicy(root)
+    assert policy.load(OWNER).plan == PlanName.free
+    assert policy.list_plan_changes(OWNER) == []
 
 
 def test_viewer_cannot_preview_or_apply_plan(tmp_path: Path) -> None:


### PR DESCRIPTION
Hardens workspace entitlement management so the local plan switch remains a development/test tool but cannot bypass a future production billing/subscription authority.

What changes:
- detect production from the composed runtime config already stored on app state;
- remove the remaining workspace navigation link to legacy `/commercial`;
- keep local plan preview/apply controls in development and test so deterministic acceptance remains possible;
- in production, show current entitlements plus an explicit message that local overrides are disabled;
- keep plan previews informational in production but remove the apply form;
- reject direct production POST `/workspace/plan` attempts with 403 before any tenant policy mutation;
- add regression coverage proving production cannot self-upgrade, no plan-change audit event is created, and development/test behavior remains intact.

This does not implement billing; it closes the unsafe production bypass until a billing/subscription authority exists.

Do not merge until exact-head full CI succeeds.