### PR TITLE
Add browser authentication and recovery flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The core evidence model is:
 - bounded public website assessment with DNS/IP validation, pinned connections, redirect revalidation and response-size limits;
 - configurable multi-page crawl profiles with same-origin controls, sitemap discovery and page-level evidence;
 - findings covering technical SEO fundamentals, AI crawler policy, AI technical readiness, trust, accessibility heuristics, domain/email posture and passive public security;
-- authenticated users, tenants, memberships, roles, invitations, password recovery and server-side sessions;
+- authenticated users, tenants, memberships, roles, invitations, browser sign-in, password recovery/reset and server-side sessions;
+- production transactional password-reset email through verified TLS SMTP, with generic recovery responses and reset tokens excluded from durable delivery evidence;
 - tenant-qualified projects, leads, lead forms, remediation tasks, monitoring configuration, report profiles, assessments and report artifacts;
 - explicit conversion from completed quick audits or qualified leads into tenant-qualified client projects;
 - tenant-native lead-form creation, editing and deletion with tenant binding, plus lead qualification, ownership, notes and follow-up management;
@@ -46,13 +47,13 @@ These checks verify repository behavior; they do not replace deployment-specific
 
 ## Production foundation and remaining deployment work
 
-The application provides explicit development, test and production modes; mandatory durable paths and trusted origins in production; trusted-host and proxy boundaries; bounded request bodies; health/readiness endpoints; and separate web and monitoring-worker processes.
+The application provides explicit development, test and production modes; mandatory durable paths and trusted origins in production; trusted-host and proxy boundaries; bounded request bodies; health/readiness endpoints; browser authentication/recovery; transactional SMTP password-reset delivery; and separate web and monitoring-worker processes.
 
 The composed runtime exposes the tenant-native agency and API workflow rather than the old standalone global browser trees. Compatibility router modules remain in the repository for isolated migration or compatibility use.
 
 A controlled `veridra-subscription-apply` command provides the provider-neutral entitlement projection boundary. It does not authenticate provider webhooks or collect payment; a payment-provider adapter must verify provider events before invoking this authority.
 
-A concrete hosted environment still requires infrastructure provisioning, TLS termination, process supervision, backups, monitoring, SMTP configuration, secrets management and deployment-specific validation. Payment collection, provider webhook authentication and customer-facing subscription management are not complete.
+A concrete hosted environment still requires infrastructure provisioning, TLS termination, process supervision, backups, monitoring, secrets management and deployment-specific validation. A real SMTP provider/account still has to be selected and configured. Payment collection, provider webhook authentication and customer-facing subscription management are not complete. Invitation delivery remains token/API-oriented rather than a complete customer email/browser acceptance journey.
 
 ## Important AI terminology
 
@@ -86,6 +87,8 @@ For the packaged Windows operational workflow, use the root helper scripts such 
 
 The Windows launcher defaults to `http://127.0.0.1:8010` to avoid common local conflicts. Override it with `VERIDRA_LOCAL_PORT` when needed.
 
+Browser sign-in is served at `/login`; password recovery starts at `/forgot-password`, and reset emails point to `/reset-password?token=...` on the configured trusted origin.
+
 Production configuration is documented in `docs/operations/production-deployment.md` and `docs/architecture/production-runtime-hardening.md`.
 
 ## Safety boundary
@@ -98,4 +101,4 @@ Passive security findings describe observable public posture only. Accessibility
 
 The authenticated agency workflow now covers the original commercial parity path: audit → project → white-label report → lead capture/qualification → remediation → monitoring/proof of improvement.
 
