### PR TITLE
Add provider-neutral subscription authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The core evidence model is:
 - project-attached remediation task creation and management from saved findings;
 - white-label report-profile creation and in-place editing, plus branded HTML, PDF and evidence-ZIP generation from tenant-qualified project data;
 - durable monitoring jobs with idempotent enqueueing, worker leases, stale-lease recovery, bounded retries and a separate worker CLI;
+- plan feature, usage and user-seat entitlement enforcement, including downgrade behavior;
+- a provider-neutral subscription authority that can project authenticated external subscription events into tenant plan, status and billing-cycle entitlements with idempotency, ordering checks and durable evidence;
 - health/readiness endpoints, trusted hosts, explicit proxy boundaries, bounded request bodies and fail-closed production runtime validation;
 - an agency workflow home that separates temporary quick audits from persistent client projects and exposes only tenant-qualified normal-user operations;
 - deterministic comparisons, history, evidence packages and CI validation.
@@ -38,7 +40,7 @@ The core evidence model is:
 
 The repository quality gate includes Ruff, strict mypy, pytest, a deterministic repository audit, a Chromium browser audit and an isolated commercial-acceptance journey.
 
-The commercial acceptance runner exercises onboarding, Professional entitlement, a client project, branded HTML/PDF output, a tenant-bound lead form and public preview, lead qualification/follow-up, remediation-task creation/management and monitoring. It captures browser evidence and fails on false checks or unexpected request failures.
+The commercial acceptance runner exercises onboarding, Agency entitlement, a client project, branded HTML/PDF output, a tenant-bound lead form and public preview, lead qualification/follow-up, remediation-task creation/management and monitoring. It captures browser evidence and fails on false checks or unexpected request failures.
 
 These checks verify repository behavior; they do not replace deployment-specific acceptance testing or an independent security assessment.
 
@@ -46,9 +48,11 @@ These checks verify repository behavior; they do not replace deployment-specific
 
 The application provides explicit development, test and production modes; mandatory durable paths and trusted origins in production; trusted-host and proxy boundaries; bounded request bodies; health/readiness endpoints; and separate web and monitoring-worker processes.
 
-A concrete hosted environment still requires infrastructure provisioning, TLS termination, process supervision, backups, monitoring, SMTP configuration, secrets management and deployment-specific validation. Billing collection and subscription lifecycle management are not complete.
+The composed runtime exposes the tenant-native agency and API workflow rather than the old standalone global browser trees. Compatibility router modules remain in the repository for isolated migration or compatibility use.
 
-Legacy compatibility routes remain mounted for older workflows, but the normal authenticated agency home now keeps users inside tenant-qualified project, lead, lead-form and workspace operations.
+A controlled `veridra-subscription-apply` command provides the provider-neutral entitlement projection boundary. It does not authenticate provider webhooks or collect payment; a payment-provider adapter must verify provider events before invoking this authority.
+
+A concrete hosted environment still requires infrastructure provisioning, TLS termination, process supervision, backups, monitoring, SMTP configuration, secrets management and deployment-specific validation. Payment collection, provider webhook authentication and customer-facing subscription management are not complete.
 
 ## Important AI terminology
 
@@ -94,4 +98,4 @@ Passive security findings describe observable public posture only. Accessibility
 
 The authenticated agency workflow now covers the original commercial parity path: audit → project → white-label report → lead capture/qualification → remediation → monitoring/proof of improvement.
 
-The next coherent priority is deployment and commercial hardening rather than another broad feature layer: provision and validate a hosted environment, complete operational integrations such as SMTP/secrets/backups/monitoring, complete billing/subscription lifecycle management, and continue isolating or retiring legacy global compatibility surfaces where tenant-native replacements already exist.
+The next coherent priority is deployment and commercial hardening rather than another broad feature layer: integrate an authenticated payment-provider adapter with the subscription authority, provision and validate a hosted environment, and complete operational integrations such as SMTP, secrets, backups and monitoring.

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -35,6 +35,37 @@ VERIDRA_MAX_REQUEST_BODY_BYTES=1000000
 
 Set `VERIDRA_TRUSTED_PROXY_IPS` only when a reverse proxy connects directly to the application. List only immediate proxy IP addresses. Forwarded headers from every other peer are rejected, and Uvicorn proxy-header interpretation remains disabled.
 
