### PR TITLE
Add tenant-native Team management

### DIFF
--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -47,6 +47,7 @@ from .tenant_profile_api import router as tenant_profile_router
 from .tenant_project_api import router as tenant_project_router
 from .tenant_report_api import router as tenant_report_router
 from .tenant_task_api import router as tenant_task_router
+from .tenant_team_web import router as tenant_team_router
 from .version import __version__
 from .workspace_enforcement import enforce_workspace_policy
 from .workspace_members_web import router as workspace_members_router
@@ -114,6 +115,7 @@ app.include_router(tenant_bound_lead_capture_router)
 app.include_router(pdf_router)
 app.include_router(crawl_profile_router)
 app.include_router(workspace_router)
+app.include_router(tenant_team_router)
 app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)

--- a/src/veridra/tenant_team_web.py
+++ b/src/veridra/tenant_team_web.py
@@ -1,0 +1,205 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+import sqlite3
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .agency_navigation import agency_navigation
+from .existing_user_invitations import SQLiteExistingUserInvitationService
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    TenantRole,
+    require_tenant_capability,
+)
+from .request_security import require_request_identity
+from .tenant_entitlements import bound_tenant_max_users
+from .tenant_invitations import SQLiteTenantInvitationService, TenantInvitationError
+
+router = APIRouter(prefix="/workspace", tags=["tenant-team"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1080px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}.row{display:grid;grid-template-columns:2fr 1fr;gap:12px}label{display:block;font-weight:700;margin:10px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:9px 13px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.danger{background:#a23333}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:9px 12px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}code{overflow-wrap:anywhere}@media(max-width:760px){.row{grid-template-columns:1fr}table{display:block;overflow:auto}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _database(request: Request) -> Path:
+    store = getattr(request.app.state, "veridra_identity_store", None)
+    database = getattr(store, "database", None)
+    if not isinstance(database, Path):
+        raise HTTPException(status_code=503, detail="Team identity storage is not configured.")
+    return database
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _require(identity: RequestIdentity) -> None:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_memberships)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="Team management is not permitted.") from exc
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _members(database: Path, tenant_id: str) -> list[sqlite3.Row]:
+    connection = sqlite3.connect(database)
+    connection.row_factory = sqlite3.Row
+    try:
+        return connection.execute(
+            """SELECT u.email, u.display_name, m.role, m.active, m.created_at
+            FROM memberships m
+            JOIN users u ON u.id = m.user_id
+            WHERE m.tenant_id = ?
+            ORDER BY m.active DESC, u.display_name, u.email""",
+            (tenant_id,),
+        ).fetchall()
+    finally:
+        connection.close()
+
+
+def _existing_user(database: Path, email: str) -> bool:
+    with sqlite3.connect(database) as connection:
+        return connection.execute(
+            "SELECT 1 FROM users WHERE email = ?",
+            (email.strip().lower(),),
+        ).fetchone() is not None
+
+
+def _service(request: Request) -> SQLiteTenantInvitationService:
+    return SQLiteTenantInvitationService(_database(request), _root(request))
+
+
+def _existing_service(request: Request) -> SQLiteExistingUserInvitationService:
+    return SQLiteExistingUserInvitationService(_database(request), _root(request))
+
+
+def _token_page(identity: RequestIdentity, *, email: str, token: str, action: str) -> str:
+    navigation = agency_navigation(identity, current="team")
+    body = f"""{navigation}<section><p><a href='/workspace/members'>Team</a></p><h1>{html.escape(action)}</h1><p class='notice success'><strong>Invitation ready for {html.escape(email)}.</strong></p><p>Copy this one-time token now and send it to the intended recipient through a trusted channel. Veridra stores only its hash.</p><p><code>{html.escape(token)}</code></p><p class='muted'>The token expires under the invitation policy and will not be shown again after leaving this page.</p><p><a class='button' href='/workspace/members'>Return to Team</a></p></section>"""
+    return _page("Team invitation", body)
+
+
+@router.get("/members", response_class=HTMLResponse)
+def tenant_team(request: Request) -> str:
+    identity = require_request_identity(request)
+    _require(identity)
+    database = _database(request)
+    rows = _members(database, identity.tenant_id)
+    active_count = sum(1 for row in rows if bool(row["active"]))
+    root = _root(request)
+    seat_limit = bound_tenant_max_users(root, identity.tenant_id) if root is not None else None
+    seat_text = (
+        f"{active_count} / {seat_limit} active seats"
+        if seat_limit is not None
+        else f"{active_count} active seats · tenant plan policy not configured"
+    )
+    member_rows = "".join(
+        "<tr><td><strong>{name}</strong><br>{email}</td><td>{role}</td><td>{status}</td><td>{created}</td></tr>".format(
+            name=html.escape(row["display_name"]),
+            email=html.escape(row["email"]),
+            role=html.escape(str(row["role"]).replace("_", " ").title()),
+            status="Active" if bool(row["active"]) else "Inactive",
+            created=html.escape(row["created_at"]),
+        )
+        for row in rows
+    ) or "<tr><td colspan='4'>No tenant memberships were found.</td></tr>"
+    invitations = _service(request).list_active(tenant_id=identity.tenant_id)
+    invitation_rows = "".join(
+        "<tr><td>{email}</td><td>{role}</td><td>{expires}</td><td><div class='actions'><form method='post' action='/workspace/members/invitations/{identifier}/resend'><button class='secondary' type='submit'>Resend token</button></form><form method='post' action='/workspace/members/invitations/{identifier}/cancel'><button class='danger' type='submit'>Cancel</button></form></div></td></tr>".format(
+            email=html.escape(invitation.email),
+            role=html.escape(invitation.role.value.title()),
+            expires=html.escape(invitation.expires_at.isoformat()),
+            identifier=html.escape(invitation.id, quote=True),
+        )
+        for invitation in invitations
+    ) or "<tr><td colspan='4'>No active invitations.</td></tr>"
+    roles = "".join(
+        f"<option value='{role.value}'>{html.escape(role.value.replace('_', ' ').title())}</option>"
+        for role in TenantRole
+        if role is not TenantRole.owner
+    )
+    navigation = agency_navigation(identity, current="team")
+    body = f"""{navigation}<section><p><a href='/agency'>Agency home</a></p><h1>Team</h1><p><strong>{html.escape(seat_text)}</strong></p><p class='muted'>These are real authenticated tenant memberships. Seat capacity is enforced again atomically when an invitation is accepted, so pending invitations cannot overbook the plan.</p></section><section><h2>Invite a team member</h2><form method='post' action='/workspace/members/invite'><div class='row'><div><label for='email'>Email</label><input id='email' name='email' type='email' maxlength='320' required></div><div><label for='role'>Role</label><select id='role' name='role'>{roles}</select></div></div><p class='muted'>Veridra automatically uses the authenticated existing-user flow when this email already belongs to an active account.</p><button type='submit'>Create invitation</button></form></section><section><h2>Members</h2><table><thead><tr><th>Member</th><th>Role</th><th>Status</th><th>Joined</th></tr></thead><tbody>{member_rows}</tbody></table></section><section><h2>Pending invitations</h2><table><thead><tr><th>Email</th><th>Role</th><th>Expires</th><th>Actions</th></tr></thead><tbody>{invitation_rows}</tbody></table></section>"""
+    return _page("Tenant team", body)
+
+
+@router.post("/members/invite", response_class=HTMLResponse)
+async def invite_team_member(request: Request) -> str:
+    identity = require_request_identity(request)
+    _require(identity)
+    values = _values(await request.body())
+    email = _one(values, "email").lower()
+    try:
+        role = TenantRole(_one(values, "role"))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invitation role is invalid.") from exc
+    if role is TenantRole.owner:
+        raise HTTPException(status_code=400, detail="Owner invitations are not permitted.")
+    database = _database(request)
+    try:
+        if _existing_user(database, email):
+            issued = _existing_service(request).issue(
+                tenant_id=identity.tenant_id,
+                created_by_user_id=identity.user_id,
+                email=email,
+                role=role,
+            )
+        else:
+            issued = _service(request).issue(
+                tenant_id=identity.tenant_id,
+                created_by_user_id=identity.user_id,
+                email=email,
+                role=role,
+            )
+    except TenantInvitationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return _token_page(identity, email=issued.email, token=issued.token, action="Invitation created")
+
+
+@router.post("/members/invitations/{invitation_id}/cancel")
+def cancel_team_invitation(invitation_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    _require(identity)
+    try:
+        _service(request).cancel(
+            tenant_id=identity.tenant_id,
+            invitation_id=invitation_id,
+        )
+    except TenantInvitationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return RedirectResponse("/workspace/members", status_code=303)
+
+
+@router.post("/members/invitations/{invitation_id}/resend", response_class=HTMLResponse)
+def resend_team_invitation(invitation_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    _require(identity)
+    try:
+        issued = _service(request).resend(
+            tenant_id=identity.tenant_id,
+            invitation_id=invitation_id,
+            created_by_user_id=identity.user_id,
+        )
+    except TenantInvitationError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return _token_page(identity, email=issued.email, token=issued.token, action="Invitation token replaced")

--- a/tests/test_tenant_team_web.py
+++ b/tests/test_tenant_team_web.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.request_security import bind_verified_request_identity
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+from veridra.tenant_invitations import SQLiteTenantInvitationService
+from veridra.tenant_team_web import router
+from veridra.workspace_policy import PlanName, WorkspaceConfig, WorkspaceStore
+
+NOW = datetime(2026, 8, 20, 13, 0, tzinfo=UTC)
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Path, Path, RequestIdentity]:
+    database = tmp_path / "identity.sqlite3"
+    root = tmp_path / "tenants"
+    created = SQLiteIdentityBootstrap(database).create_first_owner(
+        tenant_slug="customer-one",
+        tenant_name="Customer one",
+        owner_email="owner@example.com",
+        owner_name="Owner Name",
+        password="owner-correct-horse-battery",
+        confirmation=BOOTSTRAP_CONFIRMATION,
+        created_at=NOW,
+    )
+    owner = RequestIdentity(
+        user_id=created.user_id,
+        tenant_id=created.tenant_id,
+        membership_role=TenantRole.owner,
+        session_id="team-owner-session-00001",
+        authenticated_at=NOW,
+    )
+    viewer = RequestIdentity(
+        user_id="2" * 24,
+        tenant_id=created.tenant_id,
+        membership_role=TenantRole.viewer,
+        session_id="team-viewer-session-0001",
+        authenticated_at=NOW,
+    )
+    WorkspaceStore(root / created.tenant_id / "workspace").save(
+        WorkspaceConfig(plan=PlanName.agency)
+    )
+    app = FastAPI()
+    app.state.veridra_identity_store = SQLiteIdentityRecordStore(database)
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "owner":
+            bind_verified_request_identity(request, owner)
+        elif role == "viewer":
+            bind_verified_request_identity(request, viewer)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app), database, root, owner
+
+
+def test_team_page_is_tenant_native_and_permission_bound(tmp_path: Path) -> None:
+    client, _, _, _ = _client(tmp_path)
+
+    anonymous = client.get("/workspace/members")
+    viewer = client.get("/workspace/members", headers={"x-test-role": "viewer"})
+    owner = client.get("/workspace/members", headers={"x-test-role": "owner"})
+
+    assert anonymous.status_code == 401
+    assert viewer.status_code == 403
+    assert owner.status_code == 200
+    assert "href='/workspace/members' aria-current='page'" in owner.text
+    assert "Owner Name" in owner.text
+    assert "owner@example.com" in owner.text
+    assert "1 / 10 active seats" in owner.text
+    assert "real authenticated tenant memberships" in owner.text
+    assert "href='/members'" not in owner.text
+
+
+def test_team_invitation_create_resend_and_cancel(tmp_path: Path) -> None:
+    client, database, root, owner = _client(tmp_path)
+    headers = {"x-test-role": "owner"}
+
+    created = client.post(
+        "/workspace/members/invite",
+        headers=headers,
+        data={"email": "analyst@example.com", "role": "analyst"},
+    )
+
+    assert created.status_code == 200
+    assert "Invitation ready for analyst@example.com" in created.text
+    assert "Veridra stores only its hash" in created.text
+    service = SQLiteTenantInvitationService(database, root)
+    active = service.list_active(tenant_id=owner.tenant_id, now=NOW)
+    assert len(active) == 1
+    invitation_id = active[0].id
+
+    listed = client.get("/workspace/members", headers=headers)
+    assert "analyst@example.com" in listed.text
+    assert "Resend token" in listed.text
+    assert "Cancel" in listed.text
+
+    resent = client.post(
+        f"/workspace/members/invitations/{invitation_id}/resend",
+        headers=headers,
+    )
+    assert resent.status_code == 200
+    assert "Invitation token replaced" in resent.text
+    replacement = service.list_active(tenant_id=owner.tenant_id, now=NOW)
+    assert len(replacement) == 1
+    assert replacement[0].id != invitation_id
+
+    cancelled = client.post(
+        f"/workspace/members/invitations/{replacement[0].id}/cancel",
+        headers=headers,
+        follow_redirects=False,
+    )
+    assert cancelled.status_code == 303
+    assert cancelled.headers["location"] == "/workspace/members"
+    assert service.list_active(tenant_id=owner.tenant_id, now=NOW) == ()
+
+
+def test_team_rejects_owner_invitation(tmp_path: Path) -> None:
+    client, _, _, _ = _client(tmp_path)
+
+    response = client.post(
+        "/workspace/members/invite",
+        headers={"x-test-role": "owner"},
+        data={"email": "other@example.com", "role": "owner"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Owner invitations are not permitted."


### PR DESCRIPTION
Replaces the broken Team destination with a real tenant-qualified membership and invitation workflow.

What changes:
- add authenticated `/workspace/members` backed by the real identity database rather than legacy process-global MemberStore data;
- show real tenant memberships, roles, active/inactive status and join timestamps;
- show active seat use against the tenant workspace plan limit when configured;
- list real pending tenant invitations;
- allow membership managers to issue invitations, automatically choosing the existing-user invitation service when the email already belongs to an account;
- show the newly issued one-time token only in the immediate authenticated response while the database retains only its hash;
- allow resend/token rotation and cancellation of pending invitations;
- keep owner invitations forbidden;
- mount the route in the composed runtime at the exact `/workspace/members` destination already used by agency navigation;
- add functional coverage for identity/permission boundaries, tenant seat display, no legacy `/members` escape, invitation create/list/resend/cancel and owner-role rejection.

Do not merge until exact-head full CI succeeds.