### PR TITLE
Add Stripe billing adapter and customer subscription flows

### DIFF
--- a/docs/operations/stripe-billing.md
+++ b/docs/operations/stripe-billing.md
@@ -41,3 +41,7 @@ Veridra's quota ledger supports cycle anchor days 1–28 so every month has the 
 - Exercise checkout, `customer.subscription.created`, plan change, payment-failure/suspension behavior, Billing Portal, cancellation, duplicate events and delayed/out-of-order events.
 - Confirm reverse-proxy/application logs do not record secret keys, webhook secrets or full request bodies.
 - Keep Stripe Dashboard access and webhook-secret rotation procedures under normal production secret-management controls.
+
+## Scope of this adapter
+
+This code establishes the authenticated Stripe boundary and entitlement reconciliation path. It does not create a Stripe account, products, Prices, Portal configuration or a live provider webhook endpoint on the operator's behalf. Those provider-side resources must be configured explicitly and validated in Stripe test mode before any live charge is possible.

--- a/docs/operations/stripe-billing.md
+++ b/docs/operations/stripe-billing.md
@@ -1,0 +1,43 @@
+# Stripe billing boundary
+
+Veridra keeps subscription entitlements provider-neutral. Stripe is an adapter around `SubscriptionAuthority`; Stripe webhooks never write workspace plan files directly.
+
+## Required configuration
+
+Billing is disabled unless all of these are configured:
+
+- `VERIDRA_STRIPE_SECRET_KEY`
+- `VERIDRA_STRIPE_WEBHOOK_SECRET`
+- `VERIDRA_STRIPE_PRICE_SOLO`
+- `VERIDRA_STRIPE_PRICE_PROFESSIONAL`
+- `VERIDRA_STRIPE_PRICE_AGENCY`
+- `VERIDRA_TRUSTED_ORIGIN`
+
+Do not commit live or test secrets. Configure the webhook endpoint in Stripe as `/api/billing/stripe/webhook` on the trusted HTTPS origin.
+
+## Trust boundary
+
+1. Checkout and Billing Portal requests require an authenticated tenant identity with `manage_tenant` capability.
+2. Veridra creates hosted Stripe sessions server-side with the secret key. Price IDs come only from server configuration; the browser never supplies arbitrary Stripe prices.
+3. Checkout stores the Veridra tenant identifier and requested plan in Stripe subscription metadata.
+4. Webhooks are verified against the raw request body, `Stripe-Signature`, and the configured webhook secret before JSON is trusted.
+5. For subscription create/update events, Veridra retrieves the current subscription from Stripe after verification instead of trusting webhook delivery order.
+6. The Stripe Price ID is mapped back to a Veridra plan using server configuration. Unmapped prices cannot grant entitlements.
+7. The resulting provider-neutral `SubscriptionUpdate` is applied through `SubscriptionAuthority`, retaining its replay, stale-state, evidence and rollback protections.
+8. A subscription deletion suspends a workspace only when the deleted Stripe subscription is the subscription currently bound to that tenant.
+
+## Customer binding
+
+The tenant workspace stores only operational Stripe identifiers needed for reconciliation (`customer_id`, `subscription_id`) in `workspace/billing/stripe.json`. API keys and webhook secrets are never persisted there.
+
+## Billing-cycle normalization
+
+Veridra's quota ledger supports cycle anchor days 1–28 so every month has the anchor. Stripe billing-cycle days 29–31 are therefore normalized to day 28 for Veridra quota periods; Stripe remains authoritative for actual invoice dates.
+
+## Operational checks before live billing
+
+- Use Stripe test mode first.
+- Confirm each configured Price is recurring and represents the intended Veridra plan.
+- Exercise checkout, `customer.subscription.created`, plan change, payment-failure/suspension behavior, Billing Portal, cancellation, duplicate events and delayed/out-of-order events.
+- Confirm reverse-proxy/application logs do not record secret keys, webhook secrets or full request bodies.
+- Keep Stripe Dashboard access and webhook-secret rotation procedures under normal production secret-management controls.

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -36,10 +36,12 @@ from .password_recovery_api import router as password_recovery_router
 from .pdf_web import router as pdf_router
 from .public_web import ToolDefinition
 from .public_web import router as public_router
+from .runtime_billing import configure_runtime_billing
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
 from .runtime_email import configure_runtime_email
 from .session_api import router as session_router
+from .stripe_billing_web import router as stripe_billing_router
 from .tenant_assessment_routes import router as tenant_assessment_router
 from .tenant_bound_lead_capture import router as tenant_bound_lead_capture_router
 from .tenant_history_api import router as tenant_history_router
@@ -64,6 +66,7 @@ app.state.veridra_runtime_config = runtime_config
 if runtime_config.tenant_data_root is not None:
     app.state.veridra_tenant_data_root = runtime_config.tenant_data_root
 configure_runtime_email(app, runtime_config)