+## Subscription authority boundary
+
+Production users cannot apply local plan overrides. Subscription-driven entitlement changes must come through a controlled billing integration.
+
+The provider-neutral projection command is:
+
+```text
+veridra-subscription-apply \
+  --tenant-id <tenant-id> \
+  --provider <provider-key> \
+  --event-id <verified-provider-event-id> \
+  --subscription-id <provider-subscription-id> \
+  --plan <free|solo|professional|agency> \
+  --status <active|suspended> \
+  --cycle-anchor-day <1-28> \
+  --occurred-at <timezone-aware-provider-timestamp>
+```
+
+This command is not a webhook verifier and is not a payment API. Invoke it only after a trusted adapter has authenticated the provider event and mapped provider-specific subscription states into Veridra's plan/status model.
+
+The authority:
+
+- keeps provider event identity and subscription identity as evidence;
+- rejects a provider event ID reused with different data;
+- treats exact event replay as idempotent;
+- rejects stale or timestamp-ambiguous events rather than silently overwriting newer state;
+- preserves the tenant workspace display name while projecting plan, status and cycle anchor;
+- rolls back the workspace projection if durable subscription-event evidence cannot be written.
+
+Restrict execution of this command and write access to the tenant-data root to the billing integration/service account. Provider secrets, webhook signing secrets and raw payment payloads must not be passed through command-line arguments or stored in tenant workspace evidence.
+
 ## Reverse proxy boundary
 
 Terminate public TLS at a controlled reverse proxy. The proxy should:
@@ -75,11 +106,12 @@ Back up these assets as one consistency set:
 
 - identity SQLite database;
 - tenant project, lead, assessment, report-profile and delivery data;
+- tenant workspace policy, usage and subscription-event evidence;
 - durable monitoring-job SQLite database.
 
 Test restoration in an isolated environment. A backup that has not been restored successfully is not considered verified.
 
-During recovery, prevent workers from leasing jobs until the identity and tenant-data snapshots are both restored.
+During recovery, prevent workers and billing integrations from writing tenant state until the identity and tenant-data snapshots are both restored.
 
 ## Logging and secrets
 
@@ -89,7 +121,8 @@ Never log:
 - password-reset or invitation tokens;
 - `Authorization` headers;
 - SMTP passwords;
-- raw request bodies containing personal data;
+- payment-provider secrets or webhook signing secrets;
+- raw request bodies containing personal or payment data;
 - environment-variable dumps.
 
 Operational logs may include bounded internal identifiers and generic error categories where needed, but should avoid combining tenant identifiers with unnecessary personal data.
@@ -114,8 +147,10 @@ This repository does not prescribe systemd, Windows Services, Docker Compose, Ku
 - trusted proxy IPs contain only immediate proxies;
 - `/health` and `/ready` are monitored separately;
 - filesystem permissions use least privilege;
-- backup and restore have been tested;
+- backup and restore have been tested, including subscription-event evidence;
 - identity migrations complete before worker scheduling resumes;
+- subscription-provider events are authenticated before entitlement projection;
+- billing integration credentials and webhook secrets are supplied outside source control;
 - secrets are supplied outside source control;
 - log access is restricted;
 - exact deployed commit and validation evidence are recorded.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ veridra-audit = "veridra.audit:main"
 veridra-project-migrate = "veridra.project_migration_cli:main"
 veridra-identity-bootstrap = "veridra.identity_bootstrap_cli:main"
 veridra-monitoring-worker = "veridra.monitoring_worker_cli:main"
