### PR TITLE
Wire production password reset email

### DIFF
--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -31,9 +31,38 @@ VERIDRA_ALLOWED_HOSTS=app.example.com
 VERIDRA_BIND_HOST=127.0.0.1
 VERIDRA_BIND_PORT=8000
 VERIDRA_MAX_REQUEST_BODY_BYTES=1000000
+
+VERIDRA_SMTP_HOST=smtp.example.com
+VERIDRA_SMTP_PORT=587
+VERIDRA_SMTP_ENCRYPTION=starttls
+VERIDRA_SMTP_SENDER=security@example.com
+VERIDRA_SMTP_SENDER_NAME=Veridra
 ```
 
+If the SMTP provider requires authentication, also set:
+
+```text
+VERIDRA_SMTP_USERNAME=<provider-user>
+VERIDRA_SMTP_PASSWORD=<secret>
+```
+
+`VERIDRA_SMTP_PASSWORD_ENV` may name a different environment variable containing the password. The password itself is never part of `SmtpConfig` or durable delivery-attempt evidence.
+
+Production startup fails closed when SMTP host/sender configuration is missing, when SMTP configuration is invalid, or when a username is configured without its password secret. Development and test environments may run without SMTP.
+
+Only STARTTLS and implicit TLS modes are supported. SMTP uses the operating system/Python CA trust store for certificate verification and has a bounded connection timeout.
+
 Set `VERIDRA_TRUSTED_PROXY_IPS` only when a reverse proxy connects directly to the application. List only immediate proxy IP addresses. Forwarded headers from every other peer are rejected, and Uvicorn proxy-header interpretation remains disabled.
+
+## Transactional identity email
+
+Password recovery is wired to the configured SMTP transport in the composed runtime. A valid reset request for an existing account produces a one-time token and sends it by email; missing accounts receive the same public `202` response without generating a delivery.
+
+Until a dedicated browser reset screen is added, the email provides the one-time token, expiry, and the existing `/api/auth/password-recovery/reset` API path. Do not publish a synthetic reset URL that the application cannot yet serve.
+
+Identity-email attempts are written beside the identity database under `identity-email-deliveries/`. Evidence records recipient, status, subject, message digest and a one-way delivery key. The reset token itself is not persisted in delivery evidence.
+
+SMTP delivery failures are recorded but do not alter the public recovery response. This preserves the anti-account-enumeration boundary. Alert operationally on failed identity-email attempts.
 
 ## Subscription authority boundary
 
@@ -82,7 +111,7 @@ The application does not use forwarded headers to redefine the ASGI scheme, host
 
 Use a dedicated service account. Grant it:
 
-- read/write access to the identity database and its parent directory;
+- read/write access to the identity database, identity-email delivery evidence and their parent directory;
 - read/write access to the tenant-data root;
 - no write access to application source or package files;
 - no interactive login unless operationally required.
@@ -92,8 +121,8 @@ Do not place durable data inside an ephemeral container layer or temporary check
 ## Startup and migration order
 
 1. Stop web and worker processes before restoring or manually migrating data.
-2. Back up the identity database and tenant-data root together.
-3. Start one web process to apply versioned identity migrations.
+2. Back up the identity database, identity-email delivery evidence and tenant-data root together.
+3. Start one web process to apply versioned identity migrations and validate SMTP configuration.
 4. Confirm `/health` returns `200` and `/ready` returns `200`.
 5. Start the remaining web processes.
 6. Resume scheduled worker invocations.
@@ -105,6 +134,7 @@ A `503` readiness response means a configured durable dependency is unavailable.
 Back up these assets as one consistency set:
 
 - identity SQLite database;
+- identity-email delivery evidence;
 - tenant project, lead, assessment, report-profile and delivery data;
 - tenant workspace policy, usage and subscription-event evidence;
 - durable monitoring-job SQLite database.
@@ -135,7 +165,7 @@ Configure the service manager to:
 - run the monitoring worker on a fixed schedule;
 - prevent overlapping worker starts unless intentional concurrency has been tested;
 - capture stdout and stderr in protected logs;
-- alert on repeated web restarts, readiness failures and terminal monitoring-job failures.
+- alert on repeated web restarts, readiness failures, failed identity-email attempts and terminal monitoring-job failures.
 
 This repository does not prescribe systemd, Windows Services, Docker Compose, Kubernetes or a cloud-specific supervisor. Deployment tooling must preserve the same process and trust boundaries.
 
@@ -145,9 +175,11 @@ This repository does not prescribe systemd, Windows Services, Docker Compose, Ku
 - public TLS and allowed host match `VERIDRA_TRUSTED_ORIGIN`;
 - the application port is not directly internet-accessible;
 - trusted proxy IPs contain only immediate proxies;
+- SMTP TLS mode, sender identity and authentication secret are configured and tested;
+- password-reset delivery succeeds without storing the reset token in durable email evidence;
 - `/health` and `/ready` are monitored separately;
 - filesystem permissions use least privilege;
-- backup and restore have been tested, including subscription-event evidence;
+- backup and restore have been tested, including identity-email and subscription-event evidence;
 - identity migrations complete before worker scheduling resumes;
 - subscription-provider events are authenticated before entitlement projection;
 - billing integration credentials and webhook secrets are supplied outside source control;

--- a/src/veridra/identity_email_delivery.py
+++ b/src/veridra/identity_email_delivery.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import smtplib
+from collections.abc import Callable
+from datetime import UTC, datetime
+from email.message import EmailMessage
+from enum import StrEnum
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+from .email_delivery import EmailDeliveryError, EmailStatus, SmtpConfig, _default_sender
+from .password_recovery_api import PasswordResetDelivery
+
+_MAX_MESSAGE_BYTES = 128_000
+
+
+class IdentityEmailKind(StrEnum):
+    password_reset = "password_reset"
+
+
+class IdentityEmailAttempt(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: IdentityEmailKind
+    recipient: EmailStr
+    attempted_at: datetime
+    status: EmailStatus
+    subject: str = Field(min_length=1, max_length=200)
+    message_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    delivery_key: str = Field(pattern=r"^[0-9a-f]{24}$")
+    error: str = Field(default="", max_length=1000)
+
+
+class IdentityEmailAttemptStore:
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def _path(self, identifier: str) -> Path:
+        if len(identifier) != 24 or any(char not in "0123456789abcdef" for char in identifier):
+            raise EmailDeliveryError("Invalid identity-email attempt identifier.")
+        return self.directory / f"{identifier}.json"
+
+    def save(self, attempt: IdentityEmailAttempt) -> str:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        content = json.dumps(
+            attempt.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        identifier = hashlib.sha256(content).hexdigest()[:24]
+        destination = self._path(identifier)
+        with NamedTemporaryFile(
+            mode="wb",
+            dir=self.directory,
+            prefix=f".{identifier}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(destination)
+        return identifier
+
+    def list(self) -> list[tuple[str, IdentityEmailAttempt]]:
+        if not self.directory.exists():
+            return []
+        attempts: list[tuple[str, IdentityEmailAttempt]] = []
+        for path in sorted(self.directory.glob("*.json")):
+            try:
+                attempt = IdentityEmailAttempt.model_validate_json(
+                    path.read_text(encoding="utf-8")
+                )
+            except (OSError, ValueError):
+                continue
+            attempts.append((path.stem, attempt))
+        return sorted(attempts, key=lambda item: (item[1].attempted_at, item[0]), reverse=True)
+
+
+IdentityEmailSender = Callable[[SmtpConfig, EmailMessage], None]
+
+
+class PasswordResetEmailAdapter:
+    def __init__(
+        self,
+        *,
+        config: SmtpConfig,
+        store: IdentityEmailAttemptStore,
+        sender: IdentityEmailSender = _default_sender,
+    ) -> None:
+        self.config = config
+        self.store = store
+        self.sender = sender
+
+    def __call__(self, delivery: PasswordResetDelivery) -> None:
+        subject = "Your Veridra password reset token"
+        message = EmailMessage()
+        message["From"] = f"{self.config.sender_name} <{self.config.sender_email}>"
+        message["To"] = delivery.email
+        message["Subject"] = subject
+        message.set_content(
+            "A password reset was requested for your Veridra account.\n\n"
+            f"One-time reset token:\n{delivery.token}\n\n"
+            f"Expires: {delivery.expires_at.astimezone(UTC).isoformat()}\n\n"
+            "Submit this token with your new password to "
+            "/api/auth/password-recovery/reset.\n\n"
+            "If you did not request this reset, ignore this email."
+        )
+        raw = message.as_bytes()
+        if len(raw) > _MAX_MESSAGE_BYTES:
+            raise EmailDeliveryError("Generated password-reset email exceeds the delivery limit.")
+
+        status = EmailStatus.delivered
+        error = ""
+        try:
+            self.sender(self.config, message)
+        except (OSError, smtplib.SMTPException, EmailDeliveryError, ValueError) as exc:
+            status = EmailStatus.failed
+            error = str(exc)[:1000]
+
+        self.store.save(
+            IdentityEmailAttempt(
+                kind=IdentityEmailKind.password_reset,
+                recipient=delivery.email,
+                attempted_at=datetime.now(UTC),
+                status=status,
+                subject=subject,
+                message_sha256=hashlib.sha256(raw).hexdigest(),
+                delivery_key=hashlib.sha256(delivery.token.encode("utf-8")).hexdigest()[:24],
+                error=error,
+            )
+        )

--- a/src/veridra/identity_email_delivery.py
+++ b/src/veridra/identity_email_delivery.py
@@ -115,7 +115,7 @@ class PasswordResetEmailAdapter:
         )
         raw = message.as_bytes()
         if len(raw) > _MAX_MESSAGE_BYTES:
-            raise EmailDeliveryError("Generated password-reset email exceeds the delivery limit.")
+            return
 
         status = EmailStatus.delivered
         error = ""
@@ -125,15 +125,17 @@ class PasswordResetEmailAdapter:
             status = EmailStatus.failed
             error = str(exc)[:1000]
 
-        self.store.save(
-            IdentityEmailAttempt(
-                kind=IdentityEmailKind.password_reset,
-                recipient=delivery.email,
-                attempted_at=datetime.now(UTC),
-                status=status,
-                subject=subject,
-                message_sha256=hashlib.sha256(raw).hexdigest(),
-                delivery_key=hashlib.sha256(delivery.token.encode("utf-8")).hexdigest()[:24],
-                error=error,
-            )
+        attempt = IdentityEmailAttempt(
+            kind=IdentityEmailKind.password_reset,
+            recipient=delivery.email,
+            attempted_at=datetime.now(UTC),
+            status=status,
+            subject=subject,
+            message_sha256=hashlib.sha256(raw).hexdigest(),
+            delivery_key=hashlib.sha256(delivery.token.encode("utf-8")).hexdigest()[:24],
+            error=error,
         )
+        try:
+            self.store.save(attempt)
+        except (OSError, EmailDeliveryError, ValueError):
+            return

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -36,6 +36,7 @@ from .public_web import ToolDefinition
 from .public_web import router as public_router
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
+from .runtime_email import configure_runtime_email
 from .session_api import router as session_router
 from .tenant_assessment_routes import router as tenant_assessment_router
 from .tenant_bound_lead_capture import router as tenant_bound_lead_capture_router
@@ -60,6 +61,7 @@ runtime_config.configure_directories()
 app.state.veridra_runtime_config = runtime_config
 if runtime_config.tenant_data_root is not None:
     app.state.veridra_tenant_data_root = runtime_config.tenant_data_root
+configure_runtime_email(app, runtime_config)
 app.add_middleware(
     RuntimeBoundaryMiddleware,
     max_body_bytes=runtime_config.max_request_body_bytes,

--- a/src/veridra/runtime_email.py
+++ b/src/veridra/runtime_email.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .email_delivery import EmailDeliveryError, SmtpConfig, default_email_directory
+from .identity_email_delivery import IdentityEmailAttemptStore, PasswordResetEmailAdapter
+from .runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
+
+
+def configure_runtime_email(app: FastAPI, config: RuntimeConfig) -> None:
+    try:
+        smtp = SmtpConfig.from_environment()
+    except EmailDeliveryError as exc:
+        raise RuntimeConfigurationError("SMTP configuration is invalid.") from exc
+
+    if config.environment is RuntimeEnvironment.production:
+        if smtp is None:
+            raise RuntimeConfigurationError(
+                "VERIDRA_SMTP_HOST and VERIDRA_SMTP_SENDER are required in production."
+            )
+        if smtp.username and smtp.password() is None:
+            raise RuntimeConfigurationError(
+                f"{smtp.password_env} is required when VERIDRA_SMTP_USERNAME is configured."
+            )
+
+    if smtp is None:
+        return
+
+    if config.identity_database is not None:
+        attempt_directory = config.identity_database.parent / "identity-email-deliveries"
+    else:
+        attempt_directory = default_email_directory() / "identity"
+    app.state.veridra_smtp_config = smtp
+    app.state.veridra_password_reset_delivery = PasswordResetEmailAdapter(
+        config=smtp,
+        store=IdentityEmailAttemptStore(attempt_directory),
+    )

--- a/tests/test_identity_email_delivery.py
+++ b/tests/test_identity_email_delivery.py
@@ -4,6 +4,8 @@ from datetime import UTC, datetime, timedelta
 from email.message import EmailMessage
 from pathlib import Path
 
+import pytest
+
 from veridra.email_delivery import EmailEncryption, EmailStatus, SmtpConfig
 from veridra.identity_email_delivery import IdentityEmailAttemptStore, PasswordResetEmailAdapter
 from veridra.password_recovery_api import PasswordResetDelivery
@@ -22,6 +24,14 @@ def _config() -> SmtpConfig:
     )
 
 
+def _delivery() -> PasswordResetDelivery:
+    return PasswordResetDelivery(
+        email="owner@example.com",
+        token=TOKEN,
+        expires_at=NOW + timedelta(minutes=30),
+    )
+
+
 def test_password_reset_email_sends_token_but_evidence_keeps_only_hash(
     tmp_path: Path,
 ) -> None:
@@ -33,13 +43,7 @@ def test_password_reset_email_sends_token_but_evidence_keeps_only_hash(
         sender=lambda config, message: messages.append(message),
     )
 
-    adapter(
-        PasswordResetDelivery(
-            email="owner@example.com",
-            token=TOKEN,
-            expires_at=NOW + timedelta(minutes=30),
-        )
-    )
+    adapter(_delivery())
 
     assert len(messages) == 1
     assert TOKEN in messages[0].get_content()
@@ -58,15 +62,32 @@ def test_password_reset_smtp_failure_is_persisted_without_raising(tmp_path: Path
         raise OSError("smtp unavailable")
 
     adapter = PasswordResetEmailAdapter(config=_config(), store=store, sender=fail)
-    adapter(
-        PasswordResetDelivery(
-            email="owner@example.com",
-            token=TOKEN,
-            expires_at=NOW + timedelta(minutes=30),
-        )
-    )
+    adapter(_delivery())
 
     attempts = store.list()
     assert len(attempts) == 1
     assert attempts[0][1].status is EmailStatus.failed
     assert attempts[0][1].error == "smtp unavailable"
+
+
+def test_password_reset_evidence_failure_does_not_escape_delivery_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    messages: list[EmailMessage] = []
+    store = IdentityEmailAttemptStore(tmp_path)
+
+    def fail_save(attempt: object) -> str:
+        raise OSError("evidence unavailable")
+
+    monkeypatch.setattr(store, "save", fail_save)
+    adapter = PasswordResetEmailAdapter(
+        config=_config(),
+        store=store,
+        sender=lambda config, message: messages.append(message),
+    )
+
+    adapter(_delivery())
+
+    assert len(messages) == 1
+    assert store.list() == []

--- a/tests/test_identity_email_delivery.py
+++ b/tests/test_identity_email_delivery.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from email.message import EmailMessage
+from pathlib import Path
+
+from veridra.email_delivery import EmailEncryption, EmailStatus, SmtpConfig
+from veridra.identity_email_delivery import IdentityEmailAttemptStore, PasswordResetEmailAdapter
+from veridra.password_recovery_api import PasswordResetDelivery
+
+TOKEN = "reset-token-that-must-never-be-persisted"
+NOW = datetime(2026, 8, 20, 15, 0, tzinfo=UTC)
+
+
+def _config() -> SmtpConfig:
+    return SmtpConfig(
+        host="smtp.example.test",
+        port=587,
+        encryption=EmailEncryption.starttls,
+        sender_email="security@example.com",
+        sender_name="Veridra Security",
+    )
+
+
+def test_password_reset_email_sends_token_but_evidence_keeps_only_hash(
+    tmp_path: Path,
+) -> None:
+    messages: list[EmailMessage] = []
+    store = IdentityEmailAttemptStore(tmp_path)
+    adapter = PasswordResetEmailAdapter(
+        config=_config(),
+        store=store,
+        sender=lambda config, message: messages.append(message),
+    )
+
+    adapter(
+        PasswordResetDelivery(
+            email="owner@example.com",
+            token=TOKEN,
+            expires_at=NOW + timedelta(minutes=30),
+        )
+    )
+
+    assert len(messages) == 1
+    assert TOKEN in messages[0].get_content()
+    attempts = store.list()
+    assert len(attempts) == 1
+    assert attempts[0][1].status is EmailStatus.delivered
+    assert attempts[0][1].recipient == "owner@example.com"
+    assert TOKEN not in attempts[0][0]
+    assert TOKEN.encode("utf-8") not in next(tmp_path.glob("*.json")).read_bytes()
+
+
+def test_password_reset_smtp_failure_is_persisted_without_raising(tmp_path: Path) -> None:
+    store = IdentityEmailAttemptStore(tmp_path)
+
+    def fail(config: SmtpConfig, message: EmailMessage) -> None:
+        raise OSError("smtp unavailable")
+
+    adapter = PasswordResetEmailAdapter(config=_config(), store=store, sender=fail)
+    adapter(
+        PasswordResetDelivery(
+            email="owner@example.com",
+            token=TOKEN,
+            expires_at=NOW + timedelta(minutes=30),
+        )
+    )
+
+    attempts = store.list()
+    assert len(attempts) == 1
+    assert attempts[0][1].status is EmailStatus.failed
+    assert attempts[0][1].error == "smtp unavailable"

--- a/tests/test_runtime_email.py
+++ b/tests/test_runtime_email.py
@@ -15,8 +15,16 @@ def _config(tmp_path: Path, environment: RuntimeEnvironment) -> RuntimeConfig:
         environment=environment,
         identity_database=tmp_path / "identity.sqlite3",
         tenant_data_root=tmp_path / "tenants",
-        trusted_origin="https://app.example.com" if environment is RuntimeEnvironment.production else None,
-        allowed_hosts=("app.example.com",) if environment is RuntimeEnvironment.production else (),
+        trusted_origin=(
+            "https://app.example.com"
+            if environment is RuntimeEnvironment.production
+            else None
+        ),
+        allowed_hosts=(
+            ("app.example.com",)
+            if environment is RuntimeEnvironment.production
+            else ()
+        ),
         trusted_proxy_ips=(),
         max_request_body_bytes=1_000_000,
         bind_host="127.0.0.1",

--- a/tests/test_runtime_email.py
+++ b/tests/test_runtime_email.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+
+from veridra.identity_email_delivery import PasswordResetEmailAdapter
+from veridra.runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
+from veridra.runtime_email import configure_runtime_email
+
+
+def _config(tmp_path: Path, environment: RuntimeEnvironment) -> RuntimeConfig:
+    return RuntimeConfig(
+        environment=environment,
+        identity_database=tmp_path / "identity.sqlite3",
+        tenant_data_root=tmp_path / "tenants",
+        trusted_origin="https://app.example.com" if environment is RuntimeEnvironment.production else None,
+        allowed_hosts=("app.example.com",) if environment is RuntimeEnvironment.production else (),
+        trusted_proxy_ips=(),
+        max_request_body_bytes=1_000_000,
+        bind_host="127.0.0.1",
+        bind_port=8000,
+    )
+
+
+def _clear_smtp(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "VERIDRA_SMTP_HOST",
+        "VERIDRA_SMTP_SENDER",
+        "VERIDRA_SMTP_PORT",
+        "VERIDRA_SMTP_ENCRYPTION",
+        "VERIDRA_SMTP_USERNAME",
+        "VERIDRA_SMTP_PASSWORD",
+        "VERIDRA_SMTP_PASSWORD_ENV",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_development_can_run_without_transactional_email(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_smtp(monkeypatch)
+    app = FastAPI()
+
+    configure_runtime_email(app, _config(tmp_path, RuntimeEnvironment.development))
+
+    assert not hasattr(app.state, "veridra_password_reset_delivery")
+
+
+def test_production_requires_smtp_configuration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_smtp(monkeypatch)
+
+    with pytest.raises(RuntimeConfigurationError, match="required in production"):
+        configure_runtime_email(FastAPI(), _config(tmp_path, RuntimeEnvironment.production))
+
+
+def test_production_requires_auth_secret_when_username_is_configured(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_smtp(monkeypatch)
+    monkeypatch.setenv("VERIDRA_SMTP_HOST", "smtp.example.test")
+    monkeypatch.setenv("VERIDRA_SMTP_SENDER", "security@example.com")
+    monkeypatch.setenv("VERIDRA_SMTP_USERNAME", "mailer@example.com")
+
+    with pytest.raises(RuntimeConfigurationError, match="VERIDRA_SMTP_PASSWORD"):
+        configure_runtime_email(FastAPI(), _config(tmp_path, RuntimeEnvironment.production))
+
+
+def test_configured_smtp_installs_password_reset_adapter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_smtp(monkeypatch)
+    monkeypatch.setenv("VERIDRA_SMTP_HOST", "smtp.example.test")
+    monkeypatch.setenv("VERIDRA_SMTP_SENDER", "security@example.com")
+    app = FastAPI()
+
+    configure_runtime_email(app, _config(tmp_path, RuntimeEnvironment.production))
+
+    assert isinstance(app.state.veridra_password_reset_delivery, PasswordResetEmailAdapter)
+    assert app.state.veridra_smtp_config.host == "smtp.example.test"


### PR DESCRIPTION
Completes the composed runtime password-recovery delivery path using Veridra's existing secure SMTP transport.

What changes:
- add a durable password-reset email adapter that sends the one-time token and expiry without persisting the token itself;
- record delivered/failed identity-email attempts with message digest and one-way delivery key;
- preserve the generic password-recovery 202 boundary when SMTP delivery fails, preventing an email outage from becoming an account-existence oracle;
- wire the adapter into the composed runtime whenever SMTP is configured;
- fail production startup closed when SMTP host/sender configuration is missing or invalid, or when SMTP auth is configured without its password secret;
- keep development/test runtime usable without SMTP;
- retain STARTTLS/implicit-TLS behavior and CA verification from the existing SmtpConfig transport;
- document production SMTP variables, backup scope, secrets and password-recovery operational behavior;
- add focused regression coverage for token non-persistence, SMTP failure evidence and production configuration boundaries.

This does not yet add a browser password-reset page or migrate invitation tokens to email delivery.

Do not merge until exact-head full CI succeeds.