### PR TITLE
Add verified production backup and restore tooling

### DIFF
--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -1,0 +1,107 @@
+# Production backup and restore
+
+Veridra's durable state spans an identity SQLite database and tenant filesystem state. The tenant root also contains the durable monitoring-job SQLite database. These stores do not share one transaction boundary.
+
+For that reason, `veridra-backup` deliberately does **not** claim a live cross-store atomic snapshot.
+
+## Consistency rule
+
+Before backup or restore, stop or otherwise quiesce every writer that can change durable state:
+
+- the Veridra web process;
+- scheduled/running `veridra-monitoring-worker` processes;
+- Stripe webhook delivery or any other billing integration that can project subscription state;
+- manual maintenance commands that write identity or tenant data.
+
+The CLI requires `--confirm-quiesced` as an explicit operator assertion. The flag cannot prove that processes are stopped; operational supervision must enforce it.
+
+## What a snapshot contains
+
+A snapshot contains:
+
+- a SQLite-online-backup copy of `VERIDRA_IDENTITY_DB`;
+- the adjacent `identity-email-deliveries/` evidence directory when present;
+- the complete `VERIDRA_TENANT_DATA_ROOT`, including tenant projects, assessments, reports, leads, tasks, workspace policy/usage, Stripe binding/subscription evidence and `monitoring-jobs.sqlite3`;
+- `manifest.json`, containing the backup format version, Veridra version, UTC creation time, consistency declaration, file sizes and SHA-256 digests.
+
+The manifest uses archive-relative names only. Absolute production filesystem paths and runtime environment variables are not written into it.
+
+Runtime secrets are not separately exported. A secret is present only if an operator has incorrectly stored it inside one of the durable source directories; production secrets should remain in the external secret store.
+
+## Create a backup
+
+With the normal production environment variables configured:
+
+```text
+veridra-backup backup \
+  --output /secure-backups/veridra-2026-08-20.zip \
+  --confirm-quiesced
+```
+
+Or provide `--identity-db` and `--tenant-data-root` explicitly.
+
+The command refuses to:
+
+- run without the quiescence assertion;
+- overwrite an existing archive;
+- place the archive inside the identity or tenant durable source directories;
+- follow symbolic links inside durable data;
+- snapshot an identity SQLite database that fails `PRAGMA quick_check`.
+
+The output archive is written through a temporary file and published only after creation succeeds.
+
+After backup, move/copy the archive to storage with independent durability and access control. Keeping the only backup on the same disk or volume as production is not sufficient.
+
+## Restore a backup
+
+Restore into empty durable targets by default:
+
+```text
+veridra-backup restore \
+  --archive /secure-backups/veridra-2026-08-20.zip \
+  --confirm-quiesced
+```
+
+The restore verifies before writing production targets:
+
+- ZIP structure and safe relative paths;
+- exact manifest membership (no undeclared files or duplicate paths);
+- every file size and SHA-256 digest;
+- supported snapshot format version;
+- restored identity SQLite integrity.
+
+If durable targets already contain state, restore refuses by default. Replacement requires the additional explicit option:
+
+```text
+--replace-existing
+```
+
+Use replacement only during a controlled recovery after preserving the current state separately.
+
+## Recovery validation
+
+After a restore:
+
+1. Keep external writers stopped.
+2. Start one web process.
+3. Require `GET /health/live` = `200`.
+4. Require `GET /health/ready` = `200`.
+5. Validate browser sign-in with a controlled account.
+6. Validate a representative tenant project/report and monitoring history.
+7. Run the normal commercial acceptance/deployment checks.
+8. Confirm Stripe binding/subscription evidence is consistent with the current provider state before accepting new billing webhooks.
+9. Resume the monitoring worker and external billing delivery only after validation succeeds.
+
+## Retention and verification
+
+A production schedule should keep multiple generations and periodically restore one into an isolated environment. Archive creation alone is not proof of recoverability.
+
+At minimum, monitor and record:
+
+- backup command exit status;
+- resulting archive path and size;
+- snapshot creation timestamp;
+- restore-test date and result;
+- the deployed Veridra commit associated with the snapshot.
+
+Do not log archive contents, authentication records, personal data or secret values as part of backup telemetry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ veridra-project-migrate = "veridra.project_migration_cli:main"
 veridra-identity-bootstrap = "veridra.identity_bootstrap_cli:main"
 veridra-monitoring-worker = "veridra.monitoring_worker_cli:main"
 veridra-subscription-apply = "veridra.subscription_authority_cli:main"