+veridra-subscription-apply = "veridra.subscription_authority_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/subscription_authority.py
+++ b/src/veridra/subscription_authority.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .tenant_project_store import default_tenant_data_directory
+from .workspace_policy import PlanName, WorkspaceConfig, WorkspaceStatus, WorkspaceStore
+
+_TENANT_ID = re.compile(r"^[0-9a-f]{24}$")
+
+
+class SubscriptionAuthorityError(RuntimeError):
+    pass
+
+
+class SubscriptionUpdate(BaseModel):
+    """Provider-neutral subscription state that may authoritatively drive entitlements."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    tenant_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    provider: str = Field(pattern=r"^[a-z0-9][a-z0-9_-]{0,31}$")
+    provider_event_id: str = Field(min_length=1, max_length=160)
+    external_subscription_id: str = Field(min_length=1, max_length=160)
+    plan: PlanName
+    status: WorkspaceStatus
+    cycle_anchor_day: int = Field(ge=1, le=28)
+    occurred_at: datetime
+
+    @field_validator("occurred_at")
+    @classmethod
+    def require_aware_timestamp(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("Subscription event timestamps must include a timezone.")
+        return value.astimezone(UTC)
+
+
+class AppliedSubscriptionEvent(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    update: SubscriptionUpdate
+    previous_workspace: WorkspaceConfig
+    projected_workspace: WorkspaceConfig
+    applied_at: datetime
+
+
+class SubscriptionApplyResult(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    event_key: str
+    applied: bool
+    workspace: WorkspaceConfig
+
+
+def _atomic_json(path: Path, payload: BaseModel) -> None:
+    content = json.dumps(
+        payload.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile(
+        mode="wb",
+        dir=path.parent,
+        prefix=f".{path.stem}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        temporary.write(content)
+        temporary.flush()
+        os.fsync(temporary.fileno())
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(path)
+
+
+def _event_key(update: SubscriptionUpdate) -> str:
+    identity = f"{update.provider}\0{update.provider_event_id}".encode()
+    return hashlib.sha256(identity).hexdigest()[:24]
+
+
+class SubscriptionAuthority:
+    """Apply trusted billing-provider state to an existing tenant workspace.
+
+    The authority is intentionally not an HTTP endpoint. Provider adapters or controlled
+    operational tooling may call it after authenticating and validating provider events.
+    """
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or default_tenant_data_directory()
+
+    def _workspace_directory(self, tenant_id: str) -> Path:
+        if _TENANT_ID.fullmatch(tenant_id) is None:
+            raise SubscriptionAuthorityError("Tenant identifier is invalid.")
+        return self.root / tenant_id / "workspace"
+
+    def _events_directory(self, tenant_id: str) -> Path:
+        return self._workspace_directory(tenant_id) / "subscription-events"
+
+    def _event_path(self, update: SubscriptionUpdate) -> Path:
+        return self._events_directory(update.tenant_id) / f"{_event_key(update)}.json"
+
+    def list_events(self, tenant_id: str) -> list[AppliedSubscriptionEvent]:
+        directory = self._events_directory(tenant_id)
+        if not directory.exists():
+            return []
+        events: list[AppliedSubscriptionEvent] = []
+        for path in sorted(directory.glob("*.json")):
+            try:
+                event = AppliedSubscriptionEvent.model_validate_json(
+                    path.read_text(encoding="utf-8")
+                )
+            except (OSError, ValueError):
+                continue
+            events.append(event)
+        return sorted(
+            events,
+            key=lambda event: (
+                event.update.occurred_at,
+                event.update.provider,
+                event.update.provider_event_id,
+            ),
+        )
+
+    def apply(
+        self,
+        update: SubscriptionUpdate,
+        *,
+        applied_at: datetime | None = None,
+    ) -> SubscriptionApplyResult:
+        event_path = self._event_path(update)
+        event_key = event_path.stem
+        if event_path.exists():
+            try:
+                existing = AppliedSubscriptionEvent.model_validate_json(
+                    event_path.read_text(encoding="utf-8")
+                )
+            except (OSError, ValueError) as exc:
+                raise SubscriptionAuthorityError(
+                    "Existing subscription event evidence could not be read safely."
+                ) from exc
+            if existing.update != update:
+                raise SubscriptionAuthorityError(
+                    "Provider event identity was reused with different subscription data."
+                )
+            return SubscriptionApplyResult(
+                event_key=event_key,
+                applied=False,
+                workspace=existing.projected_workspace,
+            )
+
+        events = self.list_events(update.tenant_id)
+        if events:
+            latest = events[-1].update
+            if update.occurred_at < latest.occurred_at:
+                raise SubscriptionAuthorityError(
+                    "Stale subscription event cannot replace newer entitlement state."
+                )
+            if update.occurred_at == latest.occurred_at:
+                raise SubscriptionAuthorityError(
+                    "Ambiguous subscription events share the same provider timestamp."
+                )
+
+        workspace_store = WorkspaceStore(self._workspace_directory(update.tenant_id))
+        workspace_existed = workspace_store.path.exists()
+        previous = workspace_store.load()
+        projected = previous.model_copy(
+            update={
+                "plan": update.plan,
+                "status": update.status,
+                "cycle_anchor_day": update.cycle_anchor_day,
+            }
+        )
+        applied_timestamp = applied_at or datetime.now(UTC)
+        if applied_timestamp.tzinfo is None or applied_timestamp.utcoffset() is None:
+            raise SubscriptionAuthorityError("Applied timestamp must include a timezone.")
+        event = AppliedSubscriptionEvent(
+            update=update,
+            previous_workspace=previous,
+            projected_workspace=projected,
+            applied_at=applied_timestamp.astimezone(UTC),
+        )
+
+        try:
+            workspace_store.save(projected)
+            _atomic_json(event_path, event)
+        except Exception as exc:
+            try:
+                if workspace_existed:
+                    workspace_store.save(previous)
+                else:
+                    workspace_store.path.unlink(missing_ok=True)
+            except Exception as rollback_exc:
+                raise SubscriptionAuthorityError(
+                    "Subscription projection failed and workspace rollback also failed."
+                ) from rollback_exc
+            raise SubscriptionAuthorityError(
+                "Subscription event could not be projected safely."
+            ) from exc
+
+        return SubscriptionApplyResult(
+            event_key=event_key,
+            applied=True,
+            workspace=projected,
+        )

--- a/src/veridra/subscription_authority.py
+++ b/src/veridra/subscription_authority.py
@@ -101,6 +101,14 @@ class SubscriptionAuthority:
             raise SubscriptionAuthorityError("Tenant identifier is invalid.")
         return self.root / tenant_id / "workspace"
 
+    def _workspace_store(self, tenant_id: str) -> WorkspaceStore:
+        store = WorkspaceStore(self._workspace_directory(tenant_id))
+        if not store.path.exists():
+            raise SubscriptionAuthorityError(
+                "Subscription authority cannot create an unknown tenant workspace."
+            )
+        return store
+
     def _events_directory(self, tenant_id: str) -> Path:
         return self._workspace_directory(tenant_id) / "subscription-events"
 
@@ -135,6 +143,7 @@ class SubscriptionAuthority:
         *,
         applied_at: datetime | None = None,
     ) -> SubscriptionApplyResult:
+        workspace_store = self._workspace_store(update.tenant_id)
         event_path = self._event_path(update)
         event_key = event_path.stem
         if event_path.exists():
@@ -153,7 +162,7 @@ class SubscriptionAuthority:
             return SubscriptionApplyResult(
                 event_key=event_key,
                 applied=False,
-                workspace=existing.projected_workspace,
+                workspace=workspace_store.load(),
             )
 
         events = self.list_events(update.tenant_id)
@@ -168,8 +177,6 @@ class SubscriptionAuthority:
                     "Ambiguous subscription events share the same provider timestamp."
                 )
 
-        workspace_store = WorkspaceStore(self._workspace_directory(update.tenant_id))
-        workspace_existed = workspace_store.path.exists()
         previous = workspace_store.load()
         projected = previous.model_copy(
             update={
@@ -193,10 +200,7 @@ class SubscriptionAuthority:
             _atomic_json(event_path, event)
         except Exception as exc:
             try:
-                if workspace_existed:
-                    workspace_store.save(previous)
-                else:
-                    workspace_store.path.unlink(missing_ok=True)
+                workspace_store.save(previous)
             except Exception as rollback_exc:
                 raise SubscriptionAuthorityError(
                     "Subscription projection failed and workspace rollback also failed."

--- a/src/veridra/subscription_authority_cli.py
+++ b/src/veridra/subscription_authority_cli.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from .subscription_authority import (
+    SubscriptionAuthority,
+    SubscriptionAuthorityError,
+    SubscriptionUpdate,
+)
+from .tenant_project_store import default_tenant_data_directory
+from .workspace_policy import PlanName, WorkspaceStatus
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Project an already authenticated billing-provider event into tenant entitlements."
+        )
+    )
+    parser.add_argument("--tenant-id", required=True)
+    parser.add_argument("--provider", required=True)
+    parser.add_argument("--event-id", required=True)
+    parser.add_argument("--subscription-id", required=True)
+    parser.add_argument("--plan", required=True, choices=[plan.value for plan in PlanName])
+    parser.add_argument(
+        "--status",
+        required=True,
+        choices=[status.value for status in WorkspaceStatus],
+    )
+    parser.add_argument("--cycle-anchor-day", required=True, type=int)
+    parser.add_argument(
+        "--occurred-at",
+        required=True,
+        help="Provider event timestamp as timezone-aware ISO-8601 text.",
+    )
+    parser.add_argument(
+        "--tenant-data-root",
+        type=Path,
+        default=None,
+        help="Override the configured tenant-data root.",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = _parser()
+    arguments = parser.parse_args()
+    root = (
+        arguments.tenant_data_root.expanduser().resolve()
+        if arguments.tenant_data_root is not None
+        else default_tenant_data_directory()
+    )
+    try:
+        update = SubscriptionUpdate(
+            tenant_id=arguments.tenant_id,
+            provider=arguments.provider,
+            provider_event_id=arguments.event_id,
+            external_subscription_id=arguments.subscription_id,
+            plan=PlanName(arguments.plan),
+            status=WorkspaceStatus(arguments.status),
+            cycle_anchor_day=arguments.cycle_anchor_day,
+            occurred_at=datetime.fromisoformat(arguments.occurred_at),
+        )
+        result = SubscriptionAuthority(root).apply(update)
+    except (ValueError, ValidationError, SubscriptionAuthorityError) as exc:
+        parser.error(str(exc))
+
+    state = "applied" if result.applied else "already applied"
+    print(
+        f"Subscription event {state}: {result.event_key}; "
+        f"plan={result.workspace.plan.value}; status={result.workspace.status.value}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_subscription_authority.py
+++ b/tests/test_subscription_authority.py
@@ -36,11 +36,22 @@ def _update(
     )
 
 
+def _workspace(
+    tmp_path: Path,
+    config: WorkspaceConfig | None = None,
+) -> WorkspaceStore:
+    workspace = WorkspaceStore(tmp_path / TENANT_ID / "workspace")
+    workspace.save(config or WorkspaceConfig(display_name="Customer workspace"))
+    return workspace
+
+
 def test_subscription_event_projects_entitlements_and_preserves_workspace_name(
     tmp_path: Path,
 ) -> None:
-    workspace = WorkspaceStore(tmp_path / TENANT_ID / "workspace")
-    workspace.save(WorkspaceConfig(display_name="Customer workspace", plan=PlanName.free))
+    workspace = _workspace(
+        tmp_path,
+        WorkspaceConfig(display_name="Customer workspace", plan=PlanName.free),
+    )
     authority = SubscriptionAuthority(tmp_path)
 
     result = authority.apply(_update(), applied_at=NOW + timedelta(seconds=1))
@@ -57,20 +68,43 @@ def test_subscription_event_projects_entitlements_and_preserves_workspace_name(
     assert events[0].projected_workspace.plan is PlanName.agency
 
 
+def test_subscription_authority_refuses_to_create_unknown_tenant_workspace(
+    tmp_path: Path,
+) -> None:
+    authority = SubscriptionAuthority(tmp_path)
+
+    with pytest.raises(SubscriptionAuthorityError, match="unknown tenant workspace"):
+        authority.apply(_update(), applied_at=NOW + timedelta(seconds=1))
+
+    assert not (tmp_path / TENANT_ID / "workspace" / "workspace.json").exists()
+
+
 def test_replaying_same_provider_event_is_idempotent(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
     authority = SubscriptionAuthority(tmp_path)
     update = _update()
 
     first = authority.apply(update, applied_at=NOW + timedelta(seconds=1))
-    second = authority.apply(update, applied_at=NOW + timedelta(minutes=1))
+    authority.apply(
+        _update(
+            event_id="evt-2",
+            occurred_at=NOW + timedelta(minutes=1),
+            plan=PlanName.professional,
+        ),
+        applied_at=NOW + timedelta(minutes=1, seconds=1),
+    )
+    replay = authority.apply(update, applied_at=NOW + timedelta(minutes=2))
 
     assert first.applied is True
-    assert second.applied is False
-    assert second.event_key == first.event_key
-    assert len(authority.list_events(TENANT_ID)) == 1
+    assert replay.applied is False
+    assert replay.event_key == first.event_key
+    assert replay.workspace == workspace.load()
+    assert replay.workspace.plan is PlanName.professional
+    assert len(authority.list_events(TENANT_ID)) == 2
 
 
 def test_provider_event_identity_cannot_be_reused_with_different_data(tmp_path: Path) -> None:
+    _workspace(tmp_path)
     authority = SubscriptionAuthority(tmp_path)
     authority.apply(_update(), applied_at=NOW + timedelta(seconds=1))
 
@@ -82,6 +116,7 @@ def test_provider_event_identity_cannot_be_reused_with_different_data(tmp_path: 
 
 
 def test_stale_and_equal_timestamp_events_cannot_replace_current_state(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
     authority = SubscriptionAuthority(tmp_path)
     authority.apply(_update(event_id="evt-new"), applied_at=NOW + timedelta(seconds=1))
 
@@ -97,10 +132,11 @@ def test_stale_and_equal_timestamp_events_cannot_replace_current_state(tmp_path:
             applied_at=NOW + timedelta(minutes=1),
         )
 
-    assert WorkspaceStore(tmp_path / TENANT_ID / "workspace").load().plan is PlanName.agency
+    assert workspace.load().plan is PlanName.agency
 
 
 def test_suspension_event_projects_workspace_status(tmp_path: Path) -> None:
+    _workspace(tmp_path)
     authority = SubscriptionAuthority(tmp_path)
     authority.apply(_update(), applied_at=NOW + timedelta(seconds=1))
 
@@ -121,10 +157,8 @@ def test_event_evidence_failure_rolls_back_workspace_projection(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    directory = tmp_path / TENANT_ID / "workspace"
-    workspace = WorkspaceStore(directory)
     original = WorkspaceConfig(display_name="Keep me", plan=PlanName.solo)
-    workspace.save(original)
+    workspace = _workspace(tmp_path, original)
     authority = SubscriptionAuthority(tmp_path)
 
     def fail_event_write(path: Path, payload: object) -> None:

--- a/tests/test_subscription_authority.py
+++ b/tests/test_subscription_authority.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+import veridra.subscription_authority as subscription_module
+from veridra.subscription_authority import (
+    SubscriptionAuthority,
+    SubscriptionAuthorityError,
+    SubscriptionUpdate,
+)
+from veridra.workspace_policy import PlanName, WorkspaceConfig, WorkspaceStatus, WorkspaceStore
+
+TENANT_ID = "a" * 24
+NOW = datetime(2026, 8, 20, 14, 0, tzinfo=UTC)
+
+
+def _update(
+    *,
+    event_id: str = "evt-1",
+    occurred_at: datetime = NOW,
+    plan: PlanName = PlanName.agency,
+    status: WorkspaceStatus = WorkspaceStatus.active,
+) -> SubscriptionUpdate:
+    return SubscriptionUpdate(
+        tenant_id=TENANT_ID,
+        provider="test-provider",
+        provider_event_id=event_id,
+        external_subscription_id="sub-123",
+        plan=plan,
+        status=status,
+        cycle_anchor_day=20,
+        occurred_at=occurred_at,
+    )
+
+
+def test_subscription_event_projects_entitlements_and_preserves_workspace_name(
+    tmp_path: Path,
+) -> None:
+    workspace = WorkspaceStore(tmp_path / TENANT_ID / "workspace")
+    workspace.save(WorkspaceConfig(display_name="Customer workspace", plan=PlanName.free))
+    authority = SubscriptionAuthority(tmp_path)
+
+    result = authority.apply(_update(), applied_at=NOW + timedelta(seconds=1))
+
+    assert result.applied is True
+    assert result.workspace.display_name == "Customer workspace"
+    assert result.workspace.plan is PlanName.agency
+    assert result.workspace.status is WorkspaceStatus.active
+    assert result.workspace.cycle_anchor_day == 20
+    assert workspace.load() == result.workspace
+    events = authority.list_events(TENANT_ID)
+    assert len(events) == 1
+    assert events[0].previous_workspace.plan is PlanName.free
+    assert events[0].projected_workspace.plan is PlanName.agency
+
+
+def test_replaying_same_provider_event_is_idempotent(tmp_path: Path) -> None:
+    authority = SubscriptionAuthority(tmp_path)
+    update = _update()
+
+    first = authority.apply(update, applied_at=NOW + timedelta(seconds=1))
+    second = authority.apply(update, applied_at=NOW + timedelta(minutes=1))
+
+    assert first.applied is True
+    assert second.applied is False
+    assert second.event_key == first.event_key
+    assert len(authority.list_events(TENANT_ID)) == 1
+
+
+def test_provider_event_identity_cannot_be_reused_with_different_data(tmp_path: Path) -> None:
+    authority = SubscriptionAuthority(tmp_path)
+    authority.apply(_update(), applied_at=NOW + timedelta(seconds=1))
+
+    with pytest.raises(SubscriptionAuthorityError, match="identity was reused"):
+        authority.apply(
+            _update(plan=PlanName.professional),
+            applied_at=NOW + timedelta(minutes=1),
+        )
+
+
+def test_stale_and_equal_timestamp_events_cannot_replace_current_state(tmp_path: Path) -> None:
+    authority = SubscriptionAuthority(tmp_path)
+    authority.apply(_update(event_id="evt-new"), applied_at=NOW + timedelta(seconds=1))
+
+    with pytest.raises(SubscriptionAuthorityError, match="Stale subscription event"):
+        authority.apply(
+            _update(event_id="evt-old", occurred_at=NOW - timedelta(seconds=1)),
+            applied_at=NOW + timedelta(minutes=1),
+        )
+
+    with pytest.raises(SubscriptionAuthorityError, match="Ambiguous subscription events"):
+        authority.apply(
+            _update(event_id="evt-same-time"),
+            applied_at=NOW + timedelta(minutes=1),
+        )
+
+    assert WorkspaceStore(tmp_path / TENANT_ID / "workspace").load().plan is PlanName.agency
+
+
+def test_suspension_event_projects_workspace_status(tmp_path: Path) -> None:
+    authority = SubscriptionAuthority(tmp_path)
+    authority.apply(_update(), applied_at=NOW + timedelta(seconds=1))
+
+    result = authority.apply(
+        _update(
+            event_id="evt-suspended",
+            occurred_at=NOW + timedelta(minutes=1),
+            status=WorkspaceStatus.suspended,
+        ),
+        applied_at=NOW + timedelta(minutes=1, seconds=1),
+    )
+
+    assert result.workspace.status is WorkspaceStatus.suspended
+    assert result.workspace.plan is PlanName.agency
+
+
+def test_event_evidence_failure_rolls_back_workspace_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    directory = tmp_path / TENANT_ID / "workspace"
+    workspace = WorkspaceStore(directory)
+    original = WorkspaceConfig(display_name="Keep me", plan=PlanName.solo)
+    workspace.save(original)
+    authority = SubscriptionAuthority(tmp_path)
+
+    def fail_event_write(path: Path, payload: object) -> None:
+        raise OSError("simulated event write failure")
+
+    monkeypatch.setattr(subscription_module, "_atomic_json", fail_event_write)
+
+    with pytest.raises(SubscriptionAuthorityError, match="could not be projected safely"):
+        authority.apply(_update(), applied_at=NOW + timedelta(seconds=1))
+
+    assert workspace.load() == original
+    assert authority.list_events(TENANT_ID) == []


### PR DESCRIPTION
Introduces the first production subscription-lifecycle authority without coupling Veridra to a payment vendor.

What changes:
- add a provider-neutral subscription event model that projects trusted external plan/status/cycle state into the existing tenant workspace policy;
- preserve workspace display identity while updating entitlement-driving fields;
- make exact provider event replay idempotent;
- reject reused event IDs with changed payloads, stale events and timestamp-ambiguous events;
- persist durable subscription-event evidence with previous/projected workspace state;
- roll back workspace projection when event evidence cannot be persisted;
- expose a controlled `veridra-subscription-apply` CLI for already-authenticated provider integrations rather than adding a public billing endpoint;
- add regression coverage for projection, replay, conflicts, ordering, suspension and rollback;
- reconcile README/runtime status and production operations documentation, including Agency commercial acceptance and the already-concealed legacy browser trees.

This does not collect payment or authenticate provider webhooks. A future Stripe/Paddle/etc. adapter must verify provider events before invoking this authority.

Do not merge until exact-head full CI succeeds.