### PR TITLE
Harden password recovery against email abuse

### DIFF
--- a/docs/operations/password-recovery-abuse-controls.md
+++ b/docs/operations/password-recovery-abuse-controls.md
@@ -1,0 +1,25 @@
+# Password-recovery abuse controls
+
+Veridra applies a durable per-address throttle before issuing password-reset tokens or sending reset email.
+
+## Application boundary
+
+- Email addresses are normalized and represented in throttle state only by a SHA-256 subject hash.
+- The default application allowance is three recovery requests per address in a 15-minute window.
+- The next request enters a 15-minute lockout for that address.
+- Throttle state is stored in the identity SQLite database and therefore survives process restarts.
+- API and browser recovery use the same control.
+- A throttled request does not issue a token and does not send email.
+- Existing, missing and throttled addresses keep the same public recovery response. Do not expose lockout state or a `Retry-After` header from the recovery endpoint because that can weaken the account-enumeration boundary.
+
+## Deployment boundary
+
+The application-level throttle is deliberately keyed by recovery address rather than client IP. Production deployments should also apply bounded request-rate and connection controls at the trusted reverse proxy or edge to reduce distributed address spraying and high-volume requests against many addresses.
+
+Do not trust arbitrary forwarded client-IP headers inside the application. Any IP-based edge policy belongs at infrastructure that has an authoritative connection identity.
+
+## Operations
+
+Repeated password-recovery activity can be investigated from protected infrastructure logs and identity-email delivery evidence, but logs must not contain reset tokens or SMTP credentials. Avoid logging raw request bodies for recovery endpoints.
+
+The throttle is an abuse-control boundary, not an account-lock mechanism. Successful password reset continues to rely on possession of the one-time reset token and revokes existing sessions through the password-recovery service.

--- a/src/veridra/application_identity.py
+++ b/src/veridra/application_identity.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from .identity_middleware import VerifiedIdentityMiddleware
 from .login_throttle import SQLiteLoginThrottle
 from .password_auth import SQLitePasswordAuthenticator
+from .password_recovery_throttle import SQLitePasswordRecoveryThrottle
 from .same_origin import SameOriginConfigurationError, TrustedSameOriginPolicy
 from .session_cookie import SecureSessionCookieExtractor
 from .session_identity_adapter import ServerSideSessionIdentityAdapter
@@ -35,10 +36,13 @@ def configure_identity_middleware(app: FastAPI) -> bool:
     password_authenticator.initialize()
     login_throttle = SQLiteLoginThrottle(database)
     login_throttle.initialize()
+    recovery_throttle = SQLitePasswordRecoveryThrottle(database)
+    recovery_throttle.initialize()
     app.state.veridra_identity_database = database
     app.state.veridra_identity_store = store
     app.state.veridra_password_authenticator = password_authenticator
     app.state.veridra_login_throttle = login_throttle
