### PR TITLE
Add invitation email and browser acceptance

### DIFF
--- a/docs/operations/tenant-invitation-delivery.md
+++ b/docs/operations/tenant-invitation-delivery.md
@@ -1,0 +1,33 @@
+# Tenant invitation delivery
+
+Production tenant invitations use Veridra's configured transactional SMTP transport and browser acceptance flow.
+
+## Owner workflow
+
+- Team owners create or resend invitations from `/workspace/members`.
+- When transactional email is configured, the bearer invitation token is not displayed to the owner. The recipient receives a secure acceptance link by email.
+- Delivery success or failure is visible to the authenticated owner. A failed email does not consume the invitation; the owner can retry with Resend after SMTP is healthy.
+- Development runtimes without SMTP retain a one-time manual-token fallback so local testing is not blocked.
+
+## Recipient workflow
+
+- New users open `/accept-invitation?token=...`, create their account and password, and are signed into the invited tenant after successful acceptance.
+- Existing users must authenticate as the account matching the invitation email. The login continuation accepts only an internal `/accept-invitation` destination with a bounded token; arbitrary external or unrelated redirect targets are rejected.
+- Existing-user acceptance adds the target-tenant membership and issues a session scoped to that tenant.
+- Invitation services continue to enforce expiry, one-time consumption and active plan seat capacity atomically at acceptance.
+
+## Token and evidence handling
+
+Invitation tokens are bearer credentials. The invitation database and identity-email delivery evidence persist only token hashes/derived delivery keys, not the plaintext token. Acceptance pages send `Cache-Control: no-store` and `Referrer-Policy: no-referrer`.
+
+Because the browser acceptance URL contains the token in its query string, reverse proxies, observability platforms and access logs must redact or omit query strings for `/accept-invitation`. Never record invitation URLs in analytics, error-report metadata, screenshots or support logs.
+
+Identity-email delivery evidence records recipient, delivery status, subject, message digest and a one-way delivery key. SMTP failures are operational evidence, not a reason to expose the invitation token in a production response.
+
+## Deployment expectations
+
+- Use HTTPS at the trusted public origin.
+- Configure and test SMTP before inviting production users.
+- Protect identity-email evidence with the same filesystem and backup controls as password-reset delivery evidence.
+- Alert on repeated invitation delivery failures.
+- Keep raw invitation tokens, SMTP credentials and request query strings out of logs.

--- a/src/veridra/browser_auth_web.py
+++ b/src/veridra/browser_auth_web.py
@@ -6,7 +6,7 @@ import os
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlencode, urlsplit
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -49,6 +49,18 @@ def _one(values: dict[str, list[str]], name: str) -> str:
     return values.get(name, [""])[0].strip()
 
 
+def _safe_next(value: str) -> str:
+    if not value or len(value) > 1024:
+        return ""
+    parsed = urlsplit(value)
+    if parsed.scheme or parsed.netloc or parsed.fragment or parsed.path != "/accept-invitation":
+        return ""
+    token = parse_qs(parsed.query).get("token", [""])[0]
+    if len(token) < 32 or len(token) > 512:
+        return ""
+    return f"/accept-invitation?{urlencode({'token': token})}"
+
+
 def _database(request: Request) -> Path:
     value = getattr(request.app.state, "veridra_identity_database", None)
     if not isinstance(value, Path):
@@ -88,15 +100,25 @@ def _trusted_origin(request: Request) -> None:
         raise HTTPException(status_code=403, detail="Authentication request is not permitted.") from exc
 
 
-def _login_form(error: str = "", *, reset_complete: bool = False) -> HTMLResponse:
+def _login_form(
+    error: str = "",
+    *,
+    reset_complete: bool = False,
+    next_target: str = "",
+) -> HTMLResponse:
     notice = ""
     if reset_complete:
         notice = "<div class='success' role='status'>Password updated. Sign in with your new password.</div>"
     elif error:
         notice = f"<div class='error' role='alert'>{html.escape(error)}</div>"
+    hidden_next = (
+        f"<input type='hidden' name='next' value='{html.escape(next_target, quote=True)}'>"
+        if next_target
+        else ""
+    )
     return _page(
         "Sign in to Veridra",
-        f"<section><h1>Sign in to Veridra</h1><p class='muted'>Open your agency workspace.</p>{notice}<form method='post' action='/login'><label for='tenant_slug'>Workspace slug</label><input id='tenant_slug' name='tenant_slug' minlength='3' maxlength='80' pattern='[a-z0-9]+(?:-[a-z0-9]+)*' autocomplete='organization' required><label for='email'>Email</label><input id='email' name='email' type='email' maxlength='254' autocomplete='username' required><label for='password'>Password</label><input id='password' name='password' type='password' maxlength='1024' autocomplete='current-password' required><button type='submit'>Sign in</button></form><div class='links'><a href='/forgot-password'>Forgot password?</a><a href='/onboarding'>First-time setup</a></div></section>",
+        f"<section><h1>Sign in to Veridra</h1><p class='muted'>Open your agency workspace.</p>{notice}<form method='post' action='/login'>{hidden_next}<label for='tenant_slug'>Workspace slug</label><input id='tenant_slug' name='tenant_slug' minlength='3' maxlength='80' pattern='[a-z0-9]+(?:-[a-z0-9]+)*' autocomplete='organization' required><label for='email'>Email</label><input id='email' name='email' type='email' maxlength='254' autocomplete='username' required><label for='password'>Password</label><input id='password' name='password' type='password' maxlength='1024' autocomplete='current-password' required><button type='submit'>Sign in</button></form><div class='links'><a href='/forgot-password'>Forgot password?</a><a href='/onboarding'>First-time setup</a></div></section>",
     )
 
 
@@ -120,8 +142,11 @@ def _reset_form(token: str, error: str = "") -> HTMLResponse:
 
 
 @router.get("/login", response_class=HTMLResponse)
-def login_page(reset: str = "") -> HTMLResponse:
-    return _login_form(reset_complete=reset == "complete")
+def login_page(reset: str = "", next: str = "") -> HTMLResponse:
+    return _login_form(
+        reset_complete=reset == "complete",
+        next_target=_safe_next(next),
+    )
 
 
 @router.post("/login", response_model=None)
@@ -131,11 +156,15 @@ async def login_submit(request: Request) -> HTMLResponse | RedirectResponse:
     tenant_slug = _one(values, "tenant_slug")
     email = _one(values, "email").lower()
     password = values.get("password", [""])[0]
+    next_target = _safe_next(_one(values, "next"))
     authenticator, lifecycle, throttle = _services(request)
     now = datetime.now(UTC)
     decision = throttle.check(email=email, tenant_slug=tenant_slug, now=now)
     if not decision.allowed:
-        response = _login_form("Too many login attempts. Try again later.")
+        response = _login_form(
+            "Too many login attempts. Try again later.",
+            next_target=next_target,
+        )
         response.status_code = 429
         response.headers["Retry-After"] = str(decision.retry_after_seconds)
         return response
@@ -147,11 +176,14 @@ async def login_submit(request: Request) -> HTMLResponse | RedirectResponse:
     if records is None:
         failure = throttle.record_failure(email=email, tenant_slug=tenant_slug, now=now)
         if not failure.allowed:
-            response = _login_form("Too many login attempts. Try again later.")
+            response = _login_form(
+                "Too many login attempts. Try again later.",
+                next_target=next_target,
+            )
             response.status_code = 429
             response.headers["Retry-After"] = str(failure.retry_after_seconds)
             return response
-        response = _login_form("Invalid login credentials.")
+        response = _login_form("Invalid login credentials.", next_target=next_target)
         response.status_code = 401
         return response
     throttle.clear(email=email, tenant_slug=tenant_slug)
@@ -161,7 +193,7 @@ async def login_submit(request: Request) -> HTMLResponse | RedirectResponse:
         tenant_id=records.tenant.id,
         lifetime=lifetime,
     )
-    redirect = RedirectResponse("/agency", status_code=303)
+    redirect = RedirectResponse(next_target or "/agency", status_code=303)
     set_session_cookie(redirect, issued.credential, max_age=int(lifetime.total_seconds()))
     return redirect
 

--- a/src/veridra/identity_email_delivery.py
+++ b/src/veridra/identity_email_delivery.py
@@ -5,6 +5,7 @@ import json
 import os
 import smtplib
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from email.message import EmailMessage
 from enum import StrEnum
@@ -22,6 +23,7 @@ _MAX_MESSAGE_BYTES = 128_000
 
 class IdentityEmailKind(StrEnum):
     password_reset = "password_reset"
+    tenant_invitation = "tenant_invitation"
 
 
 class IdentityEmailAttempt(BaseModel):
@@ -88,7 +90,62 @@ class IdentityEmailAttemptStore:
 IdentityEmailSender = Callable[[SmtpConfig, EmailMessage], None]
 
 
-class PasswordResetEmailAdapter:
+@dataclass(frozen=True)
+class TenantInvitationDelivery:
+    email: str
+    token: str
+    expires_at: datetime
+
+
+class _RecordedEmailAdapter:
+    def __init__(
+        self,
+        *,
+        config: SmtpConfig,
+        store: IdentityEmailAttemptStore,
+        sender: IdentityEmailSender,
+    ) -> None:
+        self.config = config
+        self.store = store
+        self.sender = sender
+
+    def _deliver(
+        self,
+        *,
+        kind: IdentityEmailKind,
+        recipient: str,
+        subject: str,
+        token: str,
+        message: EmailMessage,
+    ) -> bool:
+        raw = message.as_bytes()
+        if len(raw) > _MAX_MESSAGE_BYTES:
+            return False
+        status = EmailStatus.delivered
+        error = ""
+        try:
+            self.sender(self.config, message)
+        except (OSError, smtplib.SMTPException, EmailDeliveryError, ValueError) as exc:
+            status = EmailStatus.failed
+            error = str(exc)[:1000]
+        attempt = IdentityEmailAttempt(
+            kind=kind,
+            recipient=recipient,
+            attempted_at=datetime.now(UTC),
+            status=status,
+            subject=subject,
+            message_sha256=hashlib.sha256(raw).hexdigest(),
+            delivery_key=hashlib.sha256(token.encode("utf-8")).hexdigest()[:24],
+            error=error,
+        )
+        try:
+            self.store.save(attempt)
+        except (OSError, EmailDeliveryError, ValueError):
+            pass
+        return status is EmailStatus.delivered
+
+
+class PasswordResetEmailAdapter(_RecordedEmailAdapter):
     def __init__(
         self,
         *,
@@ -97,10 +154,8 @@ class PasswordResetEmailAdapter:
         reset_origin: str | None = None,
         sender: IdentityEmailSender = _default_sender,
     ) -> None:
-        self.config = config
-        self.store = store
+        super().__init__(config=config, store=store, sender=sender)
         self.reset_origin = reset_origin.rstrip("/") if reset_origin else None
-        self.sender = sender
 
     def __call__(self, delivery: PasswordResetDelivery) -> None:
         subject = "Reset your Veridra password"
@@ -123,29 +178,47 @@ class PasswordResetEmailAdapter:
             f"Expires: {delivery.expires_at.astimezone(UTC).isoformat()}\n\n"
             "If you did not request this reset, ignore this email."
         )