-The next coherent priority is deployment and commercial hardening rather than another broad feature layer: integrate an authenticated payment-provider adapter with the subscription authority, provision and validate a hosted environment, and complete operational integrations such as SMTP, secrets, backups and monitoring.
+The next coherent priority is deployment and commercial hardening rather than another broad feature layer: complete invitation email/browser acceptance, integrate an authenticated payment-provider adapter with the subscription authority, provision and validate a hosted environment, and finish deployment-specific secrets, backups and monitoring.

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -54,15 +54,17 @@ Only STARTTLS and implicit TLS modes are supported. SMTP uses the operating syst
 
 Set `VERIDRA_TRUSTED_PROXY_IPS` only when a reverse proxy connects directly to the application. List only immediate proxy IP addresses. Forwarded headers from every other peer are rejected, and Uvicorn proxy-header interpretation remains disabled.
 
-## Transactional identity email
+## Browser authentication and password recovery
 
-Password recovery is wired to the configured SMTP transport in the composed runtime. A valid reset request for an existing account produces a one-time token and sends it by email; missing accounts receive the same public `202` response without generating a delivery.
+The composed runtime exposes browser authentication at `/login`, password-recovery request at `/forgot-password`, and one-time password reset at `/reset-password`.
 
-Until a dedicated browser reset screen is added, the email provides the one-time token, expiry, and the existing `/api/auth/password-recovery/reset` API path. Do not publish a synthetic reset URL that the application cannot yet serve.
+Browser sign-in reuses the same durable password authenticator, login throttling and server-side session lifecycle as the API. Successful sign-in issues the existing secure session cookie and redirects to `/agency`. Unsafe browser authentication operations enforce `VERIDRA_TRUSTED_ORIGIN`.
 
-Identity-email attempts are written beside the identity database under `identity-email-deliveries/`. Evidence records recipient, status, subject, message digest and a one-way delivery key. The reset token itself is not persisted in delivery evidence.
+Password recovery is wired to the configured SMTP transport. Existing and missing accounts receive the same generic browser response so the flow does not disclose whether an account exists. A valid request for an active account sends an absolute reset link derived from `VERIDRA_TRUSTED_ORIGIN`.
 
-SMTP delivery failures are recorded but do not alter the public recovery response. This preserves the anti-account-enumeration boundary. Alert operationally on failed identity-email attempts.
+Reset pages and login pages return `Cache-Control: no-store`, `Referrer-Policy: no-referrer` and `X-Frame-Options: DENY`. The reset token is carried only in the one-time email link/form and in the existing password-recovery token store as a digest; it is not written to identity-email delivery evidence. Successful reset revokes existing sessions and makes the token unusable again through the existing recovery service.
+
+Identity-email attempts are written beside the identity database under `identity-email-deliveries/`. Evidence records recipient, status, subject, message digest and a one-way delivery key. SMTP or delivery-evidence failures do not alter the public recovery response; alert operationally on failed identity-email attempts.
 
 ## Subscription authority boundary
 
@@ -124,8 +126,9 @@ Do not place durable data inside an ephemeral container layer or temporary check
 2. Back up the identity database, identity-email delivery evidence and tenant-data root together.
 3. Start one web process to apply versioned identity migrations and validate SMTP configuration.
 4. Confirm `/health` returns `200` and `/ready` returns `200`.
-5. Start the remaining web processes.
-6. Resume scheduled worker invocations.
+5. Confirm browser sign-in and a controlled password-reset delivery against the public trusted origin.
+6. Start the remaining web processes.
+7. Resume scheduled worker invocations.
 
 A `503` readiness response means a configured durable dependency is unavailable. It intentionally does not disclose paths or database details.
 
@@ -176,7 +179,9 @@ This repository does not prescribe systemd, Windows Services, Docker Compose, Ku
 - the application port is not directly internet-accessible;
 - trusted proxy IPs contain only immediate proxies;
 - SMTP TLS mode, sender identity and authentication secret are configured and tested;
-- password-reset delivery succeeds without storing the reset token in durable email evidence;
+- browser login enforces same-origin POSTs and issues the secure server-side session cookie;
+- password-reset email contains the trusted-origin browser link and the token is absent from durable email evidence;
+- existing and missing recovery requests remain indistinguishable to the browser client;
 - `/health` and `/ready` are monitored separately;
 - filesystem permissions use least privilege;
 - backup and restore have been tested, including identity-email and subscription-event evidence;