+veridra-backup = "veridra.backup_restore_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/backup_restore.py
+++ b/src/veridra/backup_restore.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from .version import __version__
+
+_FORMAT_VERSION: Final[int] = 1
+_IDENTITY_MEMBER: Final[str] = "identity/identity.sqlite3"
+_EMAIL_PREFIX: Final[str] = "identity/identity-email-deliveries/"
+_TENANT_PREFIX: Final[str] = "tenants/"
+_MANIFEST_MEMBER: Final[str] = "manifest.json"
+
+
+class BackupRestoreError(RuntimeError):
+    pass
+
+
+class SnapshotFile(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    path: str = Field(min_length=1, max_length=2048)
+    size: int = Field(ge=0)
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class SnapshotManifest(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    format_version: int = Field(ge=1)
+    created_at: datetime
+    veridra_version: str = Field(min_length=1, max_length=100)
+    consistency: str = Field(pattern=r"^operator_quiesced$")
+    files: list[SnapshotFile]
+
+
+@dataclass(frozen=True)
+class BackupResult:
+    archive: Path
+    manifest: SnapshotManifest
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    identity_database: Path
+    tenant_data_root: Path
+    restored_files: int
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_member_name(name: str) -> None:
+    path = PurePosixPath(name)
+    if (
+        not name
+        or path.is_absolute()
+        or ".." in path.parts
+        or "\\" in name
+        or name.startswith("/")
+    ):
+        raise BackupRestoreError("Backup archive contains an unsafe path.")
+
+
+def _check_sqlite(database: Path) -> None:
+    if not database.is_file():
+        raise BackupRestoreError("Identity database does not exist.")
+    try:
+        connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+        try:
+            result = connection.execute("PRAGMA quick_check").fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        raise BackupRestoreError("Identity database could not be validated.") from exc
+    if result is None or result[0] != "ok":
+        raise BackupRestoreError("Identity database failed SQLite integrity validation.")
+
+
+def _sqlite_backup(source: Path, destination: Path) -> None:
+    try:
+        source_connection = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
+        destination_connection = sqlite3.connect(destination)
+        try:
+            source_connection.backup(destination_connection)
+        finally:
+            destination_connection.close()
+            source_connection.close()
+    except sqlite3.Error as exc:
+        raise BackupRestoreError("Identity database snapshot failed.") from exc
+    _check_sqlite(destination)
+
+
+def _iter_regular_files(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    if not root.is_dir() or root.is_symlink():
+        raise BackupRestoreError("Backup source directory is invalid.")
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise BackupRestoreError("Backup source contains a symbolic link.")
+        if path.is_file():
+            files.append(path)
+        elif not path.is_dir():
+            raise BackupRestoreError("Backup source contains an unsupported filesystem entry.")
+    return files
+
+
+def _add_file(
+    archive: zipfile.ZipFile,
+    source: Path,
+    member: str,
+    entries: list[SnapshotFile],
+) -> None:
+    _validate_member_name(member)
+    archive.write(source, member)
+    entries.append(
+        SnapshotFile(path=member, size=source.stat().st_size, sha256=_sha256(source))
+    )
+
+
+def create_backup(
+    *,
+    identity_database: Path,
+    tenant_data_root: Path,
+    output: Path,
+    confirm_quiesced: bool,
+    now: datetime | None = None,
+) -> BackupResult:
+    if not confirm_quiesced:
+        raise BackupRestoreError(
+            "Backup requires explicit confirmation that web, worker and billing writers are quiesced."
+        )
+    identity_database = identity_database.expanduser().resolve()
+    tenant_data_root = tenant_data_root.expanduser().resolve()
+    output = output.expanduser().resolve()
+    _check_sqlite(identity_database)
+    if not tenant_data_root.is_dir() or tenant_data_root.is_symlink():
+        raise BackupRestoreError("Tenant data root does not exist or is invalid.")
+    if output.exists():
+        raise BackupRestoreError("Backup output already exists.")
+    if output.is_relative_to(tenant_data_root) or output.is_relative_to(identity_database.parent):
+        raise BackupRestoreError("Backup output must be outside durable source directories.")
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    timestamp = (now or datetime.now(UTC)).astimezone(UTC)
+    entries: list[SnapshotFile] = []
+    try:
+        with tempfile.TemporaryDirectory(prefix="veridra-backup-") as temporary:
+            temporary_root = Path(temporary)
+            identity_snapshot = temporary_root / "identity.sqlite3"
+            _sqlite_backup(identity_database, identity_snapshot)
+            temporary_archive = output.with_name(f".{output.name}.{os.getpid()}.tmp")
+            try:
+                with zipfile.ZipFile(
+                    temporary_archive,
+                    "w",
+                    compression=zipfile.ZIP_DEFLATED,
+                    compresslevel=6,
+                ) as archive:
+                    _add_file(archive, identity_snapshot, _IDENTITY_MEMBER, entries)
+                    email_root = identity_database.parent / "identity-email-deliveries"
+                    for source in _iter_regular_files(email_root):
+                        relative = source.relative_to(email_root).as_posix()
+                        _add_file(archive, source, _EMAIL_PREFIX + relative, entries)
+                    for source in _iter_regular_files(tenant_data_root):
+                        relative = source.relative_to(tenant_data_root).as_posix()
+                        _add_file(archive, source, _TENANT_PREFIX + relative, entries)
+                    manifest = SnapshotManifest(
+                        format_version=_FORMAT_VERSION,
+                        created_at=timestamp,
+                        veridra_version=__version__,
+                        consistency="operator_quiesced",
+                        files=sorted(entries, key=lambda entry: entry.path),
+                    )
+                    archive.writestr(
+                        _MANIFEST_MEMBER,
+                        json.dumps(
+                            manifest.model_dump(mode="json"),
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ).encode("utf-8"),
+                    )
+                temporary_archive.replace(output)
+            finally:
+                temporary_archive.unlink(missing_ok=True)
+    except (OSError, zipfile.BadZipFile) as exc:
+        output.unlink(missing_ok=True)
+        raise BackupRestoreError("Backup archive could not be created safely.") from exc
+    return BackupResult(archive=output, manifest=manifest)
+
+
+def _load_and_verify_archive(archive_path: Path, staging: Path) -> SnapshotManifest:
+    try:
+        with zipfile.ZipFile(archive_path, "r") as archive:
+            names = archive.namelist()
+            if len(names) != len(set(names)):
+                raise BackupRestoreError("Backup archive contains duplicate paths.")
+            for name in names:
+                _validate_member_name(name)
+            if _MANIFEST_MEMBER not in names:
+                raise BackupRestoreError("Backup archive has no manifest.")
+            try:
+                manifest = SnapshotManifest.model_validate_json(archive.read(_MANIFEST_MEMBER))
+            except (KeyError, ValidationError, ValueError) as exc:
+                raise BackupRestoreError("Backup manifest is invalid.") from exc
+            if manifest.format_version != _FORMAT_VERSION:
+                raise BackupRestoreError("Backup format version is not supported.")
+            expected = {_MANIFEST_MEMBER, *(entry.path for entry in manifest.files)}
+            if set(names) != expected:
+                raise BackupRestoreError("Backup archive contents do not match the manifest.")
+            if not any(entry.path == _IDENTITY_MEMBER for entry in manifest.files):
+                raise BackupRestoreError("Backup archive is missing the identity database.")
+            for entry in manifest.files:
+                _validate_member_name(entry.path)
+                destination = staging.joinpath(*PurePosixPath(entry.path).parts)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                with archive.open(entry.path, "r") as source, destination.open("wb") as target:
+                    shutil.copyfileobj(source, target, length=1024 * 1024)
+                if destination.stat().st_size != entry.size or _sha256(destination) != entry.sha256:
+                    raise BackupRestoreError("Backup archive failed integrity verification.")
+    except zipfile.BadZipFile as exc:
+        raise BackupRestoreError("Backup archive is not a valid ZIP file.") from exc
+    _check_sqlite(staging / _IDENTITY_MEMBER)
+    return manifest
+
+
+def _directory_nonempty(path: Path) -> bool:
+    return path.exists() and (not path.is_dir() or any(path.iterdir()))
+
+
+def restore_backup(
+    *,
+    archive: Path,
+    identity_database: Path,
+    tenant_data_root: Path,
+    confirm_quiesced: bool,
+    replace_existing: bool = False,
+) -> RestoreResult:
+    if not confirm_quiesced:
+        raise BackupRestoreError(
+            "Restore requires explicit confirmation that web, worker and billing writers are quiesced."
+        )
+    archive = archive.expanduser().resolve()
+    identity_database = identity_database.expanduser().resolve()
+    tenant_data_root = tenant_data_root.expanduser().resolve()
+    if not archive.is_file():
+        raise BackupRestoreError("Backup archive does not exist.")
+    email_target = identity_database.parent / "identity-email-deliveries"
+    if not replace_existing and (
+        identity_database.exists()
+        or _directory_nonempty(email_target)
+        or _directory_nonempty(tenant_data_root)
+    ):
+        raise BackupRestoreError(
+            "Restore targets already contain durable state; use explicit replacement only while quiesced."
+        )
+
+    identity_database.parent.mkdir(parents=True, exist_ok=True)
+    tenant_data_root.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="veridra-restore-") as temporary:
+        staging = Path(temporary)
+        manifest = _load_and_verify_archive(archive, staging)
+        staged_identity = staging / _IDENTITY_MEMBER
+        staged_email = staging / _EMAIL_PREFIX.rstrip("/")
+        staged_tenants = staging / _TENANT_PREFIX.rstrip("/")
+
+        replacement_root = Path(tempfile.mkdtemp(prefix=".veridra-restore-", dir=tenant_data_root.parent))
+        try:
+            staged_tenant_copy = replacement_root / "tenants"
+            if staged_tenants.exists():
+                shutil.copytree(staged_tenants, staged_tenant_copy)
+            else:
+                staged_tenant_copy.mkdir()
+
+            staged_identity_copy = identity_database.with_name(
+                f".{identity_database.name}.{os.getpid()}.restore"
+            )
+            shutil.copy2(staged_identity, staged_identity_copy)
+            staged_email_copy = identity_database.parent / f".identity-email-deliveries.{os.getpid()}.restore"
+            if staged_email.exists():
+                shutil.copytree(staged_email, staged_email_copy)
+
+            if replace_existing:
+                identity_database.unlink(missing_ok=True)
+                if email_target.exists():
+                    shutil.rmtree(email_target)
+                if tenant_data_root.exists():
+                    shutil.rmtree(tenant_data_root)
+            staged_identity_copy.replace(identity_database)
+            if staged_email_copy.exists():
+                staged_email_copy.replace(email_target)
+            staged_tenant_copy.replace(tenant_data_root)
+        except OSError as exc:
+            raise BackupRestoreError("Restore could not replace durable state safely.") from exc
+        finally:
+            shutil.rmtree(replacement_root, ignore_errors=True)
+            for candidate in identity_database.parent.glob(".*.restore"):
+                if candidate.is_dir():
+                    shutil.rmtree(candidate, ignore_errors=True)
+                else:
+                    candidate.unlink(missing_ok=True)
+
+    _check_sqlite(identity_database)
+    return RestoreResult(
+        identity_database=identity_database,
+        tenant_data_root=tenant_data_root,
+        restored_files=len(manifest.files),
+    )

--- a/src/veridra/backup_restore.py
+++ b/src/veridra/backup_restore.py
@@ -136,6 +136,13 @@ def _add_file(
     )
 
 
+def _validate_distinct_roots(identity_database: Path, tenant_data_root: Path) -> None:
+    if identity_database.is_relative_to(tenant_data_root):
+        raise BackupRestoreError("Identity database cannot be inside the tenant data root.")
+    if tenant_data_root.is_relative_to(identity_database):
+        raise BackupRestoreError("Tenant data root cannot be inside the identity database path.")
+
+
 def create_backup(
     *,
     identity_database: Path,
@@ -146,11 +153,13 @@ def create_backup(
 ) -> BackupResult:
     if not confirm_quiesced:
         raise BackupRestoreError(
-            "Backup requires explicit confirmation that web, worker and billing writers are quiesced."
+            "Backup requires explicit confirmation that web, worker and billing "
+            "writers are quiesced."
         )
     identity_database = identity_database.expanduser().resolve()
     tenant_data_root = tenant_data_root.expanduser().resolve()
     output = output.expanduser().resolve()
+    _validate_distinct_roots(identity_database, tenant_data_root)
     _check_sqlite(identity_database)
     if not tenant_data_root.is_dir() or tenant_data_root.is_symlink():
         raise BackupRestoreError("Tenant data root does not exist or is invalid.")
@@ -246,6 +255,21 @@ def _directory_nonempty(path: Path) -> bool:
     return path.exists() and (not path.is_dir() or any(path.iterdir()))
 
 
+def _remove_path(path: Path) -> None:
+    if not path.exists() and not path.is_symlink():
+        return
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)
+
+
+def _restore_previous(target: Path, previous: Path) -> None:
+    _remove_path(target)
+    if previous.exists() or previous.is_symlink():
+        previous.replace(target)
+
+
 def restore_backup(
     *,
     archive: Path,
@@ -256,21 +280,26 @@ def restore_backup(
 ) -> RestoreResult:
     if not confirm_quiesced:
         raise BackupRestoreError(
-            "Restore requires explicit confirmation that web, worker and billing writers are quiesced."
+            "Restore requires explicit confirmation that web, worker and billing "
+            "writers are quiesced."
         )
     archive = archive.expanduser().resolve()
     identity_database = identity_database.expanduser().resolve()
     tenant_data_root = tenant_data_root.expanduser().resolve()
+    _validate_distinct_roots(identity_database, tenant_data_root)
     if not archive.is_file():
         raise BackupRestoreError("Backup archive does not exist.")
     email_target = identity_database.parent / "identity-email-deliveries"
+    if any(path.is_symlink() for path in (identity_database, email_target, tenant_data_root)):
+        raise BackupRestoreError("Restore target cannot be a symbolic link.")
     if not replace_existing and (
         identity_database.exists()
         or _directory_nonempty(email_target)
         or _directory_nonempty(tenant_data_root)
     ):
         raise BackupRestoreError(
-            "Restore targets already contain durable state; use explicit replacement only while quiesced."
+            "Restore targets already contain durable state; use explicit replacement "
+            "only while quiesced."
         )
 
     identity_database.parent.mkdir(parents=True, exist_ok=True)
@@ -282,43 +311,79 @@ def restore_backup(
         staged_email = staging / _EMAIL_PREFIX.rstrip("/")
         staged_tenants = staging / _TENANT_PREFIX.rstrip("/")
 
-        replacement_root = Path(tempfile.mkdtemp(prefix=".veridra-restore-", dir=tenant_data_root.parent))
+        replacement_root = Path(
+            tempfile.mkdtemp(prefix=".veridra-restore-", dir=tenant_data_root.parent)
+        )
+        staged_tenant_copy = replacement_root / "tenants"
+        if staged_tenants.exists():
+            shutil.copytree(staged_tenants, staged_tenant_copy)
+        else:
+            staged_tenant_copy.mkdir()
+
+        process = os.getpid()
+        staged_identity_copy = identity_database.with_name(
+            f".{identity_database.name}.{process}.restore"
+        )
+        staged_email_copy = identity_database.parent / (
+            f".identity-email-deliveries.{process}.restore"
+        )
+        previous_identity = identity_database.with_name(
+            f".{identity_database.name}.{process}.previous"
+        )
+        previous_email = identity_database.parent / (
+            f".identity-email-deliveries.{process}.previous"
+        )
+        previous_tenants = tenant_data_root.with_name(
+            f".{tenant_data_root.name}.{process}.previous"
+        )
+        temporary_paths = (
+            staged_identity_copy,
+            staged_email_copy,
+            previous_identity,
+            previous_email,
+            previous_tenants,
+        )
+        if any(path.exists() or path.is_symlink() for path in temporary_paths):
+            shutil.rmtree(replacement_root, ignore_errors=True)
+            raise BackupRestoreError("Restore staging paths already exist.")
+
+        shutil.copy2(staged_identity, staged_identity_copy)
+        if staged_email.exists():
+            shutil.copytree(staged_email, staged_email_copy)
+
+        had_identity = identity_database.exists()
+        had_email = email_target.exists()
+        had_tenants = tenant_data_root.exists()
         try:
-            staged_tenant_copy = replacement_root / "tenants"
-            if staged_tenants.exists():
-                shutil.copytree(staged_tenants, staged_tenant_copy)
-            else:
-                staged_tenant_copy.mkdir()
+            if had_identity:
+                identity_database.replace(previous_identity)
+            if had_email:
+                email_target.replace(previous_email)
+            if had_tenants:
+                tenant_data_root.replace(previous_tenants)
 
-            staged_identity_copy = identity_database.with_name(
-                f".{identity_database.name}.{os.getpid()}.restore"
-            )
-            shutil.copy2(staged_identity, staged_identity_copy)
-            staged_email_copy = identity_database.parent / f".identity-email-deliveries.{os.getpid()}.restore"
-            if staged_email.exists():
-                shutil.copytree(staged_email, staged_email_copy)
-
-            if replace_existing:
-                identity_database.unlink(missing_ok=True)
-                if email_target.exists():
-                    shutil.rmtree(email_target)
-                if tenant_data_root.exists():
-                    shutil.rmtree(tenant_data_root)
             staged_identity_copy.replace(identity_database)
             if staged_email_copy.exists():
                 staged_email_copy.replace(email_target)
             staged_tenant_copy.replace(tenant_data_root)
-        except OSError as exc:
-            raise BackupRestoreError("Restore could not replace durable state safely.") from exc
+            _check_sqlite(identity_database)
+        except (OSError, BackupRestoreError) as exc:
+            try:
+                _restore_previous(identity_database, previous_identity)
+                _restore_previous(email_target, previous_email)
+                _restore_previous(tenant_data_root, previous_tenants)
+            except OSError as rollback_exc:
+                raise BackupRestoreError(
+                    "Restore failed and previous durable state could not be fully restored."
+                ) from rollback_exc
+            raise BackupRestoreError(
+                "Restore failed; previous durable state was restored."
+            ) from exc
         finally:
             shutil.rmtree(replacement_root, ignore_errors=True)
-            for candidate in identity_database.parent.glob(".*.restore"):
-                if candidate.is_dir():
-                    shutil.rmtree(candidate, ignore_errors=True)
-                else:
-                    candidate.unlink(missing_ok=True)
+            for path in temporary_paths:
+                _remove_path(path)
 
-    _check_sqlite(identity_database)
     return RestoreResult(
         identity_database=identity_database,
         tenant_data_root=tenant_data_root,

--- a/src/veridra/backup_restore_cli.py
+++ b/src/veridra/backup_restore_cli.py
@@ -62,18 +62,18 @@ def main() -> None:
             "VERIDRA_TENANT_DATA_ROOT",
         )
         if args.command == "backup":
-            result = create_backup(
+            backup_result = create_backup(
                 identity_database=identity_database,
                 tenant_data_root=tenant_data_root,
                 output=args.output,
                 confirm_quiesced=args.confirm_quiesced,
             )
             print(
-                f"backup={result.archive} files={len(result.manifest.files)} "
-                f"created_at={result.manifest.created_at.isoformat()}"
+                f"backup={backup_result.archive} files={len(backup_result.manifest.files)} "
+                f"created_at={backup_result.manifest.created_at.isoformat()}"
             )
             return
-        result = restore_backup(
+        restore_result = restore_backup(
             archive=args.archive,
             identity_database=identity_database,
             tenant_data_root=tenant_data_root,
@@ -81,8 +81,9 @@ def main() -> None:
             replace_existing=args.replace_existing,
         )
         print(
-            f"restored_files={result.restored_files} "
-            f"identity_db={result.identity_database} tenant_root={result.tenant_data_root}"
+            f"restored_files={restore_result.restored_files} "
+            f"identity_db={restore_result.identity_database} "
+            f"tenant_root={restore_result.tenant_data_root}"
         )
     except BackupRestoreError as exc:
         raise SystemExit(str(exc)) from exc

--- a/src/veridra/backup_restore_cli.py
+++ b/src/veridra/backup_restore_cli.py
@@ -8,7 +8,8 @@ from .backup_restore import BackupRestoreError, create_backup, restore_backup
 
 
 def _configured_path(explicit: Path | None, environment_name: str) -> Path:
-    value = explicit or (Path(os.environ[environment_name]) if os.environ.get(environment_name) else None)
+    configured = os.environ.get(environment_name)
+    value = explicit or (Path(configured) if configured else None)
     if value is None:
         raise BackupRestoreError(
             f"Required path is missing; provide the CLI option or {environment_name}."

--- a/src/veridra/backup_restore_cli.py
+++ b/src/veridra/backup_restore_cli.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from .backup_restore import BackupRestoreError, create_backup, restore_backup
+
+
+def _configured_path(explicit: Path | None, environment_name: str) -> Path:
+    value = explicit or (Path(os.environ[environment_name]) if os.environ.get(environment_name) else None)
+    if value is None:
+        raise BackupRestoreError(
+            f"Required path is missing; provide the CLI option or {environment_name}."
+        )
+    return value.expanduser().resolve()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create or restore a verified Veridra durable-state snapshot. "
+            "The command requires an explicit operator assertion that all writers are quiesced."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    backup = subparsers.add_parser("backup", help="Create a verified quiesced snapshot.")
+    backup.add_argument("--output", type=Path, required=True)
+    backup.add_argument("--identity-db", type=Path, default=None)
+    backup.add_argument("--tenant-data-root", type=Path, default=None)
+    backup.add_argument(
+        "--confirm-quiesced",
+        action="store_true",
+        help="Assert that web, monitoring-worker and billing writers are stopped/quiesced.",
+    )
+
+    restore = subparsers.add_parser("restore", help="Restore and verify a snapshot.")
+    restore.add_argument("--archive", type=Path, required=True)
+    restore.add_argument("--identity-db", type=Path, default=None)
+    restore.add_argument("--tenant-data-root", type=Path, default=None)
+    restore.add_argument(
+        "--confirm-quiesced",
+        action="store_true",
+        help="Assert that web, monitoring-worker and billing writers are stopped/quiesced.",
+    )
+    restore.add_argument(
+        "--replace-existing",
+        action="store_true",
+        help="Explicitly permit replacement of existing durable state.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    try:
+        identity_database = _configured_path(args.identity_db, "VERIDRA_IDENTITY_DB")
+        tenant_data_root = _configured_path(
+            args.tenant_data_root,
+            "VERIDRA_TENANT_DATA_ROOT",
+        )
+        if args.command == "backup":
+            result = create_backup(
+                identity_database=identity_database,
+                tenant_data_root=tenant_data_root,
+                output=args.output,
+                confirm_quiesced=args.confirm_quiesced,
+            )
+            print(
+                f"backup={result.archive} files={len(result.manifest.files)} "
+                f"created_at={result.manifest.created_at.isoformat()}"
+            )
+            return
+        result = restore_backup(
+            archive=args.archive,
+            identity_database=identity_database,
+            tenant_data_root=tenant_data_root,
+            confirm_quiesced=args.confirm_quiesced,
+            replace_existing=args.replace_existing,
+        )
+        print(
+            f"restored_files={result.restored_files} "
+            f"identity_db={result.identity_database} tenant_root={result.tenant_data_root}"
+        )
+    except BackupRestoreError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from veridra.backup_restore import (
+    BackupRestoreError,
+    create_backup,
+    restore_backup,
+)
+
+NOW = datetime(2026, 8, 20, 16, 15, tzinfo=UTC)
+
+
+def _identity(path: Path, value: str = "original") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.execute("CREATE TABLE users (id TEXT PRIMARY KEY, value TEXT NOT NULL)")
+        connection.execute("INSERT INTO users VALUES ('user-1', ?)", (value,))
+
+
+def _read_identity(path: Path) -> str:
+    with sqlite3.connect(path) as connection:
+        row = connection.execute("SELECT value FROM users WHERE id = 'user-1'").fetchone()
+    assert row is not None
+    return str(row[0])
+
+
+def _source_state(tmp_path: Path) -> tuple[Path, Path]:
+    identity = tmp_path / "source" / "identity" / "identity.sqlite3"
+    tenants = tmp_path / "source" / "tenants"
+    _identity(identity)
+    email = identity.parent / "identity-email-deliveries" / "attempt.json"
+    email.parent.mkdir(parents=True)
+    email.write_text('{"status":"delivered"}', encoding="utf-8")
+    project = tenants / ("a" * 24) / "projects" / "project.json"
+    project.parent.mkdir(parents=True)
+    project.write_text('{"name":"Example"}', encoding="utf-8")
+    monitoring = tenants / "monitoring-jobs.sqlite3"
+    with sqlite3.connect(monitoring) as connection:
+        connection.execute("CREATE TABLE monitoring_jobs (id TEXT PRIMARY KEY)")
+        connection.execute("INSERT INTO monitoring_jobs VALUES ('job-1')")
+    return identity, tenants
+
+
+def test_backup_requires_explicit_quiescence(tmp_path: Path) -> None:
+    identity, tenants = _source_state(tmp_path)
+
+    with pytest.raises(BackupRestoreError, match="quiesced"):
+        create_backup(
+            identity_database=identity,
+            tenant_data_root=tenants,
+            output=tmp_path / "backup.zip",
+            confirm_quiesced=False,
+        )
+
+
+def test_backup_restore_round_trip_includes_all_durable_roots(tmp_path: Path) -> None:
+    identity, tenants = _source_state(tmp_path)
+    archive = tmp_path / "backups" / "snapshot.zip"
+
+    backup = create_backup(
+        identity_database=identity,
+        tenant_data_root=tenants,
+        output=archive,
+        confirm_quiesced=True,
+        now=NOW,
+    )
+
+    assert backup.archive == archive.resolve()
+    assert backup.manifest.consistency == "operator_quiesced"
+    members = {entry.path for entry in backup.manifest.files}
+    assert "identity/identity.sqlite3" in members
+    assert "identity/identity-email-deliveries/attempt.json" in members
+    assert f"tenants/{'a' * 24}/projects/project.json" in members
+    assert "tenants/monitoring-jobs.sqlite3" in members
+
+    restored_identity = tmp_path / "restored" / "identity" / "identity.sqlite3"
+    restored_tenants = tmp_path / "restored" / "tenants"
+    result = restore_backup(
+        archive=archive,
+        identity_database=restored_identity,
+        tenant_data_root=restored_tenants,
+        confirm_quiesced=True,
+    )
+
+    assert result.restored_files == len(backup.manifest.files)
+    assert _read_identity(restored_identity) == "original"
+    assert (
+        restored_identity.parent / "identity-email-deliveries" / "attempt.json"
+    ).read_text(encoding="utf-8") == '{"status":"delivered"}'
+    assert (
+        restored_tenants / ("a" * 24) / "projects" / "project.json"
+    ).read_text(encoding="utf-8") == '{"name":"Example"}'
+    with sqlite3.connect(restored_tenants / "monitoring-jobs.sqlite3") as connection:
+        assert connection.execute("SELECT id FROM monitoring_jobs").fetchone() == ("job-1",)
+
+
+def test_restore_refuses_existing_state_without_explicit_replace(tmp_path: Path) -> None:
+    identity, tenants = _source_state(tmp_path)
+    archive = tmp_path / "snapshot.zip"
+    create_backup(
+        identity_database=identity,
+        tenant_data_root=tenants,
+        output=archive,
+        confirm_quiesced=True,
+    )
+
+    target_identity = tmp_path / "target" / "identity" / "identity.sqlite3"
+    target_tenants = tmp_path / "target" / "tenants"
+    _identity(target_identity, "keep")
+    target_tenants.mkdir(parents=True)
+    (target_tenants / "keep.txt").write_text("keep", encoding="utf-8")
+
+    with pytest.raises(BackupRestoreError, match="already contain durable state"):
+        restore_backup(
+            archive=archive,
+            identity_database=target_identity,
+            tenant_data_root=target_tenants,
+            confirm_quiesced=True,
+        )
+
+    assert _read_identity(target_identity) == "keep"
+    assert (target_tenants / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_explicit_replace_restores_snapshot_over_existing_state(tmp_path: Path) -> None:
+    identity, tenants = _source_state(tmp_path)
+    archive = tmp_path / "snapshot.zip"
+    create_backup(
+        identity_database=identity,
+        tenant_data_root=tenants,
+        output=archive,
+        confirm_quiesced=True,
+    )
+
+    target_identity = tmp_path / "target" / "identity" / "identity.sqlite3"
+    target_tenants = tmp_path / "target" / "tenants"
+    _identity(target_identity, "obsolete")
+    target_tenants.mkdir(parents=True)
+    (target_tenants / "obsolete.txt").write_text("obsolete", encoding="utf-8")
+
+    restore_backup(
+        archive=archive,
+        identity_database=target_identity,
+        tenant_data_root=target_tenants,
+        confirm_quiesced=True,
+        replace_existing=True,
+    )
+
+    assert _read_identity(target_identity) == "original"
+    assert not (target_tenants / "obsolete.txt").exists()
+    assert (target_tenants / "monitoring-jobs.sqlite3").is_file()
+
+
+def test_restore_rejects_manifest_hash_mismatch_before_replacing_targets(tmp_path: Path) -> None:
+    identity, tenants = _source_state(tmp_path)
+    archive = tmp_path / "snapshot.zip"
+    create_backup(
+        identity_database=identity,
+        tenant_data_root=tenants,
+        output=archive,
+        confirm_quiesced=True,
+    )
+
+    tampered = tmp_path / "tampered.zip"
+    with zipfile.ZipFile(archive, "r") as source, zipfile.ZipFile(tampered, "w") as target:
+        for info in source.infolist():
+            content = source.read(info.filename)
+            if info.filename.endswith("project.json"):
+                content = b'{"name":"Tampered"}'
+            target.writestr(info.filename, content)
+
+    target_identity = tmp_path / "target" / "identity.sqlite3"
+    target_tenants = tmp_path / "target-tenants"
+    _identity(target_identity, "keep")
+
+    with pytest.raises(BackupRestoreError, match="integrity verification"):
+        restore_backup(
+            archive=tampered,
+            identity_database=target_identity,
+            tenant_data_root=target_tenants,
+            confirm_quiesced=True,
+            replace_existing=True,
+        )
+
+    assert _read_identity(target_identity) == "keep"
+
+
+def test_restore_rejects_archive_paths_not_declared_by_manifest(tmp_path: Path) -> None:
+    identity, tenants = _source_state(tmp_path)
+    archive = tmp_path / "snapshot.zip"
+    create_backup(
+        identity_database=identity,
+        tenant_data_root=tenants,
+        output=archive,
+        confirm_quiesced=True,
+    )
+
+    hostile = tmp_path / "hostile.zip"
+    with zipfile.ZipFile(archive, "r") as source, zipfile.ZipFile(hostile, "w") as target:
+        for info in source.infolist():
+            target.writestr(info.filename, source.read(info.filename))
+        target.writestr("../outside.txt", b"bad")
+
+    with pytest.raises(BackupRestoreError, match="unsafe path"):
+        restore_backup(
+            archive=hostile,
+            identity_database=tmp_path / "restore" / "identity.sqlite3",
+            tenant_data_root=tmp_path / "restore-tenants",
+            confirm_quiesced=True,
+        )
+    assert not (tmp_path / "outside.txt").exists()
+
+
+def test_backup_rejects_symbolic_links(tmp_path: Path) -> None:
+    identity, tenants = _source_state(tmp_path)
+    external = tmp_path / "external.txt"
+    external.write_text("do not follow", encoding="utf-8")
+    link = tenants / "linked.txt"
+    try:
+        link.symlink_to(external)
+    except (OSError, NotImplementedError):
+        pytest.skip("symbolic links are not available on this platform")
+
+    with pytest.raises(BackupRestoreError, match="symbolic link"):
+        create_backup(
+            identity_database=identity,
+            tenant_data_root=tenants,
+            output=tmp_path / "snapshot.zip",
+            confirm_quiesced=True,
+        )
+
+
+def test_manifest_is_machine_readable_and_contains_no_source_paths(tmp_path: Path) -> None:
+    identity, tenants = _source_state(tmp_path)
+    archive = tmp_path / "snapshot.zip"
+    create_backup(
+        identity_database=identity,
+        tenant_data_root=tenants,
+        output=archive,
+        confirm_quiesced=True,
+        now=NOW,
+    )
+
+    with zipfile.ZipFile(archive, "r") as snapshot:
+        manifest = json.loads(snapshot.read("manifest.json"))
+
+    encoded = json.dumps(manifest)
+    assert manifest["format_version"] == 1
+    assert manifest["consistency"] == "operator_quiesced"
+    assert str(identity.resolve()) not in encoded
+    assert str(tenants.resolve()) not in encoded


### PR DESCRIPTION
Adds a provider-neutral production backup/restore boundary for Veridra's mixed SQLite + filesystem persistence model.

What changes:
- add `veridra-backup backup` and `veridra-backup restore` commands;
- require explicit `--confirm-quiesced` because identity SQLite and tenant filesystem state do not share a transaction boundary;
- snapshot the identity database through SQLite's backup API and validate it with `PRAGMA quick_check`;
- include adjacent identity-email delivery evidence plus the complete tenant root, including durable monitoring-job SQLite state;
- emit a versioned manifest with UTC timestamp, Veridra version, archive-relative paths, sizes and SHA-256 digests;
- refuse archive output inside durable source roots and refuse overwrite of existing archives;
- reject symlinks, unsafe paths, duplicate/undeclared archive members and integrity mismatches;
- refuse restore over existing durable state unless `--replace-existing` is explicitly supplied;
- verify the complete archive and restored identity SQLite database before normal recovery validation;
- add round-trip, corruption, path-traversal, symlink and overwrite-safety tests;
- document the required quiesce, backup, restore and recovery-validation workflow.

The CLI does not claim live cross-store atomicity and cannot prove that writers are stopped; process supervision must enforce the quiescence assertion.

Do not merge until exact-head full CI succeeds.