### PR TITLE
Enforce agency paid feature entitlements

### DIFF
--- a/src/veridra/tenant_bound_lead_capture.py
+++ b/src/veridra/tenant_bound_lead_capture.py
@@ -30,6 +30,7 @@ from .service import assess_url
 from .tenant_delivery_stores import TenantDeliveryStores
 from .tenant_entitlements import (
     record_bound_tenant_usage,
+    require_bound_tenant_feature,
     reserve_bound_tenant_usage,
 )
 from .tenant_lead_form_store import TenantLeadFormStore, TenantLeadFormStoreError
@@ -54,6 +55,19 @@ def _tenant_root(request: Request) -> Path | None:
 
 def _resolved_tenant_root(request: Request) -> Path:
     return TenantWorkspacePolicy(_tenant_root(request)).root
+
+
+def _require_bound_form_feature(
+    request: Request,
+    binding: LeadFormTenantBinding | None,
+) -> None:
+    if binding is None:
+        return
+    require_bound_tenant_feature(
+        _resolved_tenant_root(request),
+        binding.tenant_id,
+        "embedded_lead_forms",
+    )
 
 
 def _resolve_form(request: Request, form_id: str) -> LeadFormConfig:
@@ -95,6 +109,8 @@ def _attempt_stores(
 
 @router.get("/embed/audit/{form_id}", response_class=HTMLResponse)
 def tenant_bound_embedded_audit_form(form_id: str, request: Request) -> str:
+    binding = _binding(request, form_id)
+    _require_bound_form_feature(request, binding)
     config = _resolve_form(request, form_id)
     _enforce_origin(request, config)
     return _page(config.heading, _public_form(form_id, config), public=True)
@@ -102,8 +118,9 @@ def tenant_bound_embedded_audit_form(form_id: str, request: Request) -> str:
 
 @router.post("/embed/audit/{form_id}", response_class=HTMLResponse)
 async def submit_tenant_bound_embedded_audit(form_id: str, request: Request) -> str:
-    config = _resolve_form(request, form_id)
     binding = _binding(request, form_id)
+    _require_bound_form_feature(request, binding)
+    config = _resolve_form(request, form_id)
     _enforce_origin(request, config)
     _enforce_rate_limit(request, form_id)
     body = await request.body()

--- a/src/veridra/tenant_entitlements.py
+++ b/src/veridra/tenant_entitlements.py
@@ -32,6 +32,17 @@ def active_workspace(
     return policy.load(identity)
 
 
+def _feature_allowed(workspace: WorkspaceConfig, feature: str) -> bool:
+    entitlement = PLAN_CATALOGUE[workspace.plan]
+    allowed = {
+        "white_label": entitlement.white_label,
+        "embedded_lead_forms": entitlement.embedded_lead_forms,
+    }.get(feature)
+    if allowed is None:
+        raise ValueError("Unknown workspace entitlement feature.")
+    return allowed
+
+
 def require_tenant_feature(
     policy: TenantWorkspacePolicy,
     identity: RequestIdentity,
@@ -39,18 +50,12 @@ def require_tenant_feature(
 ) -> None:
     if not tenant_workspace_active(policy, identity):
         return
-    entitlement = PLAN_CATALOGUE[policy.load(identity).plan]
-    allowed = {
-        "white_label": entitlement.white_label,
-        "embedded_lead_forms": entitlement.embedded_lead_forms,
-    }.get(feature)
-    if allowed is None:
-        raise ValueError("Unknown workspace entitlement feature.")
-    if not allowed:
+    workspace = policy.load(identity)
+    if not _feature_allowed(workspace, feature):
         raise HTTPException(
             status_code=403,
             detail=(
-                f"The active {entitlement.name.value} plan does not include "
+                f"The active {workspace.plan.value} plan does not include "
                 f"{feature.replace('_', ' ')}."
             ),
         )
@@ -123,6 +128,25 @@ def _bound_workspace(
 ) -> tuple[WorkspaceStore, UsageLedger]:
     directory = root / tenant_id / "workspace"
     return WorkspaceStore(directory), UsageLedger(directory)
+
+
+def require_bound_tenant_feature(
+    root: Path,
+    tenant_id: str,
+    feature: str,
+) -> None:
+    workspace_store, _ = _bound_workspace(root, tenant_id)
+    if not workspace_store.path.exists():
+        return
+    workspace = workspace_store.load()
+    if not _feature_allowed(workspace, feature):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"The active {workspace.plan.value} plan does not include "
+                f"{feature.replace('_', ' ')}."
+            ),
+        )
 
 
 def reserve_bound_tenant_usage(

--- a/src/veridra/workspace_enforcement.py
+++ b/src/veridra/workspace_enforcement.py
@@ -14,7 +14,7 @@ from .tenant_entitlements import (
     reserve_tenant_usage,
     tenant_workspace_active,
 )
-from .tenant_project_store import TenantProjectStore
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
 from .tenant_workspace_policy import TenantWorkspacePolicy
 from .workspace_policy import UsageKind
 
@@ -27,14 +27,24 @@ def _root(request: Request) -> Path | None:
 
 
 def _profile_write(path: str, method: str) -> bool:
-    return method in {"POST", "PUT"} and path.startswith(
-        "/api/tenant/report-profiles"
+    if method not in {"POST", "PUT"}:
+        return False
+    return path.startswith("/api/tenant/report-profiles") or (
+        path.startswith("/agency/projects/")
+        and (
+            path.endswith("/reports/profile/create")
+            or path.endswith("/reports/profile/edit")
+        )
     )
 
 
 def _lead_form_write(path: str, method: str) -> bool:
-    return method in {"POST", "PUT"} and path.startswith(
-        "/api/tenant/lead-forms"
+    if method not in {"POST", "PUT"}:
+        return False
+    if path.startswith("/api/tenant/lead-forms"):
+        return True
+    return path == "/agency/lead-forms" or (
+        path.startswith("/agency/lead-forms/") and path.endswith("/edit")
     )
 
 
@@ -64,6 +74,36 @@ def _tenant_export(path: str, method: str) -> bool:
     )
 
 
+def _project_id(path: str) -> str | None:
+    prefixes = ("/agency/projects/", "/api/tenant/projects/")
+    for prefix in prefixes:
+        if path.startswith(prefix):
+            remainder = path[len(prefix) :]
+            candidate = remainder.split("/", 1)[0]
+            return candidate or None
+    return None
+
+
+def _project_uses_white_label(request: Request, project_id: str) -> bool:
+    identity = require_request_identity(request)
+    projects = TenantProjectStore(_root(request))
+    try:
+        project = projects.load(identity, projects.ref(identity, project_id))
+    except TenantProjectStoreError:
+        return False
+    return project.profile_id is not None
+
+
+def _branded_report_use(path: str, method: str) -> bool:
+    if path.startswith("/api/tenant/projects/") and method == "GET":
+        return path.endswith(("/report", "/report.pdf", "/export"))
+    return (
+        path.startswith("/agency/projects/")
+        and path.endswith("/reports/send")
+        and method in {"GET", "POST"}
+    )
+
+
 def _preflight(
     request: Request,
     policy: TenantWorkspacePolicy,
@@ -86,6 +126,14 @@ def _preflight(
 
     if _lead_form_write(path, method):
         require_tenant_feature(policy, identity, "embedded_lead_forms")
+
+    project_id = _project_id(path)
+    if (
+        project_id is not None
+        and _branded_report_use(path, method)
+        and _project_uses_white_label(request, project_id)
+    ):
+        require_tenant_feature(policy, identity, "white_label")
 
     if _monitoring_write(path, method):
         reserve_tenant_usage(policy, identity, UsageKind.monitoring_run)

--- a/tests/test_bound_feature_entitlement.py
+++ b/tests/test_bound_feature_entitlement.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.lead_form_tenant_binding import SQLiteLeadFormTenantBindingStore
+from veridra.lead_store import LeadFormConfig
+from veridra.tenant_bound_lead_capture import router
+from veridra.tenant_lead_form_store import TenantLeadFormStore
+from veridra.tenant_workspace_policy import TenantWorkspacePolicy
+from veridra.workspace_policy import PlanName, WorkspaceConfig
+
+NOW = datetime(2026, 8, 20, 12, 0, tzinfo=UTC)
+
+
+def _bound_form(tmp_path: Path) -> tuple[TestClient, TenantWorkspacePolicy, RequestIdentity, str]:
+    root = tmp_path / "tenants"
+    database = tmp_path / "identity.sqlite3"
+    first = SQLiteIdentityBootstrap(database).create_first_owner(
+        tenant_slug="customer-one",
+        tenant_name="Customer one",
+        owner_email="owner@example.com",
+        owner_name="Owner",
+        password="owner-correct-horse-battery",
+        confirmation=BOOTSTRAP_CONFIRMATION,
+        created_at=NOW,
+    )
+    identity = RequestIdentity(
+        user_id=first.user_id,
+        tenant_id=first.tenant_id,
+        membership_role=TenantRole.owner,
+        session_id="b" * 24,
+        authenticated_at=NOW,
+    )
+    form_id = TenantLeadFormStore(root).save(
+        identity,
+        LeadFormConfig(
+            organisation_label="Customer one",
+            consent_text="I agree to be contacted.",
+        ),
+    )
+    SQLiteLeadFormTenantBindingStore(database).bind(
+        form_id=form_id,
+        tenant_id=identity.tenant_id,
+        created_by_user_id=identity.user_id,
+        created_at=NOW,
+    )
+    app = FastAPI()
+    app.state.veridra_identity_database = database
+    app.state.veridra_tenant_data_root = root
+    app.include_router(router)
+    return TestClient(app), TenantWorkspacePolicy(root), identity, form_id
+
+
+def test_bound_form_stops_serving_after_downgrade_and_recovers_on_agency(
+    tmp_path: Path,
+) -> None:
+    client, policy, identity, form_id = _bound_form(tmp_path)
+
+    policy.save(identity, WorkspaceConfig(plan=PlanName.professional))
+    downgraded = client.get(f"/embed/audit/{form_id}")
+
+    policy.save(identity, WorkspaceConfig(plan=PlanName.agency))
+    entitled = client.get(f"/embed/audit/{form_id}")
+
+    assert downgraded.status_code == 403
+    assert downgraded.json()["detail"] == (
+        "The active professional plan does not include embedded lead forms."
+    )
+    assert entitled.status_code == 200
+    assert "Customer one" in entitled.text

--- a/tests/test_commercial_acceptance_runner.py
+++ b/tests/test_commercial_acceptance_runner.py
@@ -19,10 +19,10 @@ def test_runner_drives_commercial_agency_journey() -> None:
     assert 'page.goto(f"{base_url}/onboarding"' in RUNNER
     assert 'page.wait_for_url(f"{base_url}/agency")' in RUNNER
     assert 'page.goto(f"{base_url}/workspace"' in RUNNER
-    assert 'select_option("professional")' in RUNNER
+    assert 'select_option("agency")' in RUNNER
     assert '"Preview plan"' in RUNNER
     assert '"Apply local policy"' in RUNNER
-    assert 'checks["professional_plan_enabled"]' in RUNNER
+    assert 'checks["agency_plan_enabled"]' in RUNNER
     assert '"Create client project"' in RUNNER
     assert '"Prepare branded report"' in RUNNER
     assert '"Create or change report profile"' in RUNNER

--- a/tests/test_workspace_enforcement.py
+++ b/tests/test_workspace_enforcement.py
@@ -62,9 +62,45 @@ def _app(root: Path) -> FastAPI:
     def forms() -> PlainTextResponse:
         return PlainTextResponse("saved")
 
+    @app.post("/agency/projects/{project_id}/reports/profile/create")
+    def agency_profile_create(project_id: str) -> PlainTextResponse:
+        return PlainTextResponse(project_id)
+
+    @app.post("/agency/projects/{project_id}/reports/profile/edit")
+    def agency_profile_edit(project_id: str) -> PlainTextResponse:
+        return PlainTextResponse(project_id)
+
+    @app.post("/agency/projects/{project_id}/reports/profile/select")
+    def agency_profile_select(project_id: str) -> PlainTextResponse:
+        return PlainTextResponse(project_id)
+
+    @app.post("/agency/lead-forms")
+    def agency_form_create() -> PlainTextResponse:
+        return PlainTextResponse("created")
+
+    @app.post("/agency/lead-forms/{form_id}/edit")
+    def agency_form_edit(form_id: str) -> PlainTextResponse:
+        return PlainTextResponse(form_id)
+
+    @app.post("/agency/lead-forms/{form_id}/delete")
+    def agency_form_delete(form_id: str) -> PlainTextResponse:
+        return PlainTextResponse(form_id)
+
+    @app.get("/agency/projects/{project_id}/reports/send")
+    def report_send_preview(project_id: str) -> PlainTextResponse:
+        return PlainTextResponse(project_id)
+
+    @app.post("/agency/projects/{project_id}/reports/send")
+    def report_send(project_id: str) -> PlainTextResponse:
+        return PlainTextResponse(project_id)
+
     @app.post("/agency/projects/{project_id}/monitoring/run")
     def monitoring(project_id: str) -> PlainTextResponse:
         return PlainTextResponse(project_id)
+
+    @app.get("/api/tenant/projects/{project_id}/assessments/{assessment_id}/report")
+    def html_report(project_id: str, assessment_id: str) -> PlainTextResponse:
+        return PlainTextResponse(f"{project_id}:{assessment_id}:html")
 
     @app.get("/api/tenant/projects/{project_id}/assessments/{assessment_id}/report.pdf")
     def pdf(project_id: str, assessment_id: str) -> PlainTextResponse:
@@ -108,6 +144,66 @@ def test_free_plan_blocks_features_and_project_overage(tmp_path: Path) -> None:
         "/api/tenant/report-profiles", headers=headers
     ).status_code == 403
     assert client.post("/api/tenant/lead-forms", headers=headers).status_code == 403
+
+
+def test_agency_routes_obey_feature_catalogue_and_keep_cleanup_open(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "tenants"
+    policy = TenantWorkspacePolicy(root)
+    projects = TenantProjectStore(root)
+    project_id = projects.save(
+        OWNER,
+        ClientProject.build(
+            name="Branded",
+            target_url="https://example.com",
+            profile_id="f" * 24,
+        ),
+    )
+    client = TestClient(_app(root))
+    headers = {"x-test-role": "owner"}
+    form_id = "l" * 24
+    assessment_id = "a" * 24
+
+    policy.save(OWNER, WorkspaceConfig(plan=PlanName.solo))
+    assert client.post(
+        f"/agency/projects/{project_id}/reports/profile/create", headers=headers
+    ).status_code == 403
+    assert client.post(
+        f"/agency/projects/{project_id}/reports/profile/edit", headers=headers
+    ).status_code == 403
+    assert client.get(
+        f"/api/tenant/projects/{project_id}/assessments/{assessment_id}/report",
+        headers=headers,
+    ).status_code == 403
+    assert client.get(
+        f"/agency/projects/{project_id}/reports/send", headers=headers
+    ).status_code == 403
+    assert client.post(
+        f"/agency/projects/{project_id}/reports/profile/select", headers=headers
+    ).status_code == 200
+
+    policy.save(OWNER, WorkspaceConfig(plan=PlanName.professional))
+    assert client.post("/agency/lead-forms", headers=headers).status_code == 403
+    assert client.post(
+        f"/agency/lead-forms/{form_id}/edit", headers=headers
+    ).status_code == 403
+    assert client.post(
+        f"/agency/lead-forms/{form_id}/delete", headers=headers
+    ).status_code == 200
+    assert client.get(
+        f"/api/tenant/projects/{project_id}/assessments/{assessment_id}/report",
+        headers=headers,
+    ).status_code == 200
+
+    policy.save(OWNER, WorkspaceConfig(plan=PlanName.agency))
+    assert client.post(
+        f"/agency/projects/{project_id}/reports/profile/create", headers=headers
+    ).status_code == 200
+    assert client.post("/agency/lead-forms", headers=headers).status_code == 200
+    assert client.post(
+        f"/agency/lead-forms/{form_id}/edit", headers=headers
+    ).status_code == 200
 
 
 def test_agency_plan_records_successful_tenant_usage(tmp_path: Path) -> None:

--- a/tests/test_workspace_enforcement.py
+++ b/tests/test_workspace_enforcement.py
@@ -10,7 +10,9 @@ from fastapi.testclient import TestClient
 
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.project_store import ClientProject
+from veridra.report_profiles import ReportProfile
 from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_profile_store import TenantProfileStore
 from veridra.tenant_project_store import TenantProjectStore
 from veridra.tenant_workspace_policy import TenantWorkspacePolicy
 from veridra.workspace_enforcement import enforce_workspace_policy
@@ -151,13 +153,17 @@ def test_agency_routes_obey_feature_catalogue_and_keep_cleanup_open(
 ) -> None:
     root = tmp_path / "tenants"
     policy = TenantWorkspacePolicy(root)
+    profile_id = TenantProfileStore(root).save(
+        OWNER,
+        ReportProfile(organisation_name="Branded agency"),
+    )
     projects = TenantProjectStore(root)
     project_id = projects.save(
         OWNER,
         ClientProject.build(
             name="Branded",
             target_url="https://example.com",
-            profile_id="f" * 24,
+            profile_id=profile_id,
         ),
     )
     client = TestClient(_app(root))

--- a/tools/commercial_acceptance.py
+++ b/tools/commercial_acceptance.py
@@ -82,9 +82,9 @@ def _onboard(page: Page, base_url: str) -> None:
     page.wait_for_url(f"{base_url}/agency")
 
 
-def _enable_professional_plan(page: Page, base_url: str) -> None:
+def _enable_agency_plan(page: Page, base_url: str) -> None:
     page.goto(f"{base_url}/workspace", wait_until="networkidle")
-    page.locator("select[name='plan']").select_option("professional")
+    page.locator("select[name='plan']").select_option("agency")
     page.get_by_role("button", name="Preview plan").click()
     page.wait_for_url("**/workspace/plan-preview?**")
     page.get_by_role("button", name="Apply local policy").click()
@@ -384,10 +384,10 @@ def run(target: str | None = None) -> Path:
                         _run_real_quick_audit(page, base_url, target)
                         _steps(report).append(_capture(page, run_dir, "02-real-quick-audit"))
                     else:
-                        _enable_professional_plan(page, base_url)
+                        _enable_agency_plan(page, base_url)
                         checks = _checks(report)
-                        checks["professional_plan_enabled"] = (
-                            "Plan: Professional" in page.locator("main").inner_text()
+                        checks["agency_plan_enabled"] = (
+                            "Plan: Agency" in page.locator("main").inner_text()
                         )
                         _create_demo_project(page, base_url)
                         project_url = page.url


### PR DESCRIPTION
Closes paid-feature entitlement bypasses in the normal agency workflow and after downgrade.

What changes:
- extend shared workspace enforcement to agency report-profile create/edit and agency lead-form create/edit routes;
- gate branded report rendering/delivery when a project uses a tenant white-label profile;
- add bound-tenant feature enforcement so embedded public forms stop serving after downgrade;
- keep downgrade cleanup paths open: selecting the default report profile and deleting old lead forms remain allowed;
- refactor tenant feature checks so authenticated and bound-public paths share the same catalogue logic;
- move deterministic commercial acceptance from Professional to Agency, the first plan entitled to both white-label and embedded lead forms;
- add regression coverage for Solo/Professional/Agency boundaries and a downgraded public form that recovers when Agency is restored.

Do not merge until exact-head full CI succeeds.