### PR TITLE
Enforce tenant invitation seat limits

### DIFF
--- a/src/veridra/existing_user_invitation_api.py
+++ b/src/veridra/existing_user_invitation_api.py
@@ -61,7 +61,11 @@ def _service(request: Request) -> SQLiteExistingUserInvitationService:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Invitation service is not configured.",
         )
-    return SQLiteExistingUserInvitationService(database)
+    tenant_root = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return SQLiteExistingUserInvitationService(
+        database,
+        tenant_root if isinstance(tenant_root, Path) else None,
+    )
 
 
 @router.post(
@@ -110,7 +114,10 @@ def accept_existing_user_invitation(
     except TenantInvitationError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invitation is invalid, expired, used, or belongs to another account.",
+            detail=(
+                "Invitation is invalid, expired, used, belongs to another account, "
+                "or the tenant has no available seat."
+            ),
         ) from exc
     return ExistingInvitationAcceptResponse(
         user_id=accepted.user_id,

--- a/src/veridra/existing_user_invitations.py
+++ b/src/veridra/existing_user_invitations.py
@@ -16,9 +16,9 @@ from .tenant_invitations import (
 
 
 class SQLiteExistingUserInvitationService:
-    def __init__(self, database: Path) -> None:
+    def __init__(self, database: Path, tenant_data_root: Path | None = None) -> None:
         self.database = database
-        self.base = SQLiteTenantInvitationService(database)
+        self.base = SQLiteTenantInvitationService(database, tenant_data_root)
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.database)
@@ -150,6 +150,10 @@ class SQLiteExistingUserInvitationService:
                 raise TenantInvitationError(
                     "The user already belongs to this tenant."
                 )
+            self.base.require_seat_capacity(
+                connection,
+                tenant_id=invitation["tenant_id"],
+            )
             role = TenantRole(invitation["role"])
             connection.execute(
                 """INSERT INTO memberships

--- a/src/veridra/invitation_api.py
+++ b/src/veridra/invitation_api.py
@@ -68,7 +68,11 @@ def _service(request: Request) -> SQLiteTenantInvitationService:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Invitation service is not configured.",
         )
-    return SQLiteTenantInvitationService(database)
+    tenant_root = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return SQLiteTenantInvitationService(
+        database,
+        tenant_root if isinstance(tenant_root, Path) else None,
+    )
 
 
 def _conflict(exc: TenantInvitationError) -> HTTPException:
@@ -168,7 +172,7 @@ def accept_invitation(
     except TenantInvitationError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invitation is invalid, expired, or already used.",
+            detail="Invitation is invalid, expired, already used, or the tenant has no available seat.",
         ) from exc
     return InvitationAcceptResponse(
         user_id=accepted.user_id,

--- a/src/veridra/invitation_api.py
+++ b/src/veridra/invitation_api.py
@@ -172,7 +172,10 @@ def accept_invitation(
     except TenantInvitationError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Invitation is invalid, expired, already used, or the tenant has no available seat.",
+            detail=(
+                "Invitation is invalid, expired, already used, "
+                "or the tenant has no available seat."
+            ),
         ) from exc
     return InvitationAcceptResponse(
         user_id=accepted.user_id,

--- a/src/veridra/tenant_entitlements.py
+++ b/src/veridra/tenant_entitlements.py
@@ -130,6 +130,13 @@ def _bound_workspace(
     return WorkspaceStore(directory), UsageLedger(directory)
 
 
+def bound_tenant_max_users(root: Path, tenant_id: str) -> int | None:
+    workspace_store, _ = _bound_workspace(root, tenant_id)
+    if not workspace_store.path.exists():
+        return None
+    return PLAN_CATALOGUE[workspace_store.load().plan].max_users
+
+
 def require_bound_tenant_feature(
     root: Path,
     tenant_id: str,

--- a/src/veridra/tenant_invitations.py
+++ b/src/veridra/tenant_invitations.py
@@ -10,6 +10,7 @@ from typing import cast
 
 from .identity_tenancy import AccountStatus, AuthenticatedUser, TenantRole
 from .password_auth import hash_password
+from .tenant_entitlements import bound_tenant_max_users
 
 
 class TenantInvitationError(RuntimeError):
@@ -43,8 +44,9 @@ class AcceptedInvitation:
 
 
 class SQLiteTenantInvitationService:
-    def __init__(self, database: Path) -> None:
+    def __init__(self, database: Path, tenant_data_root: Path | None = None) -> None:
         self.database = database
+        self.tenant_data_root = tenant_data_root
 
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.database)
@@ -93,6 +95,25 @@ class SQLiteTenantInvitationService:
             role=TenantRole(row["role"]),
             expires_at=datetime.fromisoformat(row["expires_at"]),
         )
+
+    def require_seat_capacity(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        tenant_id: str,
+    ) -> None:
+        if self.tenant_data_root is None:
+            return
+        max_users = bound_tenant_max_users(self.tenant_data_root, tenant_id)
+        if max_users is None:
+            return
+        row = connection.execute(
+            "SELECT COUNT(*) AS count FROM memberships WHERE tenant_id = ? AND active = 1",
+            (tenant_id,),
+        ).fetchone()
+        active_users = int(row["count"]) if row is not None else 0
+        if active_users >= max_users:
+            raise TenantInvitationError("The active plan seat allowance is exhausted.")
 
     def issue(
         self,
@@ -313,6 +334,7 @@ class SQLiteTenantInvitationService:
             ).fetchone()
             if existing_user is not None:
                 raise TenantInvitationError("Invitation cannot create this account.")
+            self.require_seat_capacity(connection, tenant_id=row["tenant_id"])
             user = AuthenticatedUser.build(
                 email=row["email"],
                 display_name=display_name,

--- a/tests/test_tenant_seat_entitlements.py
+++ b/tests/test_tenant_seat_entitlements.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from veridra.existing_user_invitations import SQLiteExistingUserInvitationService
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_tenancy import (
+    AccountStatus,
+    AuthenticatedUser,
+    Tenant,
+    TenantMembership,
+    TenantRole,
+)
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+from veridra.tenant_invitations import SQLiteTenantInvitationService, TenantInvitationError
+from veridra.workspace_policy import PlanName, WorkspaceConfig, WorkspaceStore
+
+NOW = datetime(2026, 8, 20, 12, 30, tzinfo=UTC)
+PASSWORD = "invited-correct-horse-battery"
+
+
+def _bootstrap(database: Path) -> tuple[str, str]:
+    result = SQLiteIdentityBootstrap(database).create_first_owner(
+        tenant_slug="customer-one",
+        tenant_name="Customer one",
+        owner_email="owner@example.com",
+        owner_name="Owner",
+        password="owner-correct-horse-battery",
+        confirmation=BOOTSTRAP_CONFIRMATION,
+        created_at=NOW,
+    )
+    return result.tenant_id, result.user_id
+
+
+def _workspace(root: Path, tenant_id: str, plan: PlanName) -> None:
+    WorkspaceStore(root / tenant_id / "workspace").save(WorkspaceConfig(plan=plan))
+
+
+def _active_members(database: Path, tenant_id: str) -> int:
+    with sqlite3.connect(database) as connection:
+        row = connection.execute(
+            "SELECT COUNT(*) FROM memberships WHERE tenant_id = ? AND active = 1",
+            (tenant_id,),
+        ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _user_exists(database: Path, email: str) -> bool:
+    with sqlite3.connect(database) as connection:
+        row = connection.execute(
+            "SELECT 1 FROM users WHERE email = ?",
+            (email,),
+        ).fetchone()
+    return row is not None
+
+
+def test_new_user_acceptance_is_atomic_at_plan_seat_limit(tmp_path: Path) -> None:
+    database = tmp_path / "identity.sqlite3"
+    root = tmp_path / "tenants"
+    tenant_id, owner_id = _bootstrap(database)
+    service = SQLiteTenantInvitationService(database, root)
+    _workspace(root, tenant_id, PlanName.free)
+
+    first = service.issue(
+        tenant_id=tenant_id,
+        created_by_user_id=owner_id,
+        email="first@example.com",
+        role=TenantRole.analyst,
+        now=NOW,
+    )
+    with pytest.raises(TenantInvitationError, match="seat allowance"):
+        service.accept(
+            token=first.token,
+            display_name="First user",
+            password=PASSWORD,
+            now=NOW,
+        )
+
+    assert _active_members(database, tenant_id) == 1
+    assert not _user_exists(database, "first@example.com")
+    assert len(service.list_active(tenant_id=tenant_id, now=NOW)) == 1
+
+    _workspace(root, tenant_id, PlanName.professional)
+    accepted = service.accept(
+        token=first.token,
+        display_name="First user",
+        password=PASSWORD,
+        now=NOW,
+    )
+    assert accepted.tenant_id == tenant_id
+
+    second = service.issue(
+        tenant_id=tenant_id,
+        created_by_user_id=owner_id,
+        email="second@example.com",
+        role=TenantRole.viewer,
+        now=NOW,
+    )
+    service.accept(
+        token=second.token,
+        display_name="Second user",
+        password=PASSWORD,
+        now=NOW,
+    )
+    assert _active_members(database, tenant_id) == 3
+
+    third = service.issue(
+        tenant_id=tenant_id,
+        created_by_user_id=owner_id,
+        email="third@example.com",
+        role=TenantRole.sales,
+        now=NOW,
+    )
+    with pytest.raises(TenantInvitationError, match="seat allowance"):
+        service.accept(
+            token=third.token,
+            display_name="Third user",
+            password=PASSWORD,
+            now=NOW,
+        )
+    assert _active_members(database, tenant_id) == 3
+    assert not _user_exists(database, "third@example.com")
+
+
+def test_existing_user_acceptance_respects_target_tenant_seats(tmp_path: Path) -> None:
+    database = tmp_path / "identity.sqlite3"
+    root = tmp_path / "tenants"
+    target_id, owner_id = _bootstrap(database)
+    store = SQLiteIdentityRecordStore(database)
+    source = Tenant.build(slug="source", display_name="Source", now=NOW)
+    existing = AuthenticatedUser.build(
+        email="existing@example.com",
+        display_name="Existing",
+        now=NOW,
+    ).model_copy(update={"status": AccountStatus.active, "email_verified_at": NOW})
+    store.save_tenant(source)
+    store.save_user(existing)
+    store.save_membership(
+        TenantMembership(
+            tenant_id=source.id,
+            user_id=existing.id,
+            role=TenantRole.viewer,
+            active=True,
+            created_at=NOW,
+        )
+    )
+    service = SQLiteExistingUserInvitationService(database, root)
+    invitation = service.issue(
+        tenant_id=target_id,
+        created_by_user_id=owner_id,
+        email=str(existing.email),
+        role=TenantRole.analyst,
+        now=NOW,
+    )
+    _workspace(root, target_id, PlanName.free)
+
+    with pytest.raises(TenantInvitationError, match="seat allowance"):
+        service.accept(token=invitation.token, user_id=existing.id, now=NOW)
+    assert _active_members(database, target_id) == 1
+
+    _workspace(root, target_id, PlanName.professional)
+    accepted = service.accept(token=invitation.token, user_id=existing.id, now=NOW)
+    assert accepted.tenant_id == target_id
+    assert accepted.user_id == existing.id
+    assert _active_members(database, target_id) == 2
+
+
+def test_unconfigured_tenant_policy_preserves_invitation_compatibility(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "identity.sqlite3"
+    root = tmp_path / "tenants"
+    tenant_id, owner_id = _bootstrap(database)
+    service = SQLiteTenantInvitationService(database, root)
+    invitation = service.issue(
+        tenant_id=tenant_id,
+        created_by_user_id=owner_id,
+        email="compat@example.com",
+        role=TenantRole.viewer,
+        now=NOW,
+    )
+
+    accepted = service.accept(
+        token=invitation.token,
+        display_name="Compatibility user",
+        password=PASSWORD,
+        now=NOW,
+    )
+
+    assert accepted.tenant_id == tenant_id
+    assert _active_members(database, tenant_id) == 2


### PR DESCRIPTION
Enforces the plan catalogue's real tenant seat allowance where an invitation actually becomes an active membership.

What changes:
- expose the tenant-bound max-users entitlement from workspace policy;
- bind new-user and existing-user invitation services to the tenant data root when available;
- check active membership count inside each existing `BEGIN IMMEDIATE` acceptance transaction before creating/inserting the new membership;
- reject over-capacity acceptance without consuming the invitation;
- for new users, roll back before creating an orphan user or password credential;
- preserve legacy/unconfigured behavior when no tenant workspace policy exists;
- keep invitation issuance permissive so multiple pending invites can exist, while acceptance remains the authoritative serialized seat boundary;
- add regression coverage for Free, Professional exact capacity, existing-user joins, rollback behavior and unconfigured compatibility.

Do not merge until exact-head full CI succeeds.