-        raw = message.as_bytes()
-        if len(raw) > _MAX_MESSAGE_BYTES:
-            return
-
-        status = EmailStatus.delivered
-        error = ""
-        try:
-            self.sender(self.config, message)
-        except (OSError, smtplib.SMTPException, EmailDeliveryError, ValueError) as exc:
-            status = EmailStatus.failed
-            error = str(exc)[:1000]
-
-        attempt = IdentityEmailAttempt(
+        self._deliver(
             kind=IdentityEmailKind.password_reset,
             recipient=delivery.email,
-            attempted_at=datetime.now(UTC),
-            status=status,
             subject=subject,
-            message_sha256=hashlib.sha256(raw).hexdigest(),
-            delivery_key=hashlib.sha256(delivery.token.encode("utf-8")).hexdigest()[:24],
-            error=error,
+            token=delivery.token,
+            message=message,
         )
-        try:
-            self.store.save(attempt)
-        except (OSError, EmailDeliveryError, ValueError):
-            return
+
+
+class TenantInvitationEmailAdapter(_RecordedEmailAdapter):
+    def __init__(
+        self,
+        *,
+        config: SmtpConfig,
+        store: IdentityEmailAttemptStore,
+        invitation_origin: str,
+        sender: IdentityEmailSender = _default_sender,
+    ) -> None:
+        super().__init__(config=config, store=store, sender=sender)
+        self.invitation_origin = invitation_origin.rstrip("/")
+
+    def __call__(self, delivery: TenantInvitationDelivery) -> bool:
+        subject = "You have been invited to Veridra"
+        invitation_url = (
+            f"{self.invitation_origin}/accept-invitation?"
+            f"{urlencode({'token': delivery.token})}"
+        )
+        message = EmailMessage()
+        message["From"] = f"{self.config.sender_name} <{self.config.sender_email}>"
+        message["To"] = delivery.email
+        message["Subject"] = subject
+        message.set_content(
+            "You have been invited to join a Veridra workspace.\n\n"
+            f"Open this invitation link:\n{invitation_url}\n\n"
+            f"Expires: {delivery.expires_at.astimezone(UTC).isoformat()}\n\n"
+            "If you were not expecting this invitation, ignore this email."
+        )
+        return self._deliver(
+            kind=IdentityEmailKind.tenant_invitation,
+            recipient=delivery.email,
+            subject=subject,
+            token=delivery.token,
+            message=message,
+        )

--- a/src/veridra/invitation_web.py
+++ b/src/veridra/invitation_web.py
@@ -96,7 +96,7 @@ def _preview(request: Request, token: str) -> InvitationPreview:
         connection.row_factory = sqlite3.Row
         row = connection.execute(
             """SELECT i.email, i.tenant_id, i.role, i.expires_at, i.consumed_at,
-                      t.name AS tenant_name,
+                      t.display_name AS tenant_name,
                       EXISTS(SELECT 1 FROM users u WHERE u.email = i.email) AS existing_user
                FROM tenant_invitations i
                JOIN tenants t ON t.id = i.tenant_id
@@ -185,7 +185,7 @@ async def accept_invitation_submit(request: Request) -> HTMLResponse | RedirectR
             if password != confirmation:
                 return _page(
                     "Accept Veridra invitation",
-                    "<section><h1>Passwords do not match</h1><p><a class='button' href='javascript:history.back()'>Go back</a></p></section>",
+                    "<section><h1>Passwords do not match</h1><p class='muted'>Return to the invitation link and try again.</p></section>",
                     status_code=400,
                 )
             accepted = SQLiteTenantInvitationService(

--- a/src/veridra/invitation_web.py
+++ b/src/veridra/invitation_web.py
@@ -147,7 +147,7 @@ def _invalid_page() -> HTMLResponse:
     )
 
 
-@router.get("/accept-invitation", response_class=HTMLResponse)
+@router.get("/accept-invitation", response_class=HTMLResponse, response_model=None)
 def accept_invitation_page(request: Request, token: str = "") -> HTMLResponse | RedirectResponse:
     try:
         preview = _preview(request, token)

--- a/src/veridra/invitation_web.py
+++ b/src/veridra/invitation_web.py
@@ -1,0 +1,204 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import hashlib
+import html
+import os
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .existing_user_invitations import SQLiteExistingUserInvitationService
+from .identity_tenancy import RequestIdentity, TenantRole
+from .request_security import require_request_identity
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .session_api import set_session_cookie
+from .session_lifecycle import SessionLifecycleService
+from .sqlite_identity_store import SQLiteIdentityRecordStore
+from .tenant_invitations import SQLiteTenantInvitationService, TenantInvitationError
+
+router = APIRouter(tags=["browser-invitations"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:560px;margin:56px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:12px;padding:28px}h1{margin-top:0}label{display:block;font-weight:700;margin:14px 0 5px}input{width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px}button,.button{display:inline-block;margin-top:20px;border:0;border-radius:7px;background:#22272d;color:#fff;padding:11px 16px;cursor:pointer;text-decoration:none}.muted{color:#68707a}.error{border-left:4px solid #b42318;background:#fff1f0;color:#7a271a;padding:12px;margin:0 0 16px}
+"""
+
+
+@dataclass(frozen=True)
+class InvitationPreview:
+    email: str
+    tenant_id: str
+    tenant_name: str
+    role: TenantRole
+    expires_at: datetime
+    existing_user: bool
+
+
+def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
+    return HTMLResponse(
+        f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='referrer' content='no-referrer'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>",
+        status_code=status_code,
+        headers={
+            "Cache-Control": "no-store",
+            "Referrer-Policy": "no-referrer",
+            "X-Frame-Options": "DENY",
+        },
+    )
+
+
+def _database(request: Request) -> Path:
+    database = getattr(request.app.state, "veridra_identity_database", None)
+    if not isinstance(database, Path):
+        raise HTTPException(status_code=503, detail="Invitations are not configured.")
+    return database
+
+
+def _root(request: Request) -> Path | None:
+    root = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return root if isinstance(root, Path) else None
+
+
+def _store(request: Request) -> SQLiteIdentityRecordStore:
+    store = getattr(request.app.state, "veridra_identity_store", None)
+    if not isinstance(store, SQLiteIdentityRecordStore):
+        raise HTTPException(status_code=503, detail="Invitations are not configured.")
+    return store
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Invitations are not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Invitation request is not permitted.") from exc
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _preview(request: Request, token: str) -> InvitationPreview:
+    if len(token) < 32 or len(token) > 512:
+        raise TenantInvitationError("Invitation is invalid or expired.")
+    token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    with sqlite3.connect(_database(request)) as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            """SELECT i.email, i.tenant_id, i.role, i.expires_at, i.consumed_at,
+                      t.name AS tenant_name,
+                      EXISTS(SELECT 1 FROM users u WHERE u.email = i.email) AS existing_user
+               FROM tenant_invitations i
+               JOIN tenants t ON t.id = i.tenant_id
+               WHERE i.token_hash = ?""",
+            (token_hash,),
+        ).fetchone()
+    if row is None or row["consumed_at"] is not None:
+        raise TenantInvitationError("Invitation is invalid or expired.")
+    expires_at = datetime.fromisoformat(row["expires_at"])
+    if expires_at <= datetime.now(UTC):
+        raise TenantInvitationError("Invitation is invalid or expired.")
+    return InvitationPreview(
+        email=row["email"],
+        tenant_id=row["tenant_id"],
+        tenant_name=row["tenant_name"],
+        role=TenantRole(row["role"]),
+        expires_at=expires_at,
+        existing_user=bool(row["existing_user"]),
+    )
+
+
+def _optional_identity(request: Request) -> RequestIdentity | None:
+    try:
+        return require_request_identity(request)
+    except HTTPException as exc:
+        if exc.status_code == 401:
+            return None
+        raise
+
+
+def _issue_session(request: Request, *, user_id: str, tenant_id: str) -> RedirectResponse:
+    lifetime = timedelta(hours=8)
+    issued = SessionLifecycleService(_store(request)).issue(
+        user_id=user_id,
+        tenant_id=tenant_id,
+        lifetime=lifetime,
+    )
+    response = RedirectResponse("/agency", status_code=303)
+    set_session_cookie(response, issued.credential, max_age=int(lifetime.total_seconds()))
+    return response
+
+
+def _invalid_page() -> HTMLResponse:
+    return _page(
+        "Invalid Veridra invitation",
+        "<section><h1>Invitation is invalid or expired</h1><p class='muted'>Ask the workspace owner to send a new invitation.</p></section>",
+        status_code=400,
+    )
+
+
+@router.get("/accept-invitation", response_class=HTMLResponse)
+def accept_invitation_page(request: Request, token: str = "") -> HTMLResponse | RedirectResponse:
+    try:
+        preview = _preview(request, token)
+    except TenantInvitationError:
+        return _invalid_page()
+    identity = _optional_identity(request)
+    safe_token = html.escape(token, quote=True)
+    tenant_name = html.escape(preview.tenant_name)
+    role = html.escape(preview.role.value.replace("_", " ").title())
+    if preview.existing_user:
+        if identity is None:
+            return_to = f"/accept-invitation?{urlencode({'token': token})}"
+            return RedirectResponse(f"/login?{urlencode({'next': return_to})}", status_code=303)
+        body = f"<section><h1>Join {tenant_name}</h1><p>You have been invited as <strong>{role}</strong>.</p><p class='muted'>This invitation can only be accepted by the matching authenticated account.</p><form method='post' action='/accept-invitation'><input type='hidden' name='token' value='{safe_token}'><button type='submit'>Accept invitation</button></form></section>"
+        return _page("Accept Veridra invitation", body)
+    body = f"<section><h1>Join {tenant_name}</h1><p>You have been invited as <strong>{role}</strong>.</p><p class='muted'>Create your Veridra account to accept this invitation.</p><form method='post' action='/accept-invitation'><input type='hidden' name='token' value='{safe_token}'><label for='display_name'>Your name</label><input id='display_name' name='display_name' maxlength='120' autocomplete='name' required><label for='password'>Password</label><input id='password' name='password' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><label for='password_confirm'>Repeat password</label><input id='password_confirm' name='password_confirm' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><button type='submit'>Create account and join</button></form></section>"
+    return _page("Accept Veridra invitation", body)
+
+
+@router.post("/accept-invitation", response_model=None)
+async def accept_invitation_submit(request: Request) -> HTMLResponse | RedirectResponse:
+    _trusted_origin(request)
+    values = _values(await request.body())
+    token = _one(values, "token")
+    try:
+        preview = _preview(request, token)
+        if preview.existing_user:
+            identity = require_request_identity(request)
+            accepted = SQLiteExistingUserInvitationService(
+                _database(request), _root(request)
+            ).accept(token=token, user_id=identity.user_id)
+        else:
+            password = values.get("password", [""])[0]
+            confirmation = values.get("password_confirm", [""])[0]
+            if password != confirmation:
+                return _page(
+                    "Accept Veridra invitation",
+                    "<section><h1>Passwords do not match</h1><p><a class='button' href='javascript:history.back()'>Go back</a></p></section>",
+                    status_code=400,
+                )
+            accepted = SQLiteTenantInvitationService(
+                _database(request), _root(request)
+            ).accept(
+                token=token,
+                display_name=_one(values, "display_name"),
+                password=password,
+            )
+    except (TenantInvitationError, ValueError, HTTPException):
+        return _invalid_page()
+    return _issue_session(
+        request,
+        user_id=accepted.user_id,
+        tenant_id=accepted.tenant_id,
+    )

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -25,6 +25,7 @@ from .crawl_profile_web import router as crawl_profile_router
 from .existing_user_invitation_api import router as existing_user_invitation_router
 from .finding_task_api import router as finding_task_router
 from .invitation_api import router as invitation_router
+from .invitation_web import router as invitation_web_router
 from .lead_form_tenant_binding_api import router as lead_form_tenant_binding_router
 from .lead_project_conversion_api import router as lead_project_conversion_router
 from .member_assignments_web import router as member_assignments_router
@@ -95,6 +96,7 @@ configure_identity_middleware(app)
 app.include_router(public_router)
 app.include_router(onboarding_router)
 app.include_router(browser_auth_router)
+app.include_router(invitation_web_router)
 app.include_router(tenant_assessment_router)
 app.include_router(operations_router)
 app.include_router(auth_router)

--- a/src/veridra/runtime_email.py
+++ b/src/veridra/runtime_email.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from .email_delivery import EmailDeliveryError, SmtpConfig, default_email_directory
-from .identity_email_delivery import IdentityEmailAttemptStore, PasswordResetEmailAdapter
+from .identity_email_delivery import (
+    IdentityEmailAttemptStore,
+    PasswordResetEmailAdapter,
+    TenantInvitationEmailAdapter,
+)
 from .runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
 
 
@@ -30,9 +34,16 @@ def configure_runtime_email(app: FastAPI, config: RuntimeConfig) -> None:
         attempt_directory = config.identity_database.parent / "identity-email-deliveries"
     else:
         attempt_directory = default_email_directory() / "identity"
+    store = IdentityEmailAttemptStore(attempt_directory)
     app.state.veridra_smtp_config = smtp
     app.state.veridra_password_reset_delivery = PasswordResetEmailAdapter(
         config=smtp,
-        store=IdentityEmailAttemptStore(attempt_directory),
+        store=store,
         reset_origin=config.trusted_origin,
     )
+    if config.trusted_origin:
+        app.state.veridra_tenant_invitation_delivery = TenantInvitationEmailAdapter(
+            config=smtp,
+            store=store,
+            invitation_origin=config.trusted_origin,
+        )

--- a/src/veridra/tenant_team_web.py
+++ b/src/veridra/tenant_team_web.py
@@ -22,7 +22,11 @@ from .identity_tenancy import (
 )
 from .request_security import require_request_identity
 from .tenant_entitlements import bound_tenant_max_users
-from .tenant_invitations import IssuedInvitation, SQLiteTenantInvitationService, TenantInvitationError
+from .tenant_invitations import (
+    IssuedInvitation,
+    SQLiteTenantInvitationService,
+    TenantInvitationError,
+)
 
 router = APIRouter(prefix="/workspace", tags=["tenant-team"])
 InvitationDeliveryAdapter = Callable[[TenantInvitationDelivery], bool]

--- a/src/veridra/tenant_team_web.py
+++ b/src/veridra/tenant_team_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import html
 import sqlite3
+from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import parse_qs
 
@@ -11,6 +12,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 
 from .agency_navigation import agency_navigation
 from .existing_user_invitations import SQLiteExistingUserInvitationService
+from .identity_email_delivery import TenantInvitationDelivery
 from .identity_tenancy import (
     IdentityBoundaryError,
     RequestIdentity,
@@ -20,12 +22,13 @@ from .identity_tenancy import (
 )
 from .request_security import require_request_identity
 from .tenant_entitlements import bound_tenant_max_users
-from .tenant_invitations import SQLiteTenantInvitationService, TenantInvitationError
+from .tenant_invitations import IssuedInvitation, SQLiteTenantInvitationService, TenantInvitationError
 
 router = APIRouter(prefix="/workspace", tags=["tenant-team"])
+InvitationDeliveryAdapter = Callable[[TenantInvitationDelivery], bool]
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1080px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}.row{display:grid;grid-template-columns:2fr 1fr;gap:12px}label{display:block;font-weight:700;margin:10px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:9px 13px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.danger{background:#a23333}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:9px 12px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}code{overflow-wrap:anywhere}@media(max-width:760px){.row{grid-template-columns:1fr}table{display:block;overflow:auto}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1080px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}.row{display:grid;grid-template-columns:2fr 1fr;gap:12px}label{display:block;font-weight:700;margin:10px 0 5px}input,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:9px 13px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.danger{background:#a23333}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.error{border-left-color:#b42318;background:#fff1f0}.actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:9px 12px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}code{overflow-wrap:anywhere}@media(max-width:760px){.row{grid-template-columns:1fr}table{display:block;overflow:auto}}
 """
 
 
@@ -95,8 +98,45 @@ def _existing_service(request: Request) -> SQLiteExistingUserInvitationService:
 
 def _token_page(identity: RequestIdentity, *, email: str, token: str, action: str) -> str:
     navigation = agency_navigation(identity, current="team")
-    body = f"""{navigation}<section><p><a href='/workspace/members'>Team</a></p><h1>{html.escape(action)}</h1><p class='notice success'><strong>Invitation ready for {html.escape(email)}.</strong></p><p>Copy this one-time token now and send it to the intended recipient through a trusted channel. Veridra stores only its hash.</p><p><code>{html.escape(token)}</code></p><p class='muted'>The token expires under the invitation policy and will not be shown again after leaving this page.</p><p><a class='button' href='/workspace/members'>Return to Team</a></p></section>"""
+    body = f"""{navigation}<section><p><a href='/workspace/members'>Team</a></p><h1>{html.escape(action)}</h1><p class='notice success'><strong>Invitation ready for {html.escape(email)}.</strong></p><p>Transactional email is not configured in this runtime. Copy this one-time token and send it to the intended recipient through a trusted channel.</p><p><code>{html.escape(token)}</code></p><p class='muted'>The token expires under the invitation policy and will not be shown again after leaving this page.</p><p><a class='button' href='/workspace/members'>Return to Team</a></p></section>"""
     return _page("Team invitation", body)
+
+
+def _result_page(
+    identity: RequestIdentity,
+    *,
+    issued: IssuedInvitation,
+    action: str,
+    delivered: bool | None,
+) -> str:
+    if delivered is None:
+        return _token_page(
+            identity,
+            email=issued.email,
+            token=issued.token,
+            action=action,
+        )
+    navigation = agency_navigation(identity, current="team")
+    if delivered:
+        notice = f"<p class='notice success'><strong>Invitation email sent to {html.escape(issued.email)}.</strong></p><p class='muted'>The recipient can accept it from the secure link in the email. The invitation token is not displayed here.</p>"
+    else:
+        notice = f"<p class='notice error'><strong>Invitation created, but email delivery to {html.escape(issued.email)} failed.</strong></p><p class='muted'>The invitation remains active. Check SMTP delivery evidence and use Resend after the mail service is healthy.</p>"
+    body = f"{navigation}<section><p><a href='/workspace/members'>Team</a></p><h1>{html.escape(action)}</h1>{notice}<p><a class='button' href='/workspace/members'>Return to Team</a></p></section>"
+    return _page("Team invitation", body)
+
+
+def _deliver(request: Request, issued: IssuedInvitation) -> bool | None:
+    delivery = getattr(request.app.state, "veridra_tenant_invitation_delivery", None)
+    if not callable(delivery):
+        return None
+    adapter: InvitationDeliveryAdapter = delivery
+    return adapter(
+        TenantInvitationDelivery(
+            email=issued.email,
+            token=issued.token,
+            expires_at=issued.expires_at,
+        )
+    )
 
 
 @router.get("/members", response_class=HTMLResponse)
@@ -125,7 +165,7 @@ def tenant_team(request: Request) -> str:
     ) or "<tr><td colspan='4'>No tenant memberships were found.</td></tr>"
     invitations = _service(request).list_active(tenant_id=identity.tenant_id)
     invitation_rows = "".join(
-        "<tr><td>{email}</td><td>{role}</td><td>{expires}</td><td><div class='actions'><form method='post' action='/workspace/members/invitations/{identifier}/resend'><button class='secondary' type='submit'>Resend token</button></form><form method='post' action='/workspace/members/invitations/{identifier}/cancel'><button class='danger' type='submit'>Cancel</button></form></div></td></tr>".format(
+        "<tr><td>{email}</td><td>{role}</td><td>{expires}</td><td><div class='actions'><form method='post' action='/workspace/members/invitations/{identifier}/resend'><button class='secondary' type='submit'>Resend invitation</button></form><form method='post' action='/workspace/members/invitations/{identifier}/cancel'><button class='danger' type='submit'>Cancel</button></form></div></td></tr>".format(
             email=html.escape(invitation.email),
             role=html.escape(invitation.role.value.title()),
             expires=html.escape(invitation.expires_at.isoformat()),
@@ -139,7 +179,7 @@ def tenant_team(request: Request) -> str:
         if role is not TenantRole.owner
     )
     navigation = agency_navigation(identity, current="team")
-    body = f"""{navigation}<section><p><a href='/agency'>Agency home</a></p><h1>Team</h1><p><strong>{html.escape(seat_text)}</strong></p><p class='muted'>These are real authenticated tenant memberships. Seat capacity is enforced again atomically when an invitation is accepted, so pending invitations cannot overbook the plan.</p></section><section><h2>Invite a team member</h2><form method='post' action='/workspace/members/invite'><div class='row'><div><label for='email'>Email</label><input id='email' name='email' type='email' maxlength='320' required></div><div><label for='role'>Role</label><select id='role' name='role'>{roles}</select></div></div><p class='muted'>Veridra automatically uses the authenticated existing-user flow when this email already belongs to an active account.</p><button type='submit'>Create invitation</button></form></section><section><h2>Members</h2><table><thead><tr><th>Member</th><th>Role</th><th>Status</th><th>Joined</th></tr></thead><tbody>{member_rows}</tbody></table></section><section><h2>Pending invitations</h2><table><thead><tr><th>Email</th><th>Role</th><th>Expires</th><th>Actions</th></tr></thead><tbody>{invitation_rows}</tbody></table></section>"""
+    body = f"""{navigation}<section><p><a href='/agency'>Agency home</a></p><h1>Team</h1><p><strong>{html.escape(seat_text)}</strong></p><p class='muted'>These are real authenticated tenant memberships. Seat capacity is enforced again atomically when an invitation is accepted, so pending invitations cannot overbook the plan.</p></section><section><h2>Invite a team member</h2><form method='post' action='/workspace/members/invite'><div class='row'><div><label for='email'>Email</label><input id='email' name='email' type='email' maxlength='320' required></div><div><label for='role'>Role</label><select id='role' name='role'>{roles}</select></div></div><p class='muted'>Veridra automatically uses the authenticated existing-user flow when this email already belongs to an active account. Production sends a secure acceptance link by transactional email.</p><button type='submit'>Send invitation</button></form></section><section><h2>Members</h2><table><thead><tr><th>Member</th><th>Role</th><th>Status</th><th>Joined</th></tr></thead><tbody>{member_rows}</tbody></table></section><section><h2>Pending invitations</h2><table><thead><tr><th>Email</th><th>Role</th><th>Expires</th><th>Actions</th></tr></thead><tbody>{invitation_rows}</tbody></table></section>"""
     return _page("Tenant team", body)
 
 
@@ -173,7 +213,12 @@ async def invite_team_member(request: Request) -> str:
             )
     except TenantInvitationError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return _token_page(identity, email=issued.email, token=issued.token, action="Invitation created")
+    return _result_page(
+        identity,
+        issued=issued,
+        action="Invitation created",
+        delivered=_deliver(request, issued),
+    )
 
 
 @router.post("/members/invitations/{invitation_id}/cancel")
@@ -202,4 +247,9 @@ def resend_team_invitation(invitation_id: str, request: Request) -> str:
         )
     except TenantInvitationError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return _token_page(identity, email=issued.email, token=issued.token, action="Invitation token replaced")
+    return _result_page(
+        identity,
+        issued=issued,
+        action="Invitation replaced",
+        delivered=_deliver(request, issued),
+    )

--- a/tests/test_identity_email_delivery.py
+++ b/tests/test_identity_email_delivery.py
@@ -7,10 +7,17 @@ from pathlib import Path
 import pytest
 
 from veridra.email_delivery import EmailEncryption, EmailStatus, SmtpConfig
-from veridra.identity_email_delivery import IdentityEmailAttemptStore, PasswordResetEmailAdapter
+from veridra.identity_email_delivery import (
+    IdentityEmailAttemptStore,
+    IdentityEmailKind,
+    PasswordResetEmailAdapter,
+    TenantInvitationDelivery,
+    TenantInvitationEmailAdapter,
+)
 from veridra.password_recovery_api import PasswordResetDelivery
 
 TOKEN = "reset-token-that-must-never-be-persisted"
+INVITATION_TOKEN = "invitation-token-that-must-never-be-persisted-123456"
 NOW = datetime(2026, 8, 20, 15, 0, tzinfo=UTC)
 
 
@@ -73,6 +80,67 @@ def test_password_reset_email_uses_browser_reset_link_when_origin_is_configured(
     assert f"https://app.example.com/reset-password?token={TOKEN}" in body
     assert "/api/auth/password-recovery/reset" not in body
     assert TOKEN.encode("utf-8") not in next(tmp_path.glob("*.json")).read_bytes()
+
+
+def test_invitation_email_uses_browser_acceptance_link_and_hash_only_evidence(
+    tmp_path: Path,
+) -> None:
+    messages: list[EmailMessage] = []
+    store = IdentityEmailAttemptStore(tmp_path)
+    adapter = TenantInvitationEmailAdapter(
+        config=_config(),
+        store=store,
+        invitation_origin="https://app.example.com/",
+        sender=lambda config, message: messages.append(message),
+    )
+    delivery = TenantInvitationDelivery(
+        email="invitee@example.com",
+        token=INVITATION_TOKEN,
+        expires_at=NOW + timedelta(hours=48),
+    )
+
+    delivered = adapter(delivery)
+
+    assert delivered
+    assert len(messages) == 1
+    assert (
+        f"https://app.example.com/accept-invitation?token={INVITATION_TOKEN}"
+        in messages[0].get_content()
+    )
+    attempts = store.list()
+    assert len(attempts) == 1
+    assert attempts[0][1].kind is IdentityEmailKind.tenant_invitation
+    assert attempts[0][1].status is EmailStatus.delivered
+    assert attempts[0][1].recipient == "invitee@example.com"
+    assert INVITATION_TOKEN.encode("utf-8") not in next(tmp_path.glob("*.json")).read_bytes()
+
+
+def test_invitation_email_failure_returns_false_and_records_failure(tmp_path: Path) -> None:
+    store = IdentityEmailAttemptStore(tmp_path)
+
+    def fail(config: SmtpConfig, message: EmailMessage) -> None:
+        raise OSError("smtp unavailable")
+
+    adapter = TenantInvitationEmailAdapter(
+        config=_config(),
+        store=store,
+        invitation_origin="https://app.example.com",
+        sender=fail,
+    )
+
+    delivered = adapter(
+        TenantInvitationDelivery(
+            email="invitee@example.com",
+            token=INVITATION_TOKEN,
+            expires_at=NOW + timedelta(hours=48),
+        )
+    )
+
+    assert not delivered
+    attempts = store.list()
+    assert len(attempts) == 1
+    assert attempts[0][1].status is EmailStatus.failed
+    assert attempts[0][1].error == "smtp unavailable"
 
 
 def test_password_reset_smtp_failure_is_persisted_without_raising(tmp_path: Path) -> None:

--- a/tests/test_invitation_web.py
+++ b/tests/test_invitation_web.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.browser_auth_web import router as browser_auth_router
+from veridra.existing_user_invitations import SQLiteExistingUserInvitationService
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.invitation_web import router as invitation_router
+from veridra.login_throttle import SQLiteLoginThrottle
+from veridra.password_auth import SQLitePasswordAuthenticator
+from veridra.request_security import bind_verified_request_identity
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+from veridra.tenant_invitations import SQLiteTenantInvitationService
+
+NOW = datetime(2026, 8, 20, 15, 0, tzinfo=UTC)
+ORIGIN = "http://testserver"
+OWNER_PASSWORD = "owner-correct-horse-battery"
+INVITEE_PASSWORD = "invitee-correct-horse-battery"
+
+
+def _base(tmp_path: Path) -> tuple[Path, str, str]:
+    database = tmp_path / "identity.sqlite3"
+    created = SQLiteIdentityBootstrap(database).create_first_owner(
+        tenant_slug="customer-one",
+        tenant_name="Customer One",
+        owner_email="owner@example.com",
+        owner_name="Owner",
+        password=OWNER_PASSWORD,
+        confirmation=BOOTSTRAP_CONFIRMATION,
+        created_at=NOW,
+    )
+    return database, created.tenant_id, created.user_id
+
+
+def _app(database: Path) -> FastAPI:
+    store = SQLiteIdentityRecordStore(database)
+    store.initialize()
+    authenticator = SQLitePasswordAuthenticator(database)
+    authenticator.initialize()
+    throttle = SQLiteLoginThrottle(database)
+    throttle.initialize()
+    app = FastAPI()
+    app.state.veridra_identity_database = database
+    app.state.veridra_identity_store = store
+    app.state.veridra_password_authenticator = authenticator
+    app.state.veridra_login_throttle = throttle
+    app.include_router(browser_auth_router)
+    app.include_router(invitation_router)
+    return app
+
+
+def test_new_user_accepts_invitation_in_browser_and_gets_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, tenant_id, owner_id = _base(tmp_path)
+    issued = SQLiteTenantInvitationService(database).issue(
+        tenant_id=tenant_id,
+        created_by_user_id=owner_id,
+        email="invitee@example.com",
+        role=TenantRole.analyst,
+        now=NOW,
+    )
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    client = TestClient(_app(database))
+
+    page = client.get("/accept-invitation", params={"token": issued.token})
+    rejected_origin = client.post(
+        "/accept-invitation",
+        data={
+            "token": issued.token,
+            "display_name": "Invitee",
+            "password": INVITEE_PASSWORD,
+            "password_confirm": INVITEE_PASSWORD,
+        },
+        follow_redirects=False,
+    )
+    accepted = client.post(
+        "/accept-invitation",
+        headers={"Origin": ORIGIN},
+        data={
+            "token": issued.token,
+            "display_name": "Invitee",
+            "password": INVITEE_PASSWORD,
+            "password_confirm": INVITEE_PASSWORD,
+        },
+        follow_redirects=False,
+    )
+    replay = client.get("/accept-invitation", params={"token": issued.token})
+
+    assert page.status_code == 200
+    assert "Join Customer One" in page.text
+    assert "Create your Veridra account" in page.text
+    assert page.headers["cache-control"] == "no-store"
+    assert page.headers["referrer-policy"] == "no-referrer"
+    assert rejected_origin.status_code == 403
+    assert accepted.status_code == 303
+    assert accepted.headers["location"] == "/agency"
+    assert "veridra_session=" in accepted.headers["set-cookie"]
+    assert issued.token not in accepted.text
+    assert replay.status_code == 400
+    assert SQLitePasswordAuthenticator(database).authenticate(
+        email="invitee@example.com",
+        tenant_slug="customer-one",
+        password=INVITEE_PASSWORD,
+    ) is not None
+
+
+def test_existing_user_invitation_requires_login_and_accepts_matching_account(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, source_tenant_id, owner_id = _base(tmp_path)
+    target_tenant_id = "2" * 24
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """INSERT INTO tenants (id, slug, display_name, status, created_at)
+            VALUES (?, ?, ?, ?, ?)""",
+            (target_tenant_id, "customer-two", "Customer Two", "active", NOW.isoformat()),
+        )
+    issued = SQLiteExistingUserInvitationService(database).issue(
+        tenant_id=target_tenant_id,
+        created_by_user_id=owner_id,
+        email="owner@example.com",
+        role=TenantRole.analyst,
+        now=NOW,
+    )
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    app = _app(database)
+    owner_identity = RequestIdentity(
+        user_id=owner_id,
+        tenant_id=source_tenant_id,
+        membership_role=TenantRole.owner,
+        session_id="existing-invite-session-1",
+        authenticated_at=NOW,
+    )
+
+    @app.middleware("http")
+    async def optional_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if request.headers.get("x-authenticated") == "yes":
+            bind_verified_request_identity(request, owner_identity)
+        return await call_next(request)
+
+    client = TestClient(app)
+    anonymous = client.get(
+        "/accept-invitation",
+        params={"token": issued.token},
+        follow_redirects=False,
+    )
+    parsed = urlsplit(anonymous.headers["location"])
+    next_target = parse_qs(parsed.query)["next"][0]
+    login_page = client.get(anonymous.headers["location"])
+    accepted = client.post(
+        "/accept-invitation",
+        headers={"Origin": ORIGIN, "x-authenticated": "yes"},
+        data={"token": issued.token},
+        follow_redirects=False,
+    )
+
+    assert anonymous.status_code == 303
+    assert parsed.path == "/login"
+    assert next_target.startswith("/accept-invitation?token=")
+    assert issued.token in next_target
+    assert login_page.status_code == 200
+    assert html_hidden_next(next_target) in login_page.text
+    assert accepted.status_code == 303
+    assert accepted.headers["location"] == "/agency"
+    with sqlite3.connect(database) as connection:
+        membership = connection.execute(
+            "SELECT role, active FROM memberships WHERE tenant_id = ? AND user_id = ?",
+            (target_tenant_id, owner_id),
+        ).fetchone()
+    assert membership == ("analyst", 1)
+
+
+def html_hidden_next(next_target: str) -> str:
+    import html
+
+    return f"name='next' value='{html.escape(next_target, quote=True)}'"
+
+
+def test_login_next_rejects_external_redirect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database, _, _ = _base(tmp_path)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    client = TestClient(_app(database))
+
+    response = client.post(
+        "/login",
+        headers={"Origin": ORIGIN},
+        data={
+            "tenant_slug": "customer-one",
+            "email": "owner@example.com",
+            "password": OWNER_PASSWORD,
+            "next": "https://evil.example/steal",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/agency"

--- a/tests/test_runtime_email.py
+++ b/tests/test_runtime_email.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from fastapi import FastAPI
 
-from veridra.identity_email_delivery import PasswordResetEmailAdapter
+from veridra.identity_email_delivery import PasswordResetEmailAdapter, TenantInvitationEmailAdapter
 from veridra.runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
 from veridra.runtime_email import configure_runtime_email
 
@@ -55,6 +55,7 @@ def test_development_can_run_without_transactional_email(
     configure_runtime_email(app, _config(tmp_path, RuntimeEnvironment.development))
 
     assert not hasattr(app.state, "veridra_password_reset_delivery")
+    assert not hasattr(app.state, "veridra_tenant_invitation_delivery")
 
 
 def test_production_requires_smtp_configuration(
@@ -80,7 +81,7 @@ def test_production_requires_auth_secret_when_username_is_configured(
         configure_runtime_email(FastAPI(), _config(tmp_path, RuntimeEnvironment.production))
 
 
-def test_configured_smtp_installs_password_reset_adapter(
+def test_configured_smtp_installs_identity_email_adapters(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -91,7 +92,10 @@ def test_configured_smtp_installs_password_reset_adapter(
 
     configure_runtime_email(app, _config(tmp_path, RuntimeEnvironment.production))
 
-    adapter = app.state.veridra_password_reset_delivery
-    assert isinstance(adapter, PasswordResetEmailAdapter)
-    assert adapter.reset_origin == "https://app.example.com"
+    reset_adapter = app.state.veridra_password_reset_delivery
+    invitation_adapter = app.state.veridra_tenant_invitation_delivery
+    assert isinstance(reset_adapter, PasswordResetEmailAdapter)
+    assert isinstance(invitation_adapter, TenantInvitationEmailAdapter)
+    assert reset_adapter.reset_origin == "https://app.example.com"
+    assert invitation_adapter.invitation_origin == "https://app.example.com"
     assert app.state.veridra_smtp_config.host == "smtp.example.test"

--- a/tests/test_tenant_team_web.py
+++ b/tests/test_tenant_team_web.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient
 
 from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_email_delivery import TenantInvitationDelivery
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.request_security import bind_verified_request_identity
 from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
@@ -85,7 +86,9 @@ def test_team_page_is_tenant_native_and_permission_bound(tmp_path: Path) -> None
     assert "href='/members'" not in owner.text
 
 
-def test_team_invitation_create_resend_and_cancel(tmp_path: Path) -> None:
+def test_team_invitation_create_resend_and_cancel_without_email_uses_manual_fallback(
+    tmp_path: Path,
+) -> None:
     client, database, root, owner = _client(tmp_path)
     headers = {"x-test-role": "owner"}
 
@@ -97,7 +100,7 @@ def test_team_invitation_create_resend_and_cancel(tmp_path: Path) -> None:
 
     assert created.status_code == 200
     assert "Invitation ready for analyst@example.com" in created.text
-    assert "Veridra stores only its hash" in created.text
+    assert "Transactional email is not configured" in created.text
     service = SQLiteTenantInvitationService(database, root)
     active = service.list_active(tenant_id=owner.tenant_id, now=NOW)
     assert len(active) == 1
@@ -105,7 +108,7 @@ def test_team_invitation_create_resend_and_cancel(tmp_path: Path) -> None:
 
     listed = client.get("/workspace/members", headers=headers)
     assert "analyst@example.com" in listed.text
-    assert "Resend token" in listed.text
+    assert "Resend invitation" in listed.text
     assert "Cancel" in listed.text
 
     resent = client.post(
@@ -113,7 +116,7 @@ def test_team_invitation_create_resend_and_cancel(tmp_path: Path) -> None:
         headers=headers,
     )
     assert resent.status_code == 200
-    assert "Invitation token replaced" in resent.text
+    assert "Invitation ready for analyst@example.com" in resent.text
     replacement = service.list_active(tenant_id=owner.tenant_id, now=NOW)
     assert len(replacement) == 1
     assert replacement[0].id != invitation_id
@@ -126,6 +129,47 @@ def test_team_invitation_create_resend_and_cancel(tmp_path: Path) -> None:
     assert cancelled.status_code == 303
     assert cancelled.headers["location"] == "/workspace/members"
     assert service.list_active(tenant_id=owner.tenant_id, now=NOW) == ()
+
+
+def test_team_invitation_uses_email_adapter_without_exposing_token(tmp_path: Path) -> None:
+    client, _, _, _ = _client(tmp_path)
+    deliveries: list[TenantInvitationDelivery] = []
+
+    def deliver(delivery: TenantInvitationDelivery) -> bool:
+        deliveries.append(delivery)
+        return True
+
+    client.app.state.veridra_tenant_invitation_delivery = deliver
+    response = client.post(
+        "/workspace/members/invite",
+        headers={"x-test-role": "owner"},
+        data={"email": "analyst@example.com", "role": "analyst"},
+    )
+
+    assert response.status_code == 200
+    assert "Invitation email sent to analyst@example.com" in response.text
+    assert len(deliveries) == 1
+    assert deliveries[0].email == "analyst@example.com"
+    assert deliveries[0].token not in response.text
+
+
+def test_team_invitation_delivery_failure_keeps_active_invitation(tmp_path: Path) -> None:
+    client, database, root, owner = _client(tmp_path)
+    client.app.state.veridra_tenant_invitation_delivery = lambda delivery: False
+
+    response = client.post(
+        "/workspace/members/invite",
+        headers={"x-test-role": "owner"},
+        data={"email": "analyst@example.com", "role": "analyst"},
+    )
+
+    assert response.status_code == 200
+    assert "email delivery to analyst@example.com failed" in response.text
+    active = SQLiteTenantInvitationService(database, root).list_active(
+        tenant_id=owner.tenant_id,
+        now=NOW,
+    )
+    assert len(active) == 1
 
 
 def test_team_rejects_owner_invitation(tmp_path: Path) -> None:

--- a/tests/test_tenant_team_web.py
+++ b/tests/test_tenant_team_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient
@@ -139,7 +140,8 @@ def test_team_invitation_uses_email_adapter_without_exposing_token(tmp_path: Pat
         deliveries.append(delivery)
         return True
 
-    client.app.state.veridra_tenant_invitation_delivery = deliver
+    app = cast(FastAPI, client.app)
+    app.state.veridra_tenant_invitation_delivery = deliver
     response = client.post(
         "/workspace/members/invite",
         headers={"x-test-role": "owner"},
@@ -155,7 +157,8 @@ def test_team_invitation_uses_email_adapter_without_exposing_token(tmp_path: Pat
 
 def test_team_invitation_delivery_failure_keeps_active_invitation(tmp_path: Path) -> None:
     client, database, root, owner = _client(tmp_path)
-    client.app.state.veridra_tenant_invitation_delivery = lambda delivery: False
+    app = cast(FastAPI, client.app)
+    app.state.veridra_tenant_invitation_delivery = lambda delivery: False
 
     response = client.post(
         "/workspace/members/invite",


### PR DESCRIPTION
Completes the normal customer invitation handoff using Veridra's existing invitation, identity, seat-entitlement and SMTP boundaries.

What changes:
- add transactional tenant-invitation email through the existing secure SMTP/evidence subsystem;
- persist only token hashes/derived delivery keys in invitation and email evidence;
- give Team owners delivery success/failure without displaying bearer tokens when SMTP is configured;
- retain the one-time manual-token page only as a development/local fallback when transactional email is absent;
- add `/accept-invitation` browser acceptance with no-store/no-referrer protections;
- new users create credentials and join the invited tenant through the existing atomic invitation service;
- existing users are redirected through login and must authenticate as the invited account before membership is added;
- support only a tightly validated internal `/accept-invitation` post-login continuation, rejecting arbitrary redirect targets;
- issue a session scoped to the accepted tenant after either acceptance path;
- retain invitation expiry, one-time consumption and seat-capacity enforcement from the existing services;
- add tests for email delivery/evidence, Team send/failure behavior, new-user acceptance, existing-user cross-tenant acceptance, same-origin enforcement and open-redirect rejection;
- document production invitation delivery and query-string redaction requirements.

The API token contracts remain available for compatibility; this PR changes the normal Team/browser customer journey, not the underlying invitation storage model.

Do not merge until exact-head full CI succeeds.