+configure_runtime_billing(app, runtime_config)
 app.add_middleware(
     RuntimeBoundaryMiddleware,
     max_body_bytes=runtime_config.max_request_body_bytes,
@@ -97,6 +100,7 @@ app.include_router(public_router)
 app.include_router(onboarding_router)
 app.include_router(browser_auth_router)
 app.include_router(invitation_web_router)
+app.include_router(stripe_billing_router)
 app.include_router(tenant_assessment_router)
 app.include_router(operations_router)
 app.include_router(auth_router)

--- a/src/veridra/runtime_billing.py
+++ b/src/veridra/runtime_billing.py
@@ -31,7 +31,8 @@ def configure_runtime_billing(app: FastAPI, runtime: RuntimeConfig) -> None:
         raise RuntimeConfigurationError(
             "VERIDRA_TENANT_DATA_ROOT is required when Stripe billing is enabled."
         )
-    if runtime.trusted_origin is None or config.trusted_origin != runtime.trusted_origin.rstrip("/"):
+    trusted_origin = runtime.trusted_origin
+    if trusted_origin is None or config.trusted_origin != trusted_origin.rstrip("/"):
         raise RuntimeConfigurationError(
             "Stripe billing must use the configured VERIDRA_TRUSTED_ORIGIN."
         )

--- a/src/veridra/runtime_billing.py
+++ b/src/veridra/runtime_billing.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import FastAPI
+
+from .runtime_config import RuntimeConfig, RuntimeConfigurationError
+from .stripe_billing import (
+    StripeApiClient,
+    StripeBillingConfig,
+    StripeBillingError,
+    StripeSubscriptionAdapter,
+)
+
+
+@dataclass(frozen=True)
+class StripeBillingRuntime:
+    config: StripeBillingConfig
+    client: StripeApiClient
+    adapter: StripeSubscriptionAdapter
+
+
+def configure_runtime_billing(app: FastAPI, runtime: RuntimeConfig) -> None:
+    try:
+        config = StripeBillingConfig.from_environment()
+    except StripeBillingError as exc:
+        raise RuntimeConfigurationError("Stripe billing configuration is invalid.") from exc
+    if config is None:
+        return
+    if runtime.tenant_data_root is None:
+        raise RuntimeConfigurationError(
+            "VERIDRA_TENANT_DATA_ROOT is required when Stripe billing is enabled."
+        )
+    if runtime.trusted_origin is None or config.trusted_origin != runtime.trusted_origin.rstrip("/"):
+        raise RuntimeConfigurationError(
+            "Stripe billing must use the configured VERIDRA_TRUSTED_ORIGIN."
+        )
+    client = StripeApiClient(config)
+    app.state.veridra_stripe_billing = StripeBillingRuntime(
+        config=config,
+        client=client,
+        adapter=StripeSubscriptionAdapter(
+            config=config,
+            tenant_root=runtime.tenant_data_root,
+            client=client,
+        ),
+    )

--- a/src/veridra/stripe_billing.py
+++ b/src/veridra/stripe_billing.py
@@ -391,7 +391,9 @@ class StripeSubscriptionAdapter:
     def _tenant_id(subscription: StripeSubscription) -> str:
         tenant_id = subscription.metadata.get("veridra_tenant_id", "").strip().lower()
         if len(tenant_id) != 24 or any(char not in "0123456789abcdef" for char in tenant_id):
-            raise StripeBillingError("Stripe subscription is missing valid Veridra tenant metadata.")
+            raise StripeBillingError(
+                "Stripe subscription is missing valid Veridra tenant metadata."
+            )
         return tenant_id
 
     def _update(

--- a/src/veridra/stripe_billing.py
+++ b/src/veridra/stripe_billing.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import cast
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from .subscription_authority import (
+    SubscriptionApplyResult,
+    SubscriptionAuthority,
+    SubscriptionAuthorityError,
+    SubscriptionUpdate,
+)
+from .workspace_policy import PlanName, WorkspaceStatus, WorkspaceStore
+
+
+class StripeBillingError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class StripeBillingConfig:
+    secret_key: str = field(repr=False)
+    webhook_secret: str = field(repr=False)
+    price_solo: str
+    price_professional: str
+    price_agency: str
+    trusted_origin: str
+
+    @classmethod
+    def from_environment(
+        cls,
+        env: Mapping[str, str] | None = None,
+    ) -> StripeBillingConfig | None:
+        values = os.environ if env is None else env
+        names = (
+            "VERIDRA_STRIPE_SECRET_KEY",
+            "VERIDRA_STRIPE_WEBHOOK_SECRET",
+            "VERIDRA_STRIPE_PRICE_SOLO",
+            "VERIDRA_STRIPE_PRICE_PROFESSIONAL",
+            "VERIDRA_STRIPE_PRICE_AGENCY",
+            "VERIDRA_TRUSTED_ORIGIN",
+        )
+        configured = {name: values.get(name, "").strip() for name in names}
+        if not any(configured.values()):
+            return None
+        missing = [name for name, value in configured.items() if not value]
+        if missing:
+            raise StripeBillingError(
+                "Stripe billing configuration is incomplete: " + ", ".join(sorted(missing))
+            )
+        secret_key = configured["VERIDRA_STRIPE_SECRET_KEY"]
+        webhook_secret = configured["VERIDRA_STRIPE_WEBHOOK_SECRET"]
+        if not secret_key.startswith(("sk_test_", "sk_live_")):
+            raise StripeBillingError("VERIDRA_STRIPE_SECRET_KEY is not a Stripe secret key.")
+        if not webhook_secret.startswith("whsec_"):
+            raise StripeBillingError("VERIDRA_STRIPE_WEBHOOK_SECRET is not a webhook secret.")
+        prices = (
+            configured["VERIDRA_STRIPE_PRICE_SOLO"],
+            configured["VERIDRA_STRIPE_PRICE_PROFESSIONAL"],
+            configured["VERIDRA_STRIPE_PRICE_AGENCY"],
+        )
+        if any(not price.startswith("price_") for price in prices):
+            raise StripeBillingError("Stripe plan mappings must contain Stripe Price IDs.")
+        if len(set(prices)) != len(prices):
+            raise StripeBillingError("Stripe plan Price IDs must be distinct.")
+        return cls(
+            secret_key=secret_key,
+            webhook_secret=webhook_secret,
+            price_solo=prices[0],
+            price_professional=prices[1],
+            price_agency=prices[2],
+            trusted_origin=configured["VERIDRA_TRUSTED_ORIGIN"].rstrip("/"),
+        )
+
+    def price_for_plan(self, plan: PlanName) -> str:
+        try:
+            return {
+                PlanName.solo: self.price_solo,
+                PlanName.professional: self.price_professional,
+                PlanName.agency: self.price_agency,
+            }[plan]
+        except KeyError as exc:
+            raise StripeBillingError("The free plan does not have a paid checkout Price.") from exc
+
+    def plan_for_price(self, price_id: str) -> PlanName:
+        mapping = {
+            self.price_solo: PlanName.solo,
+            self.price_professional: PlanName.professional,
+            self.price_agency: PlanName.agency,
+        }
+        try:
+            return mapping[price_id]
+        except KeyError as exc:
+            raise StripeBillingError("Stripe subscription contains an unmapped Price ID.") from exc
+
+
+class StripeCheckoutSession(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1)
+    url: str = Field(min_length=1)
+
+
+class StripePortalSession(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1)
+    url: str = Field(min_length=1)
+
+
+class StripePrice(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1)
+
+
+class StripeSubscriptionItem(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    price: StripePrice
+
+
+class StripeSubscriptionItems(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    data: list[StripeSubscriptionItem]
+
+
+class StripeSubscription(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1)
+    customer: str = Field(min_length=1)
+    status: str = Field(min_length=1)
+    billing_cycle_anchor: int = Field(ge=0)
+    metadata: dict[str, str] = Field(default_factory=dict)
+    items: StripeSubscriptionItems
+
+
+class StripeWebhookData(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    object: dict[str, object]
+
+
+class StripeWebhookEvent(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1)
+    type: str = Field(min_length=1)
+    created: int = Field(ge=0)
+    data: StripeWebhookData
+
+
+class StripeTenantBinding(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    tenant_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    customer_id: str = Field(min_length=1, max_length=160)
+    subscription_id: str = Field(min_length=1, max_length=160)
+    updated_at: datetime
+
+
+class StripeTenantBindingStore:
+    def __init__(self, tenant_root: Path) -> None:
+        self.tenant_root = tenant_root
+
+    def _path(self, tenant_id: str) -> Path:
+        if len(tenant_id) != 24 or any(char not in "0123456789abcdef" for char in tenant_id):
+            raise StripeBillingError("Tenant identifier is invalid.")
+        return self.tenant_root / tenant_id / "workspace" / "billing" / "stripe.json"
+
+    def load(self, tenant_id: str) -> StripeTenantBinding | None:
+        path = self._path(tenant_id)
+        if not path.exists():
+            return None
+        try:
+            return StripeTenantBinding.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise StripeBillingError("Stripe tenant binding could not be read safely.") from exc
+
+    def save(self, binding: StripeTenantBinding) -> None:
+        path = self._path(binding.tenant_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = json.dumps(
+            binding.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        with NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            prefix=".stripe.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(path)
+
+
+class StripeApiClient:
+    def __init__(
+        self,
+        config: StripeBillingConfig,
+        *,
+        base_url: str = "https://api.stripe.com",
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.config = config
+        self.base_url = base_url.rstrip("/")
+        self.transport = transport
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        data: Mapping[str, str] | None = None,
+    ) -> dict[str, object]:
+        try:
+            with httpx.Client(
+                base_url=self.base_url,
+                auth=(self.config.secret_key, ""),
+                timeout=15.0,
+                transport=self.transport,
+            ) as client:
+                response = client.request(method, path, data=data)
+                response.raise_for_status()
+                payload = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise StripeBillingError("Stripe API request failed.") from exc
+        if not isinstance(payload, dict):
+            raise StripeBillingError("Stripe API returned an invalid response.")
+        return cast(dict[str, object], payload)
+
+    def create_checkout(
+        self,
+        *,
+        tenant_id: str,
+        customer_email: str,
+        plan: PlanName,
+    ) -> StripeCheckoutSession:
+        price_id = self.config.price_for_plan(plan)
+        payload = self._request(
+            "POST",
+            "/v1/checkout/sessions",
+            data={
+                "mode": "subscription",
+                "success_url": f"{self.config.trusted_origin}/billing?checkout=success",
+                "cancel_url": f"{self.config.trusted_origin}/billing?checkout=cancelled",
+                "client_reference_id": tenant_id,
+                "customer_email": customer_email,
+                "line_items[0][price]": price_id,
+                "line_items[0][quantity]": "1",
+                "subscription_data[metadata][veridra_tenant_id]": tenant_id,
+                "subscription_data[metadata][veridra_plan]": plan.value,
+            },
+        )
+        try:
+            return StripeCheckoutSession.model_validate(payload)
+        except ValidationError as exc:
+            raise StripeBillingError("Stripe Checkout response is invalid.") from exc
+
+    def create_portal(self, *, customer_id: str) -> StripePortalSession:
+        payload = self._request(
+            "POST",
+            "/v1/billing_portal/sessions",
+            data={
+                "customer": customer_id,
+                "return_url": f"{self.config.trusted_origin}/billing",
+            },
+        )
+        try:
+            return StripePortalSession.model_validate(payload)
+        except ValidationError as exc:
+            raise StripeBillingError("Stripe Billing Portal response is invalid.") from exc
+
+    def retrieve_subscription(self, subscription_id: str) -> StripeSubscription:
+        payload = self._request("GET", f"/v1/subscriptions/{subscription_id}")
+        try:
+            return StripeSubscription.model_validate(payload)
+        except ValidationError as exc:
+            raise StripeBillingError("Stripe subscription response is invalid.") from exc
+
+
+def verify_stripe_signature(
+    raw_body: bytes,
+    signature_header: str,
+    secret: str,
+    *,
+    now: datetime | None = None,
+    tolerance_seconds: int = 300,
+) -> None:
+    if tolerance_seconds < 1:
+        raise ValueError("Signature tolerance must be positive.")
+    timestamp: int | None = None
+    signatures: list[str] = []
+    for component in signature_header.split(","):
+        key, separator, value = component.strip().partition("=")
+        if not separator:
+            continue
+        if key == "t":
+            try:
+                timestamp = int(value)
+            except ValueError:
+                timestamp = None
+        elif key == "v1" and value:
+            signatures.append(value)
+    if timestamp is None or not signatures:
+        raise StripeBillingError("Stripe webhook signature is invalid.")
+    checked_at = (now or datetime.now(UTC)).astimezone(UTC)
+    if abs(int(checked_at.timestamp()) - timestamp) > tolerance_seconds:
+        raise StripeBillingError("Stripe webhook signature timestamp is outside tolerance.")
+    signed_payload = str(timestamp).encode("ascii") + b"." + raw_body
+    expected = hmac.new(secret.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
+    if not any(hmac.compare_digest(expected, candidate) for candidate in signatures):
+        raise StripeBillingError("Stripe webhook signature is invalid.")
+
+
+@dataclass(frozen=True)
+class StripeWebhookResult:
+    handled: bool
+    applied: bool
+    tenant_id: str = ""
+    reason: str = ""
+
+
+class StripeSubscriptionAdapter:
+    _SUBSCRIPTION_EVENTS = frozenset(
+        {
+            "customer.subscription.created",
+            "customer.subscription.updated",
+            "customer.subscription.deleted",
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        config: StripeBillingConfig,
+        tenant_root: Path,
+        client: StripeApiClient | None = None,
+    ) -> None:
+        self.config = config
+        self.tenant_root = tenant_root
+        self.client = client or StripeApiClient(config)
+        self.bindings = StripeTenantBindingStore(tenant_root)
+        self.authority = SubscriptionAuthority(tenant_root)
+
+    def parse_event(self, raw_body: bytes) -> StripeWebhookEvent:
+        try:
+            payload = json.loads(raw_body)
+            return StripeWebhookEvent.model_validate(payload)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            raise StripeBillingError("Stripe webhook payload is invalid.") from exc
+
+    @staticmethod
+    def _workspace_status(stripe_status: str) -> WorkspaceStatus:
+        return (
+            WorkspaceStatus.active
+            if stripe_status in {"active", "trialing"}
+            else WorkspaceStatus.suspended
+        )
+
+    def _plan(self, subscription: StripeSubscription) -> PlanName:
+        plans = {
+            self.config.plan_for_price(item.price.id)
+            for item in subscription.items.data
+        }
+        if len(plans) != 1:
+            raise StripeBillingError("Stripe subscription must map to exactly one Veridra plan.")
+        return plans.pop()
+
+    @staticmethod
+    def _tenant_id(subscription: StripeSubscription) -> str:
+        tenant_id = subscription.metadata.get("veridra_tenant_id", "").strip().lower()
+        if len(tenant_id) != 24 or any(char not in "0123456789abcdef" for char in tenant_id):
+            raise StripeBillingError("Stripe subscription is missing valid Veridra tenant metadata.")
+        return tenant_id
+
+    def _update(
+        self,
+        *,
+        event: StripeWebhookEvent,
+        subscription: StripeSubscription,
+    ) -> SubscriptionUpdate:
+        anchor = datetime.fromtimestamp(subscription.billing_cycle_anchor, tz=UTC).day
+        return SubscriptionUpdate(
+            tenant_id=self._tenant_id(subscription),
+            provider="stripe",
+            provider_event_id=event.id,
+            external_subscription_id=subscription.id,
+            plan=self._plan(subscription),
+            status=self._workspace_status(subscription.status),
+            cycle_anchor_day=min(anchor, 28),
+            occurred_at=datetime.fromtimestamp(event.created, tz=UTC),
+        )
+
+    def _already_current(self, update: SubscriptionUpdate) -> bool:
+        store = WorkspaceStore(self.tenant_root / update.tenant_id / "workspace")
+        if not store.path.exists():
+            return False
+        workspace = store.load()
+        return (
+            workspace.plan is update.plan
+            and workspace.status is update.status
+            and workspace.cycle_anchor_day == update.cycle_anchor_day
+        )
+
+    def _apply(self, update: SubscriptionUpdate) -> SubscriptionApplyResult | None:
+        try:
+            return self.authority.apply(update)
+        except SubscriptionAuthorityError as exc:
+            message = str(exc)
+            if (
+                "Stale subscription event" in message
+                or "Ambiguous subscription events" in message
+            ) and self._already_current(update):
+                return None
+            raise StripeBillingError("Stripe subscription state could not be projected.") from exc
+
+    def handle(self, event: StripeWebhookEvent) -> StripeWebhookResult:
+        if event.type not in self._SUBSCRIPTION_EVENTS:
+            return StripeWebhookResult(False, False, reason="event type ignored")
+        try:
+            event_subscription = StripeSubscription.model_validate(event.data.object)
+        except ValidationError as exc:
+            raise StripeBillingError("Stripe subscription event payload is invalid.") from exc
+
+        if event.type == "customer.subscription.deleted":
+            tenant_id = self._tenant_id(event_subscription)
+            binding = self.bindings.load(tenant_id)
+            if binding is None or binding.subscription_id != event_subscription.id:
+                return StripeWebhookResult(
+                    True,
+                    False,
+                    tenant_id=tenant_id,
+                    reason="deleted subscription is not the current tenant binding",
+                )
+            current = event_subscription.model_copy(update={"status": "canceled"})
+        else:
+            current = self.client.retrieve_subscription(event_subscription.id)
+            tenant_id = self._tenant_id(current)
+
+        update = self._update(event=event, subscription=current)
+        result = self._apply(update)
+        self.bindings.save(
+            StripeTenantBinding(
+                tenant_id=update.tenant_id,
+                customer_id=current.customer,
+                subscription_id=current.id,
+                updated_at=datetime.now(UTC),
+            )
+        )
+        return StripeWebhookResult(
+            True,
+            result.applied if result is not None else False,
+            tenant_id=update.tenant_id,
+            reason="subscription state reconciled",
+        )

--- a/src/veridra/stripe_billing.py
+++ b/src/veridra/stripe_billing.py
@@ -42,17 +42,20 @@ class StripeBillingConfig:
         env: Mapping[str, str] | None = None,
     ) -> StripeBillingConfig | None:
         values = os.environ if env is None else env
-        names = (
+        stripe_names = (
             "VERIDRA_STRIPE_SECRET_KEY",
             "VERIDRA_STRIPE_WEBHOOK_SECRET",
             "VERIDRA_STRIPE_PRICE_SOLO",
             "VERIDRA_STRIPE_PRICE_PROFESSIONAL",
             "VERIDRA_STRIPE_PRICE_AGENCY",
-            "VERIDRA_TRUSTED_ORIGIN",
         )
-        configured = {name: values.get(name, "").strip() for name in names}
-        if not any(configured.values()):
+        stripe_values = {name: values.get(name, "").strip() for name in stripe_names}
+        if not any(stripe_values.values()):
             return None
+        configured = {
+            **stripe_values,
+            "VERIDRA_TRUSTED_ORIGIN": values.get("VERIDRA_TRUSTED_ORIGIN", "").strip(),
+        }
         missing = [name for name, value in configured.items() if not value]
         if missing:
             raise StripeBillingError(
@@ -453,7 +456,6 @@ class StripeSubscriptionAdapter:
             current = event_subscription.model_copy(update={"status": "canceled"})
         else:
             current = self.client.retrieve_subscription(event_subscription.id)
-            tenant_id = self._tenant_id(current)
 
         update = self._update(event=event, subscription=current)
         result = self._apply(update)

--- a/src/veridra/stripe_billing_web.py
+++ b/src/veridra/stripe_billing_web.py
@@ -1,0 +1,184 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+import sqlite3
+from pathlib import Path
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .request_security import require_request_identity
+from .runtime_billing import StripeBillingRuntime
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .stripe_billing import StripeBillingError, verify_stripe_signature
+from .workspace_policy import PlanName, WorkspaceStore
+
+router = APIRouter(tags=["billing"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:860px;margin:40px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.plans{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px}.plan{border:1px solid #dfe3e8;border-radius:8px;padding:18px}button,.button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.muted{color:#68707a}.notice{border-left:4px solid #16794a;background:#f0faf5;padding:12px 14px}.cancelled{border-left-color:#68707a;background:#f4f6f8}@media(max-width:720px){.plans{grid-template-columns:1fr}}
+"""
+
+
+def _page(title: str, body: str) -> HTMLResponse:
+    return HTMLResponse(
+        f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>",
+        headers={"Cache-Control": "no-store", "X-Frame-Options": "DENY"},
+    )
+
+
+def _runtime(request: Request) -> StripeBillingRuntime:
+    runtime = getattr(request.app.state, "veridra_stripe_billing", None)
+    if not isinstance(runtime, StripeBillingRuntime):
+        raise HTTPException(status_code=503, detail="Billing is not configured.")
+    return runtime
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_tenant)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="Billing management is not permitted.") from exc
+    return identity
+
+
+def _same_origin(request: Request, runtime: StripeBillingRuntime) -> None:
+    try:
+        TrustedSameOriginPolicy(runtime.config.trusted_origin).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Billing request is not permitted.") from exc
+
+
+def _tenant_root(request: Request) -> Path:
+    root = getattr(request.app.state, "veridra_tenant_data_root", None)
+    if not isinstance(root, Path):
+        raise HTTPException(status_code=503, detail="Billing tenant storage is not configured.")
+    return root
+
+
+def _identity_database(request: Request) -> Path:
+    store = getattr(request.app.state, "veridra_identity_store", None)
+    database = getattr(store, "database", None)
+    if not isinstance(database, Path):
+        raise HTTPException(status_code=503, detail="Billing identity storage is not configured.")
+    return database
+
+
+def _user_email(request: Request, user_id: str) -> str:
+    with sqlite3.connect(_identity_database(request)) as connection:
+        row = connection.execute("SELECT email FROM users WHERE id = ?", (user_id,)).fetchone()
+    if row is None or not isinstance(row[0], str) or not row[0]:
+        raise HTTPException(status_code=503, detail="Billing account email is unavailable.")
+    return row[0]
+
+
+def _stripe_redirect(url: str, *, host: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.hostname != host or parsed.username or parsed.password:
+        raise StripeBillingError("Stripe returned an unexpected redirect destination.")
+    return url
+
+
+@router.get("/billing", response_class=HTMLResponse)
+def billing_page(request: Request, checkout: str = "") -> HTMLResponse:
+    runtime = _runtime(request)
+    identity = _identity(request)
+    root = _tenant_root(request)
+    workspace_store = WorkspaceStore(root / identity.tenant_id / "workspace")
+    if not workspace_store.path.exists():
+        raise HTTPException(status_code=404, detail="Tenant workspace was not found.")
+    workspace = workspace_store.load()
+    binding = runtime.adapter.bindings.load(identity.tenant_id)
+    notice = ""
+    if checkout == "success":
+        notice = "<p class='notice'>Checkout completed. Stripe is reconciling the subscription; this page reflects only webhook-confirmed entitlement state.</p>"
+    elif checkout == "cancelled":
+        notice = "<p class='notice cancelled'>Checkout was cancelled. No plan change is assumed.</p>"
+
+    status = html.escape(workspace.status.value.title())
+    current = html.escape(workspace.plan.value.title())
+    if binding is not None:
+        action = "<form method='post' action='/billing/portal'><button type='submit'>Manage subscription in Stripe</button></form>"
+        guidance = "Your Stripe subscription is already bound to this workspace. Use the Billing Portal for plan changes, payment methods or cancellation."
+    else:
+        cards = "".join(
+            f"<article class='plan'><h2>{html.escape(plan.value.title())}</h2><form method='post' action='/billing/checkout/{plan.value}'><button type='submit'>Choose {html.escape(plan.value.title())}</button></form></article>"
+            for plan in (PlanName.solo, PlanName.professional, PlanName.agency)
+        )
+        action = f"<div class='plans'>{cards}</div>"
+        guidance = "Choose a paid plan to continue to Stripe-hosted Checkout. Veridra changes entitlements only after a verified Stripe subscription webhook is reconciled."
+
+    body = f"<p><a href='/agency'>Agency home</a></p><section><h1>Billing</h1>{notice}<p><strong>Current Veridra plan:</strong> {current}<br><strong>Workspace status:</strong> {status}</p><p class='muted'>{html.escape(guidance)}</p>{action}</section>"
+    return _page("Veridra billing", body)
+
+
+@router.post("/billing/checkout/{plan}", response_model=None)
+def start_checkout(plan: PlanName, request: Request) -> RedirectResponse:
+    runtime = _runtime(request)
+    identity = _identity(request)
+    _same_origin(request, runtime)
+    if plan is PlanName.free:
+        raise HTTPException(status_code=400, detail="The free plan does not use Stripe Checkout.")
+    if runtime.adapter.bindings.load(identity.tenant_id) is not None:
+        raise HTTPException(
+            status_code=409,
+            detail="An existing Stripe subscription must be managed through the Billing Portal.",
+        )
+    try:
+        session = runtime.client.create_checkout(
+            tenant_id=identity.tenant_id,
+            customer_email=_user_email(request, identity.user_id),
+            plan=plan,
+        )
+        destination = _stripe_redirect(session.url, host="checkout.stripe.com")
+    except StripeBillingError as exc:
+        raise HTTPException(status_code=502, detail="Stripe Checkout is unavailable.") from exc
+    return RedirectResponse(destination, status_code=303)
+
+
+@router.post("/billing/portal", response_model=None)
+def open_billing_portal(request: Request) -> RedirectResponse:
+    runtime = _runtime(request)
+    identity = _identity(request)
+    _same_origin(request, runtime)
+    binding = runtime.adapter.bindings.load(identity.tenant_id)
+    if binding is None:
+        raise HTTPException(status_code=409, detail="No Stripe subscription is bound to this workspace.")
+    try:
+        session = runtime.client.create_portal(customer_id=binding.customer_id)
+        destination = _stripe_redirect(session.url, host="billing.stripe.com")
+    except StripeBillingError as exc:
+        raise HTTPException(status_code=502, detail="Stripe Billing Portal is unavailable.") from exc
+    return RedirectResponse(destination, status_code=303)
+
+
+@router.post("/api/billing/stripe/webhook")
+async def stripe_webhook(request: Request) -> JSONResponse:
+    runtime = _runtime(request)
+    raw_body = await request.body()
+    signature = request.headers.get("stripe-signature", "")
+    try:
+        verify_stripe_signature(raw_body, signature, runtime.config.webhook_secret)
+        event = runtime.adapter.parse_event(raw_body)
+    except StripeBillingError as exc:
+        raise HTTPException(status_code=400, detail="Stripe webhook is invalid.") from exc
+    try:
+        result = runtime.adapter.handle(event)
+    except StripeBillingError as exc:
+        raise HTTPException(status_code=503, detail="Stripe webhook reconciliation failed.") from exc
+    return JSONResponse(
+        {
+            "received": True,
+            "handled": result.handled,
+            "applied": result.applied,
+        }
+    )

--- a/tests/test_runtime_billing.py
+++ b/tests/test_runtime_billing.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+
+from veridra.runtime_billing import StripeBillingRuntime, configure_runtime_billing
+from veridra.runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
+
+
+def _runtime(tmp_path: Path) -> RuntimeConfig:
+    return RuntimeConfig(
+        environment=RuntimeEnvironment.production,
+        identity_database=tmp_path / "identity.sqlite3",
+        tenant_data_root=tmp_path / "tenants",
+        trusted_origin="https://app.example.com",
+        allowed_hosts=("app.example.com",),
+        trusted_proxy_ips=(),
+        max_request_body_bytes=1_000_000,
+        bind_host="127.0.0.1",
+        bind_port=8000,
+    )
+
+
+def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "VERIDRA_STRIPE_SECRET_KEY",
+        "VERIDRA_STRIPE_WEBHOOK_SECRET",
+        "VERIDRA_STRIPE_PRICE_SOLO",
+        "VERIDRA_STRIPE_PRICE_PROFESSIONAL",
+        "VERIDRA_STRIPE_PRICE_AGENCY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", "https://app.example.com")
+
+
+def _configure_stripe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERIDRA_STRIPE_SECRET_KEY", "sk_test_secret")
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET", "whsec_test")
+    monkeypatch.setenv("VERIDRA_STRIPE_PRICE_SOLO", "price_solo")
+    monkeypatch.setenv("VERIDRA_STRIPE_PRICE_PROFESSIONAL", "price_professional")
+    monkeypatch.setenv("VERIDRA_STRIPE_PRICE_AGENCY", "price_agency")
+
+
+def test_runtime_does_not_enable_billing_from_trusted_origin_alone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear(monkeypatch)
+    app = FastAPI()
+
+    configure_runtime_billing(app, _runtime(tmp_path))
+
+    assert not hasattr(app.state, "veridra_stripe_billing")
+
+
+def test_partial_stripe_runtime_configuration_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear(monkeypatch)
+    monkeypatch.setenv("VERIDRA_STRIPE_SECRET_KEY", "sk_test_secret")
+
+    with pytest.raises(RuntimeConfigurationError, match="Stripe billing configuration"):
+        configure_runtime_billing(FastAPI(), _runtime(tmp_path))
+
+
+def test_complete_stripe_configuration_installs_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear(monkeypatch)
+    _configure_stripe(monkeypatch)
+    app = FastAPI()
+
+    configure_runtime_billing(app, _runtime(tmp_path))
+
+    billing = app.state.veridra_stripe_billing
+    assert isinstance(billing, StripeBillingRuntime)
+    assert billing.config.price_professional == "price_professional"
+    assert billing.adapter.tenant_root == tmp_path / "tenants"

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+
+from veridra.stripe_billing import (
+    StripeApiClient,
+    StripeBillingConfig,
+    StripeBillingError,
+    StripeSubscriptionAdapter,
+    StripeTenantBinding,
+    verify_stripe_signature,
+)
+from veridra.workspace_policy import PlanName, WorkspaceConfig, WorkspaceStatus, WorkspaceStore
+
+TENANT_ID = "a" * 24
+NOW = datetime(2026, 8, 20, 16, 0, tzinfo=UTC)
+
+
+def _config() -> StripeBillingConfig:
+    return StripeBillingConfig(
+        secret_key="sk_test_secret",
+        webhook_secret="whsec_test",
+        price_solo="price_solo",
+        price_professional="price_professional",
+        price_agency="price_agency",
+        trusted_origin="https://app.example.com",
+    )
+
+
+def _subscription(
+    *,
+    subscription_id: str = "sub_current",
+    customer_id: str = "cus_current",
+    price_id: str = "price_agency",
+    status: str = "active",
+    anchor: int | None = None,
+) -> dict[str, object]:
+    return {
+        "id": subscription_id,
+        "customer": customer_id,
+        "status": status,
+        "billing_cycle_anchor": anchor or int(datetime(2026, 8, 31, tzinfo=UTC).timestamp()),
+        "metadata": {"veridra_tenant_id": TENANT_ID},
+        "items": {"data": [{"price": {"id": price_id}}]},
+    }
+
+
+def _event(
+    *,
+    event_id: str,
+    event_type: str = "customer.subscription.updated",
+    created: int,
+    subscription: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return {
+        "id": event_id,
+        "type": event_type,
+        "created": created,
+        "data": {"object": subscription or _subscription()},
+    }
+
+
+def _workspace(tmp_path: Path) -> WorkspaceStore:
+    store = WorkspaceStore(tmp_path / TENANT_ID / "workspace")
+    store.save(WorkspaceConfig(display_name="Customer", plan=PlanName.free))
+    return store
+
+
+def test_trusted_origin_alone_does_not_enable_stripe() -> None:
+    assert (
+        StripeBillingConfig.from_environment(
+            {"VERIDRA_TRUSTED_ORIGIN": "https://app.example.com"}
+        )
+        is None
+    )
+
+
+def test_partial_stripe_configuration_is_rejected() -> None:
+    with pytest.raises(StripeBillingError, match="incomplete"):
+        StripeBillingConfig.from_environment(
+            {
+                "VERIDRA_STRIPE_SECRET_KEY": "sk_test_secret",
+                "VERIDRA_TRUSTED_ORIGIN": "https://app.example.com",
+            }
+        )
+
+
+def test_stripe_signature_verifies_raw_body_and_rejects_tampering() -> None:
+    body = b'{"id":"evt_1"}'
+    timestamp = int(NOW.timestamp())
+    digest = hmac.new(
+        b"whsec_test",
+        str(timestamp).encode() + b"." + body,
+        hashlib.sha256,
+    ).hexdigest()
+    header = f"t={timestamp},v1={digest}"
+
+    verify_stripe_signature(body, header, "whsec_test", now=NOW)
+
+    with pytest.raises(StripeBillingError, match="signature"):
+        verify_stripe_signature(body + b" ", header, "whsec_test", now=NOW)
+    with pytest.raises(StripeBillingError, match="outside tolerance"):
+        verify_stripe_signature(
+            body,
+            header,
+            "whsec_test",
+            now=datetime(2026, 8, 20, 16, 10, tzinfo=UTC),
+        )
+
+
+def test_checkout_uses_server_price_and_tenant_subscription_metadata() -> None:
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/checkout/sessions"
+        form = parse_qs(request.content.decode())
+        seen.update({key: values[0] for key, values in form.items()})
+        return httpx.Response(
+            200,
+            json={"id": "cs_test_1", "url": "https://checkout.stripe.com/c/pay/test"},
+        )
+
+    client = StripeApiClient(_config(), transport=httpx.MockTransport(handler))
+    session = client.create_checkout(
+        tenant_id=TENANT_ID,
+        customer_email="owner@example.com",
+        plan=PlanName.professional,
+    )
+
+    assert session.id == "cs_test_1"
+    assert seen["mode"] == "subscription"
+    assert seen["line_items[0][price]"] == "price_professional"
+    assert seen["client_reference_id"] == TENANT_ID
+    assert seen["subscription_data[metadata][veridra_tenant_id]"] == TENANT_ID
+    assert seen["subscription_data[metadata][veridra_plan]"] == "professional"
+
+
+def test_adapter_retrieves_current_subscription_and_projects_authoritative_state(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/subscriptions/sub_current"
+        return httpx.Response(200, json=_subscription(price_id="price_agency"))
+
+    client = StripeApiClient(_config(), transport=httpx.MockTransport(handler))
+    adapter = StripeSubscriptionAdapter(config=_config(), tenant_root=tmp_path, client=client)
+    event = adapter.parse_event(
+        json.dumps(
+            _event(
+                event_id="evt_created",
+                event_type="customer.subscription.created",
+                created=int(NOW.timestamp()),
+            )
+        ).encode()
+    )
+
+    result = adapter.handle(event)
+
+    assert result.handled is True
+    assert result.applied is True
+    assert workspace.load().plan is PlanName.agency
+    assert workspace.load().status is WorkspaceStatus.active
+    assert workspace.load().cycle_anchor_day == 28
+    binding = adapter.bindings.load(TENANT_ID)
+    assert binding is not None
+    assert binding.customer_id == "cus_current"
+    assert binding.subscription_id == "sub_current"
+
+
+def test_delayed_webhook_cannot_roll_back_newer_current_stripe_state(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    current_price = "price_agency"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_subscription(price_id=current_price))
+
+    client = StripeApiClient(_config(), transport=httpx.MockTransport(handler))
+    adapter = StripeSubscriptionAdapter(config=_config(), tenant_root=tmp_path, client=client)
+
+    first = adapter.parse_event(
+        json.dumps(_event(event_id="evt_200", created=200)).encode()
+    )
+    adapter.handle(first)
+    assert workspace.load().plan is PlanName.agency
+
+    delayed = adapter.parse_event(
+        json.dumps(
+            _event(
+                event_id="evt_150",
+                created=150,
+                subscription=_subscription(price_id="price_solo"),
+            )
+        ).encode()
+    )
+    result = adapter.handle(delayed)
+
+    assert result.applied is False
+    assert workspace.load().plan is PlanName.agency
+
+
+def test_old_subscription_deletion_cannot_suspend_replacement(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    workspace.save(
+        WorkspaceConfig(
+            display_name="Customer",
+            plan=PlanName.professional,
+            status=WorkspaceStatus.active,
+        )
+    )
+    adapter = StripeSubscriptionAdapter(config=_config(), tenant_root=tmp_path)
+    adapter.bindings.save(
+        StripeTenantBinding(
+            tenant_id=TENANT_ID,
+            customer_id="cus_new",
+            subscription_id="sub_new",
+            updated_at=NOW,
+        )
+    )
+    deletion = adapter.parse_event(
+        json.dumps(
+            _event(
+                event_id="evt_delete_old",
+                event_type="customer.subscription.deleted",
+                created=int(NOW.timestamp()),
+                subscription=_subscription(
+                    subscription_id="sub_old",
+                    customer_id="cus_old",
+                    price_id="price_solo",
+                    status="canceled",
+                ),
+            )
+        ).encode()
+    )
+
+    result = adapter.handle(deletion)
+
+    assert result.handled is True
+    assert result.applied is False
+    assert workspace.load().status is WorkspaceStatus.active
+    assert adapter.bindings.load(TENANT_ID).subscription_id == "sub_new"  # type: ignore[union-attr]

--- a/tests/test_stripe_billing_web.py
+++ b/tests/test_stripe_billing_web.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.request_security import bind_verified_request_identity
+from veridra.runtime_billing import StripeBillingRuntime
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+from veridra.stripe_billing import (
+    StripeApiClient,
+    StripeBillingConfig,
+    StripeSubscriptionAdapter,
+    StripeTenantBinding,
+)
+from veridra.stripe_billing_web import router
+from veridra.workspace_policy import PlanName, WorkspaceConfig, WorkspaceStore
+
+ORIGIN = "https://app.example.com"
+
+
+def _config() -> StripeBillingConfig:
+    return StripeBillingConfig(
+        secret_key="sk_test_secret",
+        webhook_secret="whsec_test",
+        price_solo="price_solo",
+        price_professional="price_professional",
+        price_agency="price_agency",
+        trusted_origin=ORIGIN,
+    )
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, StripeSubscriptionAdapter, RequestIdentity]:
+    database = tmp_path / "identity.sqlite3"
+    tenant_root = tmp_path / "tenants"
+    created = SQLiteIdentityBootstrap(database, tenant_data_root=tenant_root).create_first_owner(
+        tenant_slug="customer-one",
+        tenant_name="Customer one",
+        owner_email="owner@example.com",
+        owner_name="Owner",
+        password="owner-correct-horse-battery",
+        confirmation=BOOTSTRAP_CONFIRMATION,
+    )
+    WorkspaceStore(tenant_root / created.tenant_id / "workspace").save(
+        WorkspaceConfig(display_name="Customer one", plan=PlanName.free)
+    )
+    owner = RequestIdentity(
+        user_id=created.user_id,
+        tenant_id=created.tenant_id,
+        membership_role=TenantRole.owner,
+        session_id="1" * 24,
+        authenticated_at=datetime.now(UTC),
+    )
+    viewer = RequestIdentity(
+        user_id=created.user_id,
+        tenant_id=created.tenant_id,
+        membership_role=TenantRole.viewer,
+        session_id="2" * 24,
+        authenticated_at=datetime.now(UTC),
+    )
+
+    def stripe_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/checkout/sessions":
+            return httpx.Response(
+                200,
+                json={"id": "cs_test", "url": "https://checkout.stripe.com/c/pay/test"},
+            )
+        if request.url.path == "/v1/billing_portal/sessions":
+            return httpx.Response(
+                200,
+                json={"id": "bps_test", "url": "https://billing.stripe.com/p/session/test"},
+            )
+        if request.url.path.startswith("/v1/subscriptions/"):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "sub_current",
+                    "customer": "cus_current",
+                    "status": "active",
+                    "billing_cycle_anchor": int(datetime(2026, 8, 20, tzinfo=UTC).timestamp()),
+                    "metadata": {"veridra_tenant_id": created.tenant_id},
+                    "items": {"data": [{"price": {"id": "price_professional"}}]},
+                },
+            )
+        raise AssertionError(f"Unexpected Stripe request: {request.url}")
+
+    config = _config()
+    stripe_client = StripeApiClient(config, transport=httpx.MockTransport(stripe_handler))
+    adapter = StripeSubscriptionAdapter(
+        config=config,
+        tenant_root=tenant_root,
+        client=stripe_client,
+    )
+    app = FastAPI()
+    app.state.veridra_identity_store = SQLiteIdentityRecordStore(database)
+    app.state.veridra_tenant_data_root = tenant_root
+    app.state.veridra_stripe_billing = StripeBillingRuntime(config, stripe_client, adapter)
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if request.headers.get("x-test-role") == "owner":
+            bind_verified_request_identity(request, owner)
+        elif request.headers.get("x-test-role") == "viewer":
+            bind_verified_request_identity(request, viewer)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app, base_url=ORIGIN), adapter, owner
+
+
+def test_billing_page_requires_tenant_management_capability(tmp_path: Path) -> None:
+    client, _, _ = _client(tmp_path)
+
+    assert client.get("/billing").status_code == 401
+    assert client.get("/billing", headers={"x-test-role": "viewer"}).status_code == 403
+    owner = client.get("/billing", headers={"x-test-role": "owner"})
+    assert owner.status_code == 200
+    assert "Current Veridra plan:</strong> Free" in owner.text
+    assert "Stripe-hosted Checkout" in owner.text
+
+
+def test_checkout_is_same_origin_and_redirects_to_stripe(tmp_path: Path) -> None:
+    client, _, _ = _client(tmp_path)
+
+    missing_origin = client.post(
+        "/billing/checkout/professional",
+        headers={"x-test-role": "owner"},
+        follow_redirects=False,
+    )
+    assert missing_origin.status_code == 403
+
+    checkout = client.post(
+        "/billing/checkout/professional",
+        headers={"x-test-role": "owner", "origin": ORIGIN},
+        follow_redirects=False,
+    )
+    assert checkout.status_code == 303
+    assert checkout.headers["location"].startswith("https://checkout.stripe.com/")
+
+
+def test_existing_subscription_uses_portal_and_blocks_duplicate_checkout(tmp_path: Path) -> None:
+    client, adapter, owner = _client(tmp_path)
+    adapter.bindings.save(
+        StripeTenantBinding(
+            tenant_id=owner.tenant_id,
+            customer_id="cus_current",
+            subscription_id="sub_current",
+            updated_at=datetime.now(UTC),
+        )
+    )
+
+    duplicate = client.post(
+        "/billing/checkout/agency",
+        headers={"x-test-role": "owner", "origin": ORIGIN},
+        follow_redirects=False,
+    )
+    assert duplicate.status_code == 409
+
+    portal = client.post(
+        "/billing/portal",
+        headers={"x-test-role": "owner", "origin": ORIGIN},
+        follow_redirects=False,
+    )
+    assert portal.status_code == 303
+    assert portal.headers["location"].startswith("https://billing.stripe.com/")
+
+
+def test_webhook_requires_valid_signature_and_projects_subscription(tmp_path: Path) -> None:
+    client, _, owner = _client(tmp_path)
+    now = datetime.now(UTC)
+    payload = json.dumps(
+        {
+            "id": "evt_current",
+            "type": "customer.subscription.updated",
+            "created": int(now.timestamp()),
+            "data": {
+                "object": {
+                    "id": "sub_current",
+                    "customer": "cus_current",
+                    "status": "active",
+                    "billing_cycle_anchor": int(now.timestamp()),
+                    "metadata": {"veridra_tenant_id": owner.tenant_id},
+                    "items": {"data": [{"price": {"id": "price_solo"}}]},
+                }
+            },
+        },
+        separators=(",", ":"),
+    ).encode()
+
+    rejected = client.post(
+        "/api/billing/stripe/webhook",
+        content=payload,
+        headers={"stripe-signature": "t=1,v1=bad"},
+    )
+    assert rejected.status_code == 400
+
+    timestamp = int(now.timestamp())
+    digest = hmac.new(
+        b"whsec_test",
+        str(timestamp).encode() + b"." + payload,
+        hashlib.sha256,
+    ).hexdigest()
+    accepted = client.post(
+        "/api/billing/stripe/webhook",
+        content=payload,
+        headers={"stripe-signature": f"t={timestamp},v1={digest}"},
+    )
+    assert accepted.status_code == 200
+    assert accepted.json() == {"received": True, "handled": True, "applied": True}
+
+    workspace = WorkspaceStore(tmp_path / "tenants" / owner.tenant_id / "workspace").load()
+    assert workspace.plan is PlanName.professional


### PR DESCRIPTION
Adds an optional Stripe billing adapter around Veridra's existing provider-neutral SubscriptionAuthority.

What changes:
- opt-in Stripe runtime configuration with explicit secret, webhook-secret and server-side Price mappings;
- authenticated tenant billing page and manage-tenant capability enforcement;
- Stripe-hosted subscription Checkout for unbound paid tenants using only server-configured Prices;
- duplicate-subscription prevention once a Stripe tenant binding exists;
- Stripe Billing Portal for existing subscriptions;
- raw-body `Stripe-Signature` verification before webhook payload parsing;
- current-subscription re-fetch for create/update events so webhook delivery order is not treated as subscription truth;
- tenant/subscription binding so deletion of an old replaced subscription cannot suspend the current workspace;
- provider Price-to-Veridra-plan mapping before projection through SubscriptionAuthority;
- active/trialing versus suspended entitlement projection while retaining authority replay/stale-event/evidence/rollback protections;
- quota anchor normalization to day 28 for Stripe anchors on days 29-31;
- focused tests for configuration, signature verification, Checkout metadata, delayed webhooks, replacement cancellation, authenticated billing routes, Portal routing and signed webhook reconciliation;
- deployment documentation that distinguishes code readiness from provider-side Stripe account/Product/Price/Portal/webhook configuration.

No live Stripe keys, products or Price IDs are created or assumed by this PR. Billing remains disabled unless explicitly configured.

Do not merge until exact-head full CI succeeds.