--- a/src/veridra/browser_auth_web.py
+++ b/src/veridra/browser_auth_web.py
@@ -153,9 +153,9 @@ async def login_submit(request: Request) -> HTMLResponse | RedirectResponse:
         tenant_id=records.tenant.id,
         lifetime=lifetime,
     )
-    response = RedirectResponse("/agency", status_code=303)
-    set_session_cookie(response, issued.credential, max_age=int(lifetime.total_seconds()))
-    return response
+    redirect = RedirectResponse("/agency", status_code=303)
+    set_session_cookie(redirect, issued.credential, max_age=int(lifetime.total_seconds()))
+    return redirect
 
 
 @router.get("/forgot-password", response_class=HTMLResponse)

--- a/src/veridra/browser_auth_web.py
+++ b/src/veridra/browser_auth_web.py
@@ -1,0 +1,224 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+import os
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .login_throttle import SQLiteLoginThrottle
+from .password_auth import SQLitePasswordAuthenticator
+from .password_recovery import PasswordRecoveryError, SQLitePasswordRecoveryService
+from .password_recovery_api import PasswordResetDelivery
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .session_api import set_session_cookie
+from .session_lifecycle import SessionLifecycleService
+from .sqlite_identity_store import SQLiteIdentityRecordStore
+
+router = APIRouter(tags=["browser-authentication"])
+PasswordResetDeliveryAdapter = Callable[[PasswordResetDelivery], None]
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:520px;margin:56px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:12px;padding:28px}h1{margin-top:0}label{display:block;font-weight:700;margin:14px 0 5px}input{width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px}button{margin-top:20px;border:0;border-radius:7px;background:#22272d;color:#fff;padding:11px 16px;cursor:pointer}.muted{color:#68707a}.error{border-left:4px solid #b42318;background:#fff1f0;color:#7a271a;padding:12px;margin:0 0 16px}.success{border-left:4px solid #16794a;background:#f0faf5;color:#0d5c38;padding:12px;margin:0 0 16px}.links{margin-top:18px;display:flex;gap:14px;flex-wrap:wrap}a{color:#2457a6}
+"""
+
+
+def _page(title: str, content: str) -> HTMLResponse:
+    document = f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='referrer' content='no-referrer'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{content}</main></body></html>"
+    return HTMLResponse(
+        document,
+        headers={
+            "Cache-Control": "no-store",
+            "Referrer-Policy": "no-referrer",
+            "X-Frame-Options": "DENY",
+        },
+    )
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _database(request: Request) -> Path:
+    value = getattr(request.app.state, "veridra_identity_database", None)
+    if not isinstance(value, Path):
+        raise HTTPException(status_code=503, detail="Authentication is not configured.")
+    return value
+
+
+def _services(
+    request: Request,
+) -> tuple[SQLitePasswordAuthenticator, SessionLifecycleService, SQLiteLoginThrottle]:
+    authenticator = getattr(request.app.state, "veridra_password_authenticator", None)
+    identity_store = getattr(request.app.state, "veridra_identity_store", None)
+    login_throttle = getattr(request.app.state, "veridra_login_throttle", None)
+    if (
+        not isinstance(authenticator, SQLitePasswordAuthenticator)
+        or not isinstance(identity_store, SQLiteIdentityRecordStore)
+        or not isinstance(login_throttle, SQLiteLoginThrottle)
+    ):
+        raise HTTPException(status_code=503, detail="Authentication is not configured.")
+    return authenticator, SessionLifecycleService(identity_store), login_throttle
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Authentication is not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Authentication request is not permitted.") from exc
+
+
+def _login_form(error: str = "", *, reset_complete: bool = False) -> HTMLResponse:
+    notice = ""
+    if reset_complete:
+        notice = "<div class='success' role='status'>Password updated. Sign in with your new password.</div>"
+    elif error:
+        notice = f"<div class='error' role='alert'>{html.escape(error)}</div>"
+    return _page(
+        "Sign in to Veridra",
+        f"<section><h1>Sign in to Veridra</h1><p class='muted'>Open your agency workspace.</p>{notice}<form method='post' action='/login'><label for='tenant_slug'>Workspace slug</label><input id='tenant_slug' name='tenant_slug' minlength='3' maxlength='80' pattern='[a-z0-9]+(?:-[a-z0-9]+)*' autocomplete='organization' required><label for='email'>Email</label><input id='email' name='email' type='email' maxlength='254' autocomplete='username' required><label for='password'>Password</label><input id='password' name='password' type='password' maxlength='1024' autocomplete='current-password' required><button type='submit'>Sign in</button></form><div class='links'><a href='/forgot-password'>Forgot password?</a><a href='/onboarding'>First-time setup</a></div></section>",
+    )
+
+
+def _forgot_form(*, submitted: bool = False) -> HTMLResponse:
+    notice = ""
+    if submitted:
+        notice = "<div class='success' role='status'>If an active account exists for that email, reset instructions have been sent.</div>"
+    return _page(
+        "Reset your Veridra password",
+        f"<section><h1>Reset your password</h1><p class='muted'>Enter the email address used for your Veridra account.</p>{notice}<form method='post' action='/forgot-password'><label for='email'>Email</label><input id='email' name='email' type='email' maxlength='254' autocomplete='email' required><button type='submit'>Send reset instructions</button></form><div class='links'><a href='/login'>Back to sign in</a></div></section>",
+    )
+
+
+def _reset_form(token: str, error: str = "") -> HTMLResponse:
+    notice = f"<div class='error' role='alert'>{html.escape(error)}</div>" if error else ""
+    token_value = html.escape(token, quote=True)
+    return _page(
+        "Choose a new Veridra password",
+        f"<section><h1>Choose a new password</h1><p class='muted'>Use at least 12 characters.</p>{notice}<form method='post' action='/reset-password'><input type='hidden' name='token' value='{token_value}'><label for='new_password'>New password</label><input id='new_password' name='new_password' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><label for='password_confirm'>Repeat new password</label><input id='password_confirm' name='password_confirm' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><button type='submit'>Update password</button></form></section>",
+    )
+
+
+@router.get("/login", response_class=HTMLResponse)
+def login_page(reset: str = "") -> HTMLResponse:
+    return _login_form(reset_complete=reset == "complete")
+
+
+@router.post("/login", response_model=None)
+async def login_submit(request: Request) -> HTMLResponse | RedirectResponse:
+    _trusted_origin(request)
+    values = _values(await request.body())
+    tenant_slug = _one(values, "tenant_slug")
+    email = _one(values, "email").lower()
+    password = values.get("password", [""])[0]
+    authenticator, lifecycle, throttle = _services(request)
+    now = datetime.now(UTC)
+    decision = throttle.check(email=email, tenant_slug=tenant_slug, now=now)
+    if not decision.allowed:
+        response = _login_form("Too many login attempts. Try again later.")
+        response.status_code = 429
+        response.headers["Retry-After"] = str(decision.retry_after_seconds)
+        return response
+    records = authenticator.authenticate(
+        email=email,
+        tenant_slug=tenant_slug,
+        password=password,
+    )
+    if records is None:
+        failure = throttle.record_failure(email=email, tenant_slug=tenant_slug, now=now)
+        if not failure.allowed:
+            response = _login_form("Too many login attempts. Try again later.")
+            response.status_code = 429
+            response.headers["Retry-After"] = str(failure.retry_after_seconds)
+            return response
+        response = _login_form("Invalid login credentials.")
+        response.status_code = 401
+        return response
+    throttle.clear(email=email, tenant_slug=tenant_slug)
+    lifetime = timedelta(hours=8)
+    issued = lifecycle.issue(
+        user_id=records.user.id,
+        tenant_id=records.tenant.id,
+        lifetime=lifetime,
+    )
+    response = RedirectResponse("/agency", status_code=303)
+    set_session_cookie(response, issued.credential, max_age=int(lifetime.total_seconds()))
+    return response
+
+
+@router.get("/forgot-password", response_class=HTMLResponse)
+def forgot_password_page() -> HTMLResponse:
+    return _forgot_form()
+
+
+@router.post("/forgot-password", response_class=HTMLResponse)
+async def forgot_password_submit(request: Request) -> HTMLResponse:
+    _trusted_origin(request)
+    email = _one(_values(await request.body()), "email").lower()
+    issued = SQLitePasswordRecoveryService(_database(request)).issue(email=email)
+    if issued is not None:
+        delivery = getattr(request.app.state, "veridra_password_reset_delivery", None)
+        if callable(delivery):
+            adapter: PasswordResetDeliveryAdapter = delivery
+            adapter(
+                PasswordResetDelivery(
+                    email=issued.email,
+                    token=issued.token,
+                    expires_at=issued.expires_at,
+                )
+            )
+    return _forgot_form(submitted=True)
+
+
+@router.get("/reset-password", response_class=HTMLResponse)
+def reset_password_page(token: str = "") -> HTMLResponse:
+    if not token or len(token) > 512:
+        response = _page(
+            "Invalid password reset",
+            "<section><h1>Reset link is invalid</h1><p class='muted'>Request a new password reset email.</p><div class='links'><a href='/forgot-password'>Request another reset</a></div></section>",
+        )
+        response.status_code = 400
+        return response
+    return _reset_form(token)
+
+
+@router.post("/reset-password", response_model=None)
+async def reset_password_submit(request: Request) -> HTMLResponse | RedirectResponse:
+    _trusted_origin(request)
+    values = _values(await request.body())
+    token = _one(values, "token")
+    new_password = values.get("new_password", [""])[0]
+    confirmation = values.get("password_confirm", [""])[0]
+    if new_password != confirmation:
+        response = _reset_form(token, "Passwords do not match.")
+        response.status_code = 400
+        return response
+    if len(new_password) < 12 or len(new_password) > 1024:
+        response = _reset_form(token, "Password must contain between 12 and 1024 characters.")
+        response.status_code = 400
+        return response
+    try:
+        SQLitePasswordRecoveryService(_database(request)).reset_password(
+            token=token,
+            new_password=new_password,
+        )
+    except (PasswordRecoveryError, ValueError):
+        response = _page(
+            "Invalid password reset",
+            "<section><h1>Reset link is invalid or expired</h1><p class='muted'>Request a new password reset email.</p><div class='links'><a href='/forgot-password'>Request another reset</a></div></section>",
+        )
+        response.status_code = 400
+        return response
+    return RedirectResponse("/login?reset=complete", status_code=303)

--- a/src/veridra/identity_email_delivery.py
+++ b/src/veridra/identity_email_delivery.py
@@ -10,6 +10,7 @@ from email.message import EmailMessage
 from enum import StrEnum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from urllib.parse import urlencode
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
@@ -93,24 +94,33 @@ class PasswordResetEmailAdapter:
         *,
         config: SmtpConfig,
         store: IdentityEmailAttemptStore,
+        reset_origin: str | None = None,
         sender: IdentityEmailSender = _default_sender,
     ) -> None:
         self.config = config
         self.store = store
+        self.reset_origin = reset_origin.rstrip("/") if reset_origin else None
         self.sender = sender
 
     def __call__(self, delivery: PasswordResetDelivery) -> None:
-        subject = "Your Veridra password reset token"
+        subject = "Reset your Veridra password"
         message = EmailMessage()
         message["From"] = f"{self.config.sender_name} <{self.config.sender_email}>"
         message["To"] = delivery.email
         message["Subject"] = subject
+        if self.reset_origin:
+            reset_url = f"{self.reset_origin}/reset-password?{urlencode({'token': delivery.token})}"
+            instructions = f"Open this secure reset link:\n{reset_url}"
+        else:
+            instructions = (
+                f"One-time reset token:\n{delivery.token}\n\n"
+                "Submit this token with your new password to "
+                "/api/auth/password-recovery/reset."
+            )
         message.set_content(
             "A password reset was requested for your Veridra account.\n\n"
-            f"One-time reset token:\n{delivery.token}\n\n"
+            f"{instructions}\n\n"
             f"Expires: {delivery.expires_at.astimezone(UTC).isoformat()}\n\n"
-            "Submit this token with your new password to "
-            "/api/auth/password-recovery/reset.\n\n"
             "If you did not request this reset, ignore this email."
         )
         raw = message.as_bytes()

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -20,6 +20,7 @@ from .agency_workflow_web import router as agency_workflow_router
 from .application_identity import configure_identity_middleware
 from .assessment_project_conversion_api import router as assessment_project_conversion_router
 from .auth_api import router as auth_router
+from .browser_auth_web import router as browser_auth_router
 from .crawl_profile_web import router as crawl_profile_router
 from .existing_user_invitation_api import router as existing_user_invitation_router
 from .finding_task_api import router as finding_task_router
@@ -93,6 +94,7 @@ app.middleware("http")(enforce_workspace_policy)
 configure_identity_middleware(app)
 app.include_router(public_router)
 app.include_router(onboarding_router)
+app.include_router(browser_auth_router)
 app.include_router(tenant_assessment_router)
 app.include_router(operations_router)
 app.include_router(auth_router)

--- a/src/veridra/runtime_email.py
+++ b/src/veridra/runtime_email.py
@@ -34,4 +34,5 @@ def configure_runtime_email(app: FastAPI, config: RuntimeConfig) -> None:
     app.state.veridra_password_reset_delivery = PasswordResetEmailAdapter(
         config=smtp,
         store=IdentityEmailAttemptStore(attempt_directory),
+        reset_origin=config.trusted_origin,
     )

--- a/tests/test_browser_auth_web.py
+++ b/tests/test_browser_auth_web.py
@@ -124,7 +124,7 @@ def test_browser_login_rejects_invalid_credentials_and_issues_session_on_success
     assert "veridra_session=" in cookie
     assert "HttpOnly" in cookie
     assert "Secure" in cookie
-    assert "SameSite=lax" in cookie
+    assert "SameSite=strict" in cookie
 
 
 def test_forgot_password_keeps_existing_and_missing_accounts_indistinguishable(

--- a/tests/test_browser_auth_web.py
+++ b/tests/test_browser_auth_web.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.browser_auth_web import router
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.login_throttle import SQLiteLoginThrottle
+from veridra.password_auth import SQLitePasswordAuthenticator
+from veridra.password_recovery_api import PasswordResetDelivery
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+
+PASSWORD = "correct-horse-battery-staple"
+NEW_PASSWORD = "new-correct-horse-battery-staple"
+ORIGIN = "http://testserver"
+
+
+def _client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TestClient, list[PasswordResetDelivery], Path]:
+    database = tmp_path / "identity.sqlite3"
+    SQLiteIdentityBootstrap(database).create_first_owner(
+        tenant_slug="customer-one",
+        tenant_name="Customer one",
+        owner_email="owner@example.com",
+        owner_name="Owner",
+        password=PASSWORD,
+        confirmation=BOOTSTRAP_CONFIRMATION,
+    )
+    store = SQLiteIdentityRecordStore(database)
+    store.initialize()
+    authenticator = SQLitePasswordAuthenticator(database)
+    authenticator.initialize()
+    throttle = SQLiteLoginThrottle(database)
+    throttle.initialize()
+    deliveries: list[PasswordResetDelivery] = []
+
+    app = FastAPI()
+    app.state.veridra_identity_database = database
+    app.state.veridra_identity_store = store
+    app.state.veridra_password_authenticator = authenticator
+    app.state.veridra_login_throttle = throttle
+    app.state.veridra_password_reset_delivery = deliveries.append
+    app.include_router(router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    return TestClient(app), deliveries, database
+
+
+def test_login_page_is_browser_safe_and_links_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _, _ = _client(tmp_path, monkeypatch)
+
+    response = client.get("/login")
+
+    assert response.status_code == 200
+    assert "Sign in to Veridra" in response.text
+    assert "name='tenant_slug'" in response.text
+    assert "name='email'" in response.text
+    assert "name='password'" in response.text
+    assert "href='/forgot-password'" in response.text
+    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["referrer-policy"] == "no-referrer"
+    assert response.headers["x-frame-options"] == "DENY"
+
+
+def test_login_post_requires_same_origin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _, _ = _client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/login",
+        data={
+            "tenant_slug": "customer-one",
+            "email": "owner@example.com",
+            "password": PASSWORD,
+        },
+    )
+
+    assert response.status_code == 403
+
+
+def test_browser_login_rejects_invalid_credentials_and_issues_session_on_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _, _ = _client(tmp_path, monkeypatch)
+    headers = {"Origin": ORIGIN}
+
+    invalid = client.post(
+        "/login",
+        headers=headers,
+        data={
+            "tenant_slug": "customer-one",
+            "email": "owner@example.com",
+            "password": "not-the-password",
+        },
+        follow_redirects=False,
+    )
+    valid = client.post(
+        "/login",
+        headers=headers,
+        data={
+            "tenant_slug": "customer-one",
+            "email": "owner@example.com",
+            "password": PASSWORD,
+        },
+        follow_redirects=False,
+    )
+
+    assert invalid.status_code == 401
+    assert "Invalid login credentials" in invalid.text
+    assert "set-cookie" not in invalid.headers
+    assert valid.status_code == 303
+    assert valid.headers["location"] == "/agency"
+    cookie = valid.headers["set-cookie"]
+    assert "veridra_session=" in cookie
+    assert "HttpOnly" in cookie
+    assert "Secure" in cookie
+    assert "SameSite=lax" in cookie
+
+
+def test_forgot_password_keeps_existing_and_missing_accounts_indistinguishable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, deliveries, _ = _client(tmp_path, monkeypatch)
+    headers = {"Origin": ORIGIN}
+
+    existing = client.post(
+        "/forgot-password",
+        headers=headers,
+        data={"email": "owner@example.com"},
+    )
+    missing = client.post(
+        "/forgot-password",
+        headers=headers,
+        data={"email": "missing@example.com"},
+    )
+
+    assert existing.status_code == missing.status_code == 200
+    expected = "If an active account exists for that email, reset instructions have been sent."
+    assert expected in existing.text
+    assert expected in missing.text
+    assert len(deliveries) == 1
+    assert deliveries[0].email == "owner@example.com"
+
+
+def test_browser_reset_changes_password_revokes_token_and_supports_new_login(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, deliveries, _ = _client(tmp_path, monkeypatch)
+    headers = {"Origin": ORIGIN}
+    forgot = client.post(
+        "/forgot-password",
+        headers=headers,
+        data={"email": "owner@example.com"},
+    )
+    assert forgot.status_code == 200
+    token = deliveries[0].token
+
+    reset_page = client.get("/reset-password", params={"token": token})
+    mismatch = client.post(
+        "/reset-password",
+        headers=headers,
+        data={
+            "token": token,
+            "new_password": NEW_PASSWORD,
+            "password_confirm": "different-password-value",
+        },
+        follow_redirects=False,
+    )
+    reset = client.post(
+        "/reset-password",
+        headers=headers,
+        data={
+            "token": token,
+            "new_password": NEW_PASSWORD,
+            "password_confirm": NEW_PASSWORD,
+        },
+        follow_redirects=False,
+    )
+    reuse = client.post(
+        "/reset-password",
+        headers=headers,
+        data={
+            "token": token,
+            "new_password": NEW_PASSWORD,
+            "password_confirm": NEW_PASSWORD,
+        },
+        follow_redirects=False,
+    )
+    old_login = client.post(
+        "/login",
+        headers=headers,
+        data={
+            "tenant_slug": "customer-one",
+            "email": "owner@example.com",
+            "password": PASSWORD,
+        },
+        follow_redirects=False,
+    )
+    new_login = client.post(
+        "/login",
+        headers=headers,
+        data={
+            "tenant_slug": "customer-one",
+            "email": "owner@example.com",
+            "password": NEW_PASSWORD,
+        },
+        follow_redirects=False,
+    )
+
+    assert reset_page.status_code == 200
+    assert token in reset_page.text
+    assert reset_page.headers["cache-control"] == "no-store"
+    assert reset_page.headers["referrer-policy"] == "no-referrer"
+    assert mismatch.status_code == 400
+    assert "Passwords do not match" in mismatch.text
+    assert reset.status_code == 303
+    assert reset.headers["location"] == "/login?reset=complete"
+    assert reuse.status_code == 400
+    assert "invalid or expired" in reuse.text
+    assert old_login.status_code == 401
+    assert new_login.status_code == 303

--- a/tests/test_identity_email_delivery.py
+++ b/tests/test_identity_email_delivery.py
@@ -55,6 +55,26 @@ def test_password_reset_email_sends_token_but_evidence_keeps_only_hash(
     assert TOKEN.encode("utf-8") not in next(tmp_path.glob("*.json")).read_bytes()
 
 
+def test_password_reset_email_uses_browser_reset_link_when_origin_is_configured(
+    tmp_path: Path,
+) -> None:
+    messages: list[EmailMessage] = []
+    store = IdentityEmailAttemptStore(tmp_path)
+    adapter = PasswordResetEmailAdapter(
+        config=_config(),
+        store=store,
+        reset_origin="https://app.example.com/",
+        sender=lambda config, message: messages.append(message),
+    )
+
+    adapter(_delivery())
+
+    body = messages[0].get_content()
+    assert f"https://app.example.com/reset-password?token={TOKEN}" in body
+    assert "/api/auth/password-recovery/reset" not in body
+    assert TOKEN.encode("utf-8") not in next(tmp_path.glob("*.json")).read_bytes()
+
+
 def test_password_reset_smtp_failure_is_persisted_without_raising(tmp_path: Path) -> None:
     store = IdentityEmailAttemptStore(tmp_path)
 

--- a/tests/test_runtime_email.py
+++ b/tests/test_runtime_email.py
@@ -91,5 +91,7 @@ def test_configured_smtp_installs_password_reset_adapter(
 
     configure_runtime_email(app, _config(tmp_path, RuntimeEnvironment.production))
 
-    assert isinstance(app.state.veridra_password_reset_delivery, PasswordResetEmailAdapter)
+    adapter = app.state.veridra_password_reset_delivery
+    assert isinstance(adapter, PasswordResetEmailAdapter)
+    assert adapter.reset_origin == "https://app.example.com"
     assert app.state.veridra_smtp_config.host == "smtp.example.test"


### PR DESCRIPTION
Adds the missing customer-facing authentication shell on top of Veridra's existing durable identity services.

What changes:
- add browser sign-in at `/login` using the existing password authenticator, login throttle and server-side session lifecycle;
- add `/forgot-password` and `/reset-password` browser flows backed by the existing password-recovery service;
- keep recovery responses generic for existing and nonexistent accounts;
- enforce trusted same-origin validation on browser authentication POSTs;
- add no-store/referrer/frame protections to authentication pages;
- update password-reset email delivery so configured SMTP messages link to the trusted-origin browser reset page while still including expiry/token context;
- preserve one-time reset semantics and existing session revocation after reset;
- mount the browser authentication router in the composed runtime;
- add regression coverage for successful/failed sign-in, secure session-cookie issuance, same-origin rejection, recovery anti-enumeration, one-time reset, old-password invalidation and trusted reset-link generation;
- reconcile README and production deployment documentation.

A separate follow-up should add rate limiting to password-recovery issuance across both API and browser paths; this PR does not create a browser-only throttle that would leave the API inconsistent.

Do not merge until exact-head full CI succeeds.