+    app.state.veridra_password_recovery_throttle = recovery_throttle
     adapter = ServerSideSessionIdentityAdapter(
         extractor=SecureSessionCookieExtractor(),
         store=store,

--- a/src/veridra/browser_auth_web.py
+++ b/src/veridra/browser_auth_web.py
@@ -15,6 +15,7 @@ from .login_throttle import SQLiteLoginThrottle
 from .password_auth import SQLitePasswordAuthenticator
 from .password_recovery import PasswordRecoveryError, SQLitePasswordRecoveryService
 from .password_recovery_api import PasswordResetDelivery
+from .password_recovery_throttle import SQLitePasswordRecoveryThrottle
 from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
 from .session_api import set_session_cookie
 from .session_lifecycle import SessionLifecycleService
@@ -68,6 +69,13 @@ def _services(
     ):
         raise HTTPException(status_code=503, detail="Authentication is not configured.")
     return authenticator, SessionLifecycleService(identity_store), login_throttle
+
+
+def _recovery_throttle(request: Request) -> SQLitePasswordRecoveryThrottle:
+    configured = getattr(request.app.state, "veridra_password_recovery_throttle", None)
+    if isinstance(configured, SQLitePasswordRecoveryThrottle):
+        return configured
+    return SQLitePasswordRecoveryThrottle(_database(request))
 
 
 def _trusted_origin(request: Request) -> None:
@@ -167,18 +175,19 @@ def forgot_password_page() -> HTMLResponse:
 async def forgot_password_submit(request: Request) -> HTMLResponse:
     _trusted_origin(request)
     email = _one(_values(await request.body()), "email").lower()
-    issued = SQLitePasswordRecoveryService(_database(request)).issue(email=email)
-    if issued is not None:
-        delivery = getattr(request.app.state, "veridra_password_reset_delivery", None)
-        if callable(delivery):
-            adapter: PasswordResetDeliveryAdapter = delivery
-            adapter(
-                PasswordResetDelivery(
-                    email=issued.email,
-                    token=issued.token,
-                    expires_at=issued.expires_at,
+    if _recovery_throttle(request).consume(email=email).allowed:
+        issued = SQLitePasswordRecoveryService(_database(request)).issue(email=email)
+        if issued is not None:
+            delivery = getattr(request.app.state, "veridra_password_reset_delivery", None)
+            if callable(delivery):
+                adapter: PasswordResetDeliveryAdapter = delivery
+                adapter(
+                    PasswordResetDelivery(
+                        email=issued.email,
+                        token=issued.token,
+                        expires_at=issued.expires_at,
+                    )
                 )
-            )
     return _forgot_form(submitted=True)
 
 

--- a/src/veridra/password_recovery_api.py
+++ b/src/veridra/password_recovery_api.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Protocol, cast
 
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 from .password_recovery import PasswordRecoveryError, SQLitePasswordRecoveryService
+from .password_recovery_throttle import SQLitePasswordRecoveryThrottle
 
 router = APIRouter(prefix="/api/auth/password-recovery", tags=["authentication"])
 
@@ -37,14 +39,25 @@ class PasswordResetRequest(BaseModel):
     new_password: str = Field(min_length=12, max_length=1024)
 
 
-def _service(request: Request) -> SQLitePasswordRecoveryService:
+def _database(request: Request) -> Path:
     database = getattr(request.app.state, "veridra_identity_database", None)
-    if database is None:
+    if not isinstance(database, Path):
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Password recovery is not configured.",
         )
-    return SQLitePasswordRecoveryService(database)
+    return database
+
+
+def _service(request: Request) -> SQLitePasswordRecoveryService:
+    return SQLitePasswordRecoveryService(_database(request))
+
+
+def _throttle(request: Request) -> SQLitePasswordRecoveryThrottle:
+    configured = getattr(request.app.state, "veridra_password_recovery_throttle", None)
+    if isinstance(configured, SQLitePasswordRecoveryThrottle):
+        return configured
+    return SQLitePasswordRecoveryThrottle(_database(request))
 
 
 def _delivery_adapter(request: Request) -> Callable[[PasswordResetDelivery], None]:
@@ -61,7 +74,10 @@ def _delivery_adapter(request: Request) -> Callable[[PasswordResetDelivery], Non
 def request_password_reset(payload: PasswordRecoveryRequest, request: Request) -> None:
     service = _service(request)
     adapter = _delivery_adapter(request)
-    issued = service.issue(email=str(payload.email))
+    email = str(payload.email)
+    if not _throttle(request).consume(email=email).allowed:
+        return
+    issued = service.issue(email=email)
     if issued is not None:
         adapter(
             PasswordResetDelivery(

--- a/src/veridra/password_recovery_throttle.py
+++ b/src/veridra/password_recovery_throttle.py
@@ -80,8 +80,8 @@ class SQLitePasswordRecoveryThrottle:
             if row is not None:
                 locked_until_raw = row["locked_until"]
                 if locked_until_raw is not None:
-                    locked_until = datetime.fromisoformat(locked_until_raw)
-                    remaining = int((locked_until - requested_at).total_seconds())
+                    current_locked_until = datetime.fromisoformat(locked_until_raw)
+                    remaining = int((current_locked_until - requested_at).total_seconds())
                     if remaining > 0:
                         return PasswordRecoveryThrottleDecision(False, max(1, remaining))
                 previous_window = datetime.fromisoformat(row["window_started_at"])
@@ -89,10 +89,10 @@ class SQLitePasswordRecoveryThrottle:
                     window_started_at = previous_window
                     request_count = int(row["request_count"]) + 1
 
-            locked_until = None
+            next_locked_until: datetime | None = None
             allowed = request_count <= self.max_requests
             if not allowed:
-                locked_until = requested_at + self.lockout_duration
+                next_locked_until = requested_at + self.lockout_duration
 
             connection.execute(
                 """INSERT INTO password_recovery_throttle
@@ -106,7 +106,7 @@ class SQLitePasswordRecoveryThrottle:
                     subject_hash,
                     request_count,
                     window_started_at.isoformat(),
-                    locked_until.isoformat() if locked_until is not None else None,
+                    next_locked_until.isoformat() if next_locked_until is not None else None,
                 ),
             )
 

--- a/src/veridra/password_recovery_throttle.py
+++ b/src/veridra/password_recovery_throttle.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class PasswordRecoveryThrottleDecision:
+    allowed: bool
+    retry_after_seconds: int = 0
+
+
+class SQLitePasswordRecoveryThrottle:
+    """Persistent per-address throttling for password-reset issuance.
+
+    The public recovery response must remain identical whether an account exists,
+    is missing, or the address is currently throttled. Deployment-edge/IP rate
+    limiting remains a separate reverse-proxy responsibility.
+    """
+
+    def __init__(
+        self,
+        database: Path,
+        *,
+        max_requests: int = 3,
+        request_window: timedelta = timedelta(minutes=15),
+        lockout_duration: timedelta = timedelta(minutes=15),
+    ) -> None:
+        if max_requests < 1:
+            raise ValueError("max_requests must be positive.")
+        if request_window <= timedelta(0) or lockout_duration <= timedelta(0):
+            raise ValueError("Throttle durations must be positive.")
+        self.database = database
+        self.max_requests = max_requests
+        self.request_window = request_window
+        self.lockout_duration = lockout_duration
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """CREATE TABLE IF NOT EXISTS password_recovery_throttle (
+                    subject_hash TEXT PRIMARY KEY,
+                    request_count INTEGER NOT NULL,
+                    window_started_at TEXT NOT NULL,
+                    locked_until TEXT
+                )"""
+            )
+
+    @staticmethod
+    def subject_hash(email: str) -> str:
+        return hashlib.sha256(email.strip().lower().encode("utf-8")).hexdigest()
+
+    def consume(
+        self,
+        *,
+        email: str,
+        now: datetime | None = None,
+    ) -> PasswordRecoveryThrottleDecision:
+        requested_at = (now or datetime.now(UTC)).astimezone(UTC)
+        subject_hash = self.subject_hash(email)
+        self.initialize()
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """SELECT request_count, window_started_at, locked_until
+                FROM password_recovery_throttle WHERE subject_hash = ?""",
+                (subject_hash,),
+            ).fetchone()
+
+            window_started_at = requested_at
+            request_count = 1
+            if row is not None:
+                locked_until_raw = row["locked_until"]
+                if locked_until_raw is not None:
+                    locked_until = datetime.fromisoformat(locked_until_raw)
+                    remaining = int((locked_until - requested_at).total_seconds())
+                    if remaining > 0:
+                        return PasswordRecoveryThrottleDecision(False, max(1, remaining))
+                previous_window = datetime.fromisoformat(row["window_started_at"])
+                if requested_at - previous_window <= self.request_window:
+                    window_started_at = previous_window
+                    request_count = int(row["request_count"]) + 1
+
+            locked_until = None
+            allowed = request_count <= self.max_requests
+            if not allowed:
+                locked_until = requested_at + self.lockout_duration
+
+            connection.execute(
+                """INSERT INTO password_recovery_throttle
+                (subject_hash, request_count, window_started_at, locked_until)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(subject_hash) DO UPDATE SET
+                    request_count=excluded.request_count,
+                    window_started_at=excluded.window_started_at,
+                    locked_until=excluded.locked_until""",
+                (
+                    subject_hash,
+                    request_count,
+                    window_started_at.isoformat(),
+                    locked_until.isoformat() if locked_until is not None else None,
+                ),
+            )
+
+        if allowed:
+            return PasswordRecoveryThrottleDecision(True)
+        return PasswordRecoveryThrottleDecision(
+            False,
+            max(1, int(self.lockout_duration.total_seconds())),
+        )

--- a/tests/test_password_recovery_throttle.py
+++ b/tests/test_password_recovery_throttle.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from veridra.password_recovery_throttle import SQLitePasswordRecoveryThrottle
+
+NOW = datetime(2026, 8, 20, 15, 0, tzinfo=UTC)
+
+
+def test_recovery_throttle_normalizes_subject_and_persists_lockout(tmp_path: Path) -> None:
+    database = tmp_path / "identity.sqlite3"
+    first = SQLitePasswordRecoveryThrottle(database)
+
+    assert first.consume(email=" Owner@Example.com ", now=NOW).allowed
+    assert first.consume(email="owner@example.com", now=NOW + timedelta(minutes=1)).allowed
+    assert first.consume(email="OWNER@EXAMPLE.COM", now=NOW + timedelta(minutes=2)).allowed
+    denied = first.consume(email="owner@example.com", now=NOW + timedelta(minutes=3))
+
+    assert not denied.allowed
+    assert denied.retry_after_seconds == 900
+
+    second = SQLitePasswordRecoveryThrottle(database)
+    persisted = second.consume(email="owner@example.com", now=NOW + timedelta(minutes=4))
+
+    assert not persisted.allowed
+    assert persisted.retry_after_seconds == 840
+
+
+def test_recovery_throttle_is_per_address_and_recovers_after_lockout(tmp_path: Path) -> None:
+    database = tmp_path / "identity.sqlite3"
+    throttle = SQLitePasswordRecoveryThrottle(database)
+
+    for minute in range(3):
+        assert throttle.consume(
+            email="owner@example.com",
+            now=NOW + timedelta(minutes=minute),
+        ).allowed
+    assert not throttle.consume(
+        email="owner@example.com",
+        now=NOW + timedelta(minutes=3),
+    ).allowed
+
+    assert throttle.consume(
+        email="other@example.com",
+        now=NOW + timedelta(minutes=4),
+    ).allowed
+    assert throttle.consume(
+        email="owner@example.com",
+        now=NOW + timedelta(minutes=19),
+    ).allowed
+
+
+def test_recovery_throttle_does_not_store_plain_email(tmp_path: Path) -> None:
+    database = tmp_path / "identity.sqlite3"
+    throttle = SQLitePasswordRecoveryThrottle(database)
+
+    throttle.consume(email="sensitive@example.com", now=NOW)
+
+    assert b"sensitive@example.com" not in database.read_bytes()

--- a/tests/test_password_recovery_throttle_integration.py
+++ b/tests/test_password_recovery_throttle_integration.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.browser_auth_web import router as browser_auth_router
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.password_recovery_api import PasswordResetDelivery
+from veridra.password_recovery_api import router as recovery_api_router
+from veridra.password_recovery_throttle import SQLitePasswordRecoveryThrottle
+
+PASSWORD = "correct-horse-battery-staple"
+ORIGIN = "http://testserver"
+GENERIC_MESSAGE = "If an active account exists for that email, reset instructions have been sent."
+
+
+def _database(tmp_path: Path) -> Path:
+    database = tmp_path / "identity.sqlite3"
+    SQLiteIdentityBootstrap(database).create_first_owner(
+        tenant_slug="customer-one",
+        tenant_name="Customer one",
+        owner_email="owner@example.com",
+        owner_name="Owner",
+        password=PASSWORD,
+        confirmation=BOOTSTRAP_CONFIRMATION,
+    )
+    return database
+
+
+def test_api_recovery_throttle_suppresses_delivery_without_changing_public_response(
+    tmp_path: Path,
+) -> None:
+    database = _database(tmp_path)
+    deliveries: list[PasswordResetDelivery] = []
+    app = FastAPI()
+    app.state.veridra_identity_database = database
+    app.state.veridra_password_reset_delivery = deliveries.append
+    app.state.veridra_password_recovery_throttle = SQLitePasswordRecoveryThrottle(database)
+    app.include_router(recovery_api_router)
+    client = TestClient(app)
+
+    existing = [
+        client.post(
+            "/api/auth/password-recovery/request",
+            json={"email": "owner@example.com"},
+        )
+        for _ in range(4)
+    ]
+    missing = client.post(
+        "/api/auth/password-recovery/request",
+        json={"email": "missing@example.com"},
+    )
+
+    assert all(response.status_code == 202 for response in existing)
+    assert missing.status_code == 202
+    assert all(response.content == missing.content for response in existing)
+    assert len(deliveries) == 3
+
+
+def test_browser_recovery_throttle_keeps_generic_success_page(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = _database(tmp_path)
+    deliveries: list[PasswordResetDelivery] = []
+    app = FastAPI()
+    app.state.veridra_identity_database = database
+    app.state.veridra_password_reset_delivery = deliveries.append
+    app.state.veridra_password_recovery_throttle = SQLitePasswordRecoveryThrottle(database)
+    app.include_router(browser_auth_router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    client = TestClient(app)
+
+    responses = [
+        client.post(
+            "/forgot-password",
+            headers={"Origin": ORIGIN},
+            data={"email": "owner@example.com"},
+        )
+        for _ in range(4)
+    ]
+
+    assert all(response.status_code == 200 for response in responses)
+    assert all(GENERIC_MESSAGE in response.text for response in responses)
+    assert len(deliveries) == 3


### PR DESCRIPTION
Adds durable password-recovery issuance throttling across both API and browser surfaces while preserving Veridra's account-enumeration boundary.

What changes:
- add a persistent per-address password-recovery throttle stored in the identity SQLite database;
- normalize addresses and persist only a SHA-256 subject hash in throttle state;
- allow a bounded recovery-request window and silently suppress token issuance/email after the threshold;
- share the same control between `/api/auth/password-recovery/request` and `/forgot-password`;
- keep existing, missing and throttled addresses on the same public response path with no visible lockout/Retry-After signal;
- initialize durable throttle state with the rest of identity runtime state;
- keep IP/global rate controls at the trusted reverse-proxy/edge boundary rather than trusting arbitrary forwarded client addresses;
- add unit coverage for normalization, persistence, per-address isolation, lockout recovery and plaintext-email non-persistence;
- add API/browser integration coverage proving delivery is bounded without changing public responses;
- document the application and deployment abuse-control boundaries.

Do not merge until exact-head full CI succeeds.