### PR TITLE
Harden production response security headers

### DIFF
--- a/docs/operations/security-headers.md
+++ b/docs/operations/security-headers.md
@@ -1,0 +1,27 @@
+# Production response security headers
+
+The composed Veridra runtime applies a global response-hardening middleware.
+
+All HTTP responses receive:
+
+- `X-Content-Type-Options: nosniff`;
+- `Referrer-Policy: strict-origin-when-cross-origin` unless a route already supplied a stricter policy;
+- `Permissions-Policy: camera=(), microphone=(), geolocation=()`;
+- a narrow Content Security Policy that blocks plugin/object content and constrains document base URLs.
+
+Non-embed routes also receive:
+
+- `X-Frame-Options: DENY`;
+- `Content-Security-Policy` with `frame-ancestors 'none'`.
+
+Routes under `/embed/` intentionally omit anti-framing directives because those responses are designed to be embedded by customer sites. They still receive the other global hardening headers.
+
+Production responses additionally receive:
+
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains`.
+
+HSTS assumes the documented production contract: the public origin and relevant subdomains are HTTPS. Do not expose a production Veridra hostname over plaintext HTTP after enabling this contract.
+
+The middleware uses add-if-missing behavior. Route-specific responses such as password reset pages may retain stronger headers such as `Referrer-Policy: no-referrer`.
+
+The CSP is intentionally narrow rather than declaring `default-src 'self'` today. Veridra currently renders inline styles in several server-generated pages; adopting a stricter script/style policy requires a separate nonce/hash migration and browser validation rather than silently breaking UI in a security-header change.

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -41,6 +41,7 @@ from .runtime_billing import configure_runtime_billing
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
 from .runtime_email import configure_runtime_email
+from .security_headers import SecurityHeadersMiddleware
 from .session_api import router as session_router
 from .stripe_billing_web import router as stripe_billing_router
 from .tenant_assessment_routes import router as tenant_assessment_router
@@ -75,6 +76,10 @@ app.add_middleware(
 )
 if runtime_config.allowed_hosts:
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(runtime_config.allowed_hosts))
+app.add_middleware(
+    SecurityHeadersMiddleware,
+    environment=runtime_config.environment,
+)
 
 if "Accessibility" not in app_module._AREAS:
     vars(app_module)["_AREAS"] = (*app_module._AREAS, "Accessibility")

--- a/src/veridra/security_headers.py
+++ b/src/veridra/security_headers.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from .runtime_config import RuntimeEnvironment
+
+
+class SecurityHeadersMiddleware:
+    """Apply response hardening without breaking the intentional embed surface."""
+
+    def __init__(self, app: ASGIApp, *, environment: RuntimeEnvironment) -> None:
+        self.app = app
+        self.environment = environment
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = str(scope.get("path", ""))
+        embeddable = path.startswith("/embed/")
+
+        async def send_with_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                names = {name.lower() for name, _ in headers}
+
+                def add_if_missing(name: bytes, value: bytes) -> None:
+                    if name.lower() not in names:
+                        headers.append((name, value))
+                        names.add(name.lower())
+
+                add_if_missing(b"x-content-type-options", b"nosniff")
+                add_if_missing(b"referrer-policy", b"strict-origin-when-cross-origin")
+                add_if_missing(
+                    b"permissions-policy",
+                    b"camera=(), microphone=(), geolocation=()",
+                )
+                if embeddable:
+                    add_if_missing(
+                        b"content-security-policy",
+                        b"object-src 'none'; base-uri 'self'",
+                    )
+                else:
+                    add_if_missing(b"x-frame-options", b"DENY")
+                    add_if_missing(
+                        b"content-security-policy",
+                        b"object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
+                    )
+                if self.environment is RuntimeEnvironment.production:
+                    add_if_missing(
+                        b"strict-transport-security",
+                        b"max-age=31536000; includeSubDomains",
+                    )
+                message["headers"] = headers
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.runtime_config import RuntimeEnvironment
+from veridra.security_headers import SecurityHeadersMiddleware
+
+
+def _client(environment: RuntimeEnvironment) -> TestClient:
+    app = FastAPI()
+
+    @app.get("/normal")
+    def normal() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    @app.get("/embed/example")
+    def embed() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    @app.get("/stricter")
+    def stricter() -> dict[str, str]:
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            {"ok": "yes"},
+            headers={"Referrer-Policy": "no-referrer"},
+        )  # type: ignore[return-value]
+
+    app.add_middleware(SecurityHeadersMiddleware, environment=environment)
+    return TestClient(app)
+
+
+def test_normal_response_gets_safe_global_headers() -> None:
+    response = _client(RuntimeEnvironment.development).get("/normal")
+
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["permissions-policy"] == "camera=(), microphone=(), geolocation=()"
+    assert response.headers["x-frame-options"] == "DENY"
+    assert response.headers["content-security-policy"] == (
+        "object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+    )
+    assert "strict-transport-security" not in response.headers
+
+
+def test_embed_surface_remains_frameable_but_keeps_safe_headers() -> None:
+    response = _client(RuntimeEnvironment.production).get("/embed/example")
+
+    assert "x-frame-options" not in response.headers
+    assert response.headers["content-security-policy"] == "object-src 'none'; base-uri 'self'"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["strict-transport-security"] == (
+        "max-age=31536000; includeSubDomains"
+    )
+
+
+def test_existing_stricter_route_header_is_preserved() -> None:
+    response = _client(RuntimeEnvironment.production).get("/stricter")
+
+    assert response.headers["referrer-policy"] == "no-referrer"
+    assert response.headers["x-frame-options"] == "DENY"
+
+
+def test_production_adds_hsts() -> None:
+    response = _client(RuntimeEnvironment.production).get("/normal")
+
+    assert response.headers["strict-transport-security"] == (
+        "max-age=31536000; includeSubDomains"
+    )


### PR DESCRIPTION
Adds global response security headers without breaking Veridra's intentional public embed surface.

What changes:
- add `X-Content-Type-Options: nosniff` globally;
- add a default `Referrer-Policy: strict-origin-when-cross-origin` while preserving stricter route-specific values;
- disable camera, microphone and geolocation through Permissions Policy;
- add a narrow CSP blocking object/plugin content and constraining `base-uri`;
- deny framing through both X-Frame-Options and CSP `frame-ancestors` on normal routes;
- preserve `/embed/` as intentionally frameable while retaining the other security headers;
- add one-year `Strict-Transport-Security` with includeSubDomains in production only;
- mount the middleware outside the normal application boundary so generated responses receive the headers consistently;
- add regression tests for normal routes, embed routes, HSTS and preservation of stricter route headers;
- document why a stricter default-src/style-src CSP is intentionally deferred until inline styles are migrated to nonce/hash-safe rendering.

Do not merge until exact-head full CI succeeds.