### PR TITLE
Add production operational alert checks

### DIFF
--- a/docs/operations/monitoring-alerting.md
+++ b/docs/operations/monitoring-alerting.md
@@ -1,0 +1,99 @@
+# Production monitoring and alerting
+
+Veridra exposes two different operational layers:
+
+- HTTP liveness/readiness for traffic management: `GET /health/live` and `GET /health/ready`;
+- a non-public operator check for scheduled alerting: `veridra-ops-check`.
+
+Do not expose `veridra-ops-check` as a public HTTP endpoint. Run it from the host, container task, scheduler or monitoring agent that already has access to the production durable paths.
+
+## Command
+
+With the normal production environment variables configured:
+
+```text
+veridra-ops-check
+```
+
+To include backup freshness:
+
+```text
+veridra-ops-check --backup-dir /secure-backups
+```
+
+Important options:
+
+```text
+--recent-hours 24
+--queued-overdue-minutes 30
+--backup-max-age-hours 26
+```
+
+The command writes one compact JSON object to stdout and exits with:
+
+- `0` — all checks are healthy;
+- `1` — warning; operator attention is appropriate;
+- `2` — critical; investigate promptly.
+
+A scheduler or monitoring platform can alert directly from that exit code and store the JSON result as bounded operational evidence.
+
+## Checks
+
+The command evaluates:
+
+- identity SQLite integrity and the required identity schema;
+- tenant-data-root availability;
+- monitoring-job SQLite integrity;
+- recent terminal monitoring failures;
+- queued monitoring jobs that are overdue beyond the configured threshold;
+- expired worker leases;
+- malformed monitoring timestamps;
+- recent failed identity-email deliveries;
+- malformed identity-email evidence;
+- optional backup freshness.
+
+Backup freshness accepts only ZIP files containing a valid Veridra snapshot manifest with the supported format and `operator_quiesced` consistency declaration. It uses the manifest creation timestamp rather than filesystem modification time.
+
+Freshness is not a full restore/integrity test. `veridra-backup restore` and periodic isolated restoration remain the proof that the complete snapshot is recoverable.
+
+## Privacy boundary
+
+The JSON output intentionally contains only check names, severity, aggregate counts and generic details. It does not emit:
+
+- tenant or project identifiers;
+- customer email addresses;
+- monitoring error text;
+- identity-email provider error text;
+- durable filesystem paths;
+- secret values.
+
+Keep the output protected as operational telemetry even though it is deliberately bounded.
+
+## Suggested supervision
+
+A practical starting point is to run the operator check every five minutes and alert on non-zero exit codes. Tune thresholds to the actual worker cadence and backup schedule before production launch.
+
+Use separate signals for separate decisions:
+
+- `/health/live`: restart/process-health decision;
+- `/health/ready`: route/no-route customer traffic decision;
+- `veridra-ops-check`: operator investigation/alert decision.
+
+Do not automatically restart the application merely because the operator check reports a warning or a terminal business job failure.
+
+## Backup alerting
+
+Only configure `--backup-dir` when that directory represents the location in which completed Veridra snapshot archives are expected to appear. If backup creation and off-host upload are separate jobs, monitor both the local snapshot job and the destination storage independently.
+
+A fresh local manifest does not prove the off-host copy succeeded.
+
+## Deployment validation
+
+Before relying on alerts in production:
+
+1. exercise one healthy run and confirm exit `0`;
+2. temporarily use a deliberately stale backup test directory and confirm exit `2`;
+3. create a controlled overdue monitoring-job fixture in a non-production environment and confirm warning behavior;
+4. verify the monitoring platform captures stdout without adding environment-variable dumps;
+5. verify alert messages do not attach durable files or sensitive logs;
+6. record the monitoring cadence and thresholds with the deployed configuration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ veridra-identity-bootstrap = "veridra.identity_bootstrap_cli:main"
 veridra-monitoring-worker = "veridra.monitoring_worker_cli:main"
 veridra-subscription-apply = "veridra.subscription_authority_cli:main"
 veridra-backup = "veridra.backup_restore_cli:main"
+veridra-ops-check = "veridra.ops_check_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/ops_check.py
+++ b/src/veridra/ops_check.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import zipfile
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
@@ -9,6 +10,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from .backup_restore import SnapshotManifest
 from .identity_email_delivery import IdentityEmailAttempt
 
 
@@ -75,14 +77,20 @@ def _identity_check(database: Path) -> CheckResult:
         )
     try:
         with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as connection:
-            row = connection.execute("PRAGMA quick_check").fetchone()
+            integrity = connection.execute("PRAGMA quick_check").fetchone()
+            rows = connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
     except sqlite3.Error:
-        row = None
-    if row is None or row[0] != "ok":
+        integrity = None
+        rows = []
+    required = {"tenants", "users", "memberships", "sessions"}
+    tables = {str(row[0]) for row in rows}
+    if integrity is None or integrity[0] != "ok" or not required.issubset(tables):
         return CheckResult(
             name="identity_database",
             status=CheckStatus.critical,
-            detail="identity database integrity check failed",
+            detail="identity database integrity or schema check failed",
         )
     return CheckResult(
         name="identity_database",
@@ -230,25 +238,29 @@ def _monitoring_checks(
     return checks
 
 
-def _identity_email_check(
+def _identity_email_checks(
     database: Path,
     *,
     now: datetime,
     recent_window: timedelta,
-) -> CheckResult:
+) -> list[CheckResult]:
     directory = database.parent / "identity-email-deliveries"
     if not directory.exists():
-        return CheckResult(
-            name="identity_email_failures",
-            status=CheckStatus.ok,
-            detail="identity email evidence is not initialized",
-        )
+        return [
+            CheckResult(
+                name="identity_email_failures",
+                status=CheckStatus.ok,
+                detail="identity email evidence is not initialized",
+            )
+        ]
     if not directory.is_dir() or directory.is_symlink():
-        return CheckResult(
-            name="identity_email_failures",
-            status=CheckStatus.critical,
-            detail="identity email evidence is unavailable",
-        )
+        return [
+            CheckResult(
+                name="identity_email_evidence",
+                status=CheckStatus.critical,
+                detail="identity email evidence is unavailable",
+            )
+        ]
     cutoff = now - recent_window
     failures = 0
     malformed = 0
@@ -263,19 +275,41 @@ def _identity_email_check(
             continue
         if attempt.status.value == "failed" and attempt.attempted_at.astimezone(UTC) >= cutoff:
             failures += 1
-    if malformed:
-        return CheckResult(
-            name="identity_email_evidence",
-            status=CheckStatus.warning,
-            count=malformed,
-            detail="identity email evidence contains unreadable records",
+    checks = [
+        CheckResult(
+            name="identity_email_failures",
+            status=CheckStatus.warning if failures else CheckStatus.ok,
+            count=failures,
+            detail=(
+                "recent identity email failures" if failures else "no recent identity email failures"
+            ),
         )
-    return CheckResult(
-        name="identity_email_failures",
-        status=CheckStatus.warning if failures else CheckStatus.ok,
-        count=failures,
-        detail="recent identity email failures" if failures else "no recent identity email failures",
-    )
+    ]
+    if malformed:
+        checks.append(
+            CheckResult(
+                name="identity_email_evidence",
+                status=CheckStatus.warning,
+                count=malformed,
+                detail="identity email evidence contains unreadable records",
+            )
+        )
+    return checks
+
+
+def _backup_created_at(path: Path) -> datetime | None:
+    try:
+        with zipfile.ZipFile(path, "r") as archive:
+            if "manifest.json" not in archive.namelist():
+                return None
+            manifest = SnapshotManifest.model_validate_json(archive.read("manifest.json"))
+    except (OSError, ValueError, ValidationError, zipfile.BadZipFile):
+        return None
+    if manifest.format_version != 1 or manifest.consistency != "operator_quiesced":
+        return None
+    if manifest.created_at.tzinfo is None:
+        return None
+    return manifest.created_at.astimezone(UTC)
 
 
 def _backup_check(
@@ -290,23 +324,21 @@ def _backup_check(
             status=CheckStatus.critical,
             detail="backup directory is unavailable",
         )
-    archives = [path for path in directory.glob("*.zip") if path.is_file() and not path.is_symlink()]
-    if not archives:
+    created = [
+        timestamp
+        for path in directory.glob("*.zip")
+        if path.is_file()
+        and not path.is_symlink()
+        and (timestamp := _backup_created_at(path)) is not None
+    ]
+    if not created:
         return CheckResult(
             name="backup_freshness",
             status=CheckStatus.critical,
-            detail="no backup archive was found",
+            detail="no valid Veridra backup archive was found",
         )
-    try:
-        newest = max(datetime.fromtimestamp(path.stat().st_mtime, tz=UTC) for path in archives)
-    except OSError:
-        return CheckResult(
-            name="backup_freshness",
-            status=CheckStatus.critical,
-            detail="backup archive metadata cannot be read",
-        )
-    age = now - newest
-    stale = age > max_age
+    newest = max(created)
+    stale = now - newest > max_age
     return CheckResult(
         name="backup_freshness",
         status=CheckStatus.critical if stale else CheckStatus.ok,
@@ -339,8 +371,8 @@ def run_ops_check(
                 queued_overdue=config.queued_overdue,
             )
         )
-    checks.append(
-        _identity_email_check(
+    checks.extend(
+        _identity_email_checks(
             identity,
             now=checked_at,
             recent_window=config.recent_window,

--- a/src/veridra/ops_check.py
+++ b/src/veridra/ops_check.py
@@ -217,13 +217,21 @@ def _monitoring_checks(
             name="monitoring_queue_overdue",
             status=CheckStatus.warning if overdue else CheckStatus.ok,
             count=overdue,
-            detail="monitoring jobs are overdue" if overdue else "monitoring queue is within threshold",
+            detail=(
+                "monitoring jobs are overdue"
+                if overdue
+                else "monitoring queue is within threshold"
+            ),
         ),
         CheckResult(
             name="monitoring_expired_leases",
             status=CheckStatus.critical if expired_leases else CheckStatus.ok,
             count=expired_leases,
-            detail="monitoring leases expired" if expired_leases else "no expired monitoring leases",
+            detail=(
+                "monitoring leases expired"
+                if expired_leases
+                else "no expired monitoring leases"
+            ),
         ),
     ]
     if malformed:
@@ -281,7 +289,9 @@ def _identity_email_checks(
             status=CheckStatus.warning if failures else CheckStatus.ok,
             count=failures,
             detail=(
-                "recent identity email failures" if failures else "no recent identity email failures"
+                "recent identity email failures"
+                if failures
+                else "no recent identity email failures"
             ),
         )
     ]

--- a/src/veridra/ops_check.py
+++ b/src/veridra/ops_check.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from .identity_email_delivery import IdentityEmailAttempt
+
+
+class OpsCheckError(RuntimeError):
+    pass
+
+
+class CheckStatus(StrEnum):
+    ok = "ok"
+    warning = "warning"
+    critical = "critical"
+
+
+class CheckResult(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(min_length=1, max_length=80)
+    status: CheckStatus
+    count: int = Field(default=0, ge=0)
+    detail: str = Field(min_length=1, max_length=200)
+
+
+class OpsCheckReport(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    status: CheckStatus
+    checked_at: datetime
+    checks: list[CheckResult]
+
+    @property
+    def exit_code(self) -> int:
+        if self.status is CheckStatus.critical:
+            return 2
+        if self.status is CheckStatus.warning:
+            return 1
+        return 0
+
+
+@dataclass(frozen=True)
+class OpsCheckConfig:
+    identity_database: Path
+    tenant_data_root: Path
+    recent_window: timedelta = timedelta(hours=24)
+    queued_overdue: timedelta = timedelta(minutes=30)
+    backup_directory: Path | None = None
+    backup_max_age: timedelta = timedelta(hours=26)
+
+
+def _overall(checks: list[CheckResult]) -> CheckStatus:
+    statuses = {check.status for check in checks}
+    if CheckStatus.critical in statuses:
+        return CheckStatus.critical
+    if CheckStatus.warning in statuses:
+        return CheckStatus.warning
+    return CheckStatus.ok
+
+
+def _identity_check(database: Path) -> CheckResult:
+    if not database.is_file() or database.is_symlink():
+        return CheckResult(
+            name="identity_database",
+            status=CheckStatus.critical,
+            detail="identity database is unavailable",
+        )
+    try:
+        with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as connection:
+            row = connection.execute("PRAGMA quick_check").fetchone()
+    except sqlite3.Error:
+        row = None
+    if row is None or row[0] != "ok":
+        return CheckResult(
+            name="identity_database",
+            status=CheckStatus.critical,
+            detail="identity database integrity check failed",
+        )
+    return CheckResult(
+        name="identity_database",
+        status=CheckStatus.ok,
+        detail="identity database is readable",
+    )
+
+
+def _tenant_root_check(root: Path) -> CheckResult:
+    if not root.is_dir() or root.is_symlink():
+        return CheckResult(
+            name="tenant_data_root",
+            status=CheckStatus.critical,
+            detail="tenant data root is unavailable",
+        )
+    try:
+        next(root.iterdir(), None)
+    except OSError:
+        return CheckResult(
+            name="tenant_data_root",
+            status=CheckStatus.critical,
+            detail="tenant data root cannot be read",
+        )
+    return CheckResult(
+        name="tenant_data_root",
+        status=CheckStatus.ok,
+        detail="tenant data root is readable",
+    )
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(UTC)
+
+
+def _monitoring_checks(
+    root: Path,
+    *,
+    now: datetime,
+    recent_window: timedelta,
+    queued_overdue: timedelta,
+) -> list[CheckResult]:
+    database = root / "monitoring-jobs.sqlite3"
+    if not database.exists():
+        return [
+            CheckResult(
+                name="monitoring_jobs",
+                status=CheckStatus.ok,
+                detail="monitoring job store is not initialized",
+            )
+        ]
+    if not database.is_file() or database.is_symlink():
+        return [
+            CheckResult(
+                name="monitoring_jobs",
+                status=CheckStatus.critical,
+                detail="monitoring job store is unavailable",
+            )
+        ]
+    try:
+        with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as connection:
+            connection.row_factory = sqlite3.Row
+            integrity = connection.execute("PRAGMA quick_check").fetchone()
+            rows = connection.execute(
+                """SELECT state, next_attempt_at, lease_expires_at, updated_at
+                FROM monitoring_jobs"""
+            ).fetchall()
+    except sqlite3.Error:
+        return [
+            CheckResult(
+                name="monitoring_jobs",
+                status=CheckStatus.critical,
+                detail="monitoring job store cannot be queried",
+            )
+        ]
+    if integrity is None or integrity[0] != "ok":
+        return [
+            CheckResult(
+                name="monitoring_jobs",
+                status=CheckStatus.critical,
+                detail="monitoring job store integrity check failed",
+            )
+        ]
+
+    recent_cutoff = now - recent_window
+    overdue_cutoff = now - queued_overdue
+    failed = 0
+    overdue = 0
+    expired_leases = 0
+    malformed = 0
+    for row in rows:
+        updated_at = _parse_timestamp(row["updated_at"])
+        next_attempt_at = _parse_timestamp(row["next_attempt_at"])
+        lease_expires_at = _parse_timestamp(row["lease_expires_at"])
+        state = str(row["state"])
+        if updated_at is None or next_attempt_at is None:
+            malformed += 1
+            continue
+        if state == "failed" and updated_at >= recent_cutoff:
+            failed += 1
+        elif state == "queued" and next_attempt_at <= overdue_cutoff:
+            overdue += 1
+        elif state == "leased":
+            if lease_expires_at is None:
+                malformed += 1
+            elif lease_expires_at <= now:
+                expired_leases += 1
+
+    checks = [
+        CheckResult(
+            name="monitoring_failed_recent",
+            status=CheckStatus.critical if failed else CheckStatus.ok,
+            count=failed,
+            detail="recent terminal monitoring jobs" if failed else "no recent terminal jobs",
+        ),
+        CheckResult(
+            name="monitoring_queue_overdue",
+            status=CheckStatus.warning if overdue else CheckStatus.ok,
+            count=overdue,
+            detail="monitoring jobs are overdue" if overdue else "monitoring queue is within threshold",
+        ),
+        CheckResult(
+            name="monitoring_expired_leases",
+            status=CheckStatus.critical if expired_leases else CheckStatus.ok,
+            count=expired_leases,
+            detail="monitoring leases expired" if expired_leases else "no expired monitoring leases",
+        ),
+    ]
+    if malformed:
+        checks.append(
+            CheckResult(
+                name="monitoring_malformed_rows",
+                status=CheckStatus.critical,
+                count=malformed,
+                detail="monitoring job timestamps are invalid",
+            )
+        )
+    return checks
+
+
+def _identity_email_check(
+    database: Path,
+    *,
+    now: datetime,
+    recent_window: timedelta,
+) -> CheckResult:
+    directory = database.parent / "identity-email-deliveries"
+    if not directory.exists():
+        return CheckResult(
+            name="identity_email_failures",
+            status=CheckStatus.ok,
+            detail="identity email evidence is not initialized",
+        )
+    if not directory.is_dir() or directory.is_symlink():
+        return CheckResult(
+            name="identity_email_failures",
+            status=CheckStatus.critical,
+            detail="identity email evidence is unavailable",
+        )
+    cutoff = now - recent_window
+    failures = 0
+    malformed = 0
+    for path in directory.glob("*.json"):
+        if not path.is_file() or path.is_symlink():
+            malformed += 1
+            continue
+        try:
+            attempt = IdentityEmailAttempt.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValidationError, ValueError):
+            malformed += 1
+            continue
+        if attempt.status.value == "failed" and attempt.attempted_at.astimezone(UTC) >= cutoff:
+            failures += 1
+    if malformed:
+        return CheckResult(
+            name="identity_email_evidence",
+            status=CheckStatus.warning,
+            count=malformed,
+            detail="identity email evidence contains unreadable records",
+        )
+    return CheckResult(
+        name="identity_email_failures",
+        status=CheckStatus.warning if failures else CheckStatus.ok,
+        count=failures,
+        detail="recent identity email failures" if failures else "no recent identity email failures",
+    )
+
+
+def _backup_check(
+    directory: Path,
+    *,
+    now: datetime,
+    max_age: timedelta,
+) -> CheckResult:
+    if not directory.is_dir() or directory.is_symlink():
+        return CheckResult(
+            name="backup_freshness",
+            status=CheckStatus.critical,
+            detail="backup directory is unavailable",
+        )
+    archives = [path for path in directory.glob("*.zip") if path.is_file() and not path.is_symlink()]
+    if not archives:
+        return CheckResult(
+            name="backup_freshness",
+            status=CheckStatus.critical,
+            detail="no backup archive was found",
+        )
+    try:
+        newest = max(datetime.fromtimestamp(path.stat().st_mtime, tz=UTC) for path in archives)
+    except OSError:
+        return CheckResult(
+            name="backup_freshness",
+            status=CheckStatus.critical,
+            detail="backup archive metadata cannot be read",
+        )
+    age = now - newest
+    stale = age > max_age
+    return CheckResult(
+        name="backup_freshness",
+        status=CheckStatus.critical if stale else CheckStatus.ok,
+        detail="latest backup is stale" if stale else "latest backup is within threshold",
+    )
+
+
+def run_ops_check(
+    config: OpsCheckConfig,
+    *,
+    now: datetime | None = None,
+) -> OpsCheckReport:
+    checked_at = (now or datetime.now(UTC)).astimezone(UTC)
+    if config.recent_window <= timedelta(0):
+        raise OpsCheckError("recent_window must be positive")
+    if config.queued_overdue <= timedelta(0):
+        raise OpsCheckError("queued_overdue must be positive")
+    if config.backup_max_age <= timedelta(0):
+        raise OpsCheckError("backup_max_age must be positive")
+
+    identity = config.identity_database.expanduser().resolve()
+    tenant_root = config.tenant_data_root.expanduser().resolve()
+    checks = [_identity_check(identity), _tenant_root_check(tenant_root)]
+    if checks[1].status is not CheckStatus.critical:
+        checks.extend(
+            _monitoring_checks(
+                tenant_root,
+                now=checked_at,
+                recent_window=config.recent_window,
+                queued_overdue=config.queued_overdue,
+            )
+        )
+    checks.append(
+        _identity_email_check(
+            identity,
+            now=checked_at,
+            recent_window=config.recent_window,
+        )
+    )
+    if config.backup_directory is not None:
+        checks.append(
+            _backup_check(
+                config.backup_directory.expanduser().resolve(),
+                now=checked_at,
+                max_age=config.backup_max_age,
+            )
+        )
+    return OpsCheckReport(status=_overall(checks), checked_at=checked_at, checks=checks)
+
+
+def report_json(report: OpsCheckReport) -> str:
+    return json.dumps(report.model_dump(mode="json"), sort_keys=True, separators=(",", ":"))

--- a/src/veridra/ops_check_cli.py
+++ b/src/veridra/ops_check_cli.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import timedelta
+from pathlib import Path
+
+from .ops_check import OpsCheckConfig, OpsCheckError, report_json, run_ops_check
+
+
+def _path(explicit: Path | None, environment_name: str) -> Path:
+    configured = os.environ.get(environment_name)
+    value = explicit or (Path(configured) if configured else None)
+    if value is None:
+        raise OpsCheckError(
+            f"Required path is missing; provide the CLI option or {environment_name}."
+        )
+    return value.expanduser().resolve()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a non-public Veridra production operations check and emit stable JSON. "
+            "Exit codes: 0 ok, 1 warning, 2 critical."
+        )
+    )
+    parser.add_argument("--identity-db", type=Path, default=None)
+    parser.add_argument("--tenant-data-root", type=Path, default=None)
+    parser.add_argument("--backup-dir", type=Path, default=None)
+    parser.add_argument("--recent-hours", type=float, default=24.0)
+    parser.add_argument("--queued-overdue-minutes", type=float, default=30.0)
+    parser.add_argument("--backup-max-age-hours", type=float, default=26.0)
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    try:
+        report = run_ops_check(
+            OpsCheckConfig(
+                identity_database=_path(args.identity_db, "VERIDRA_IDENTITY_DB"),
+                tenant_data_root=_path(
+                    args.tenant_data_root,
+                    "VERIDRA_TENANT_DATA_ROOT",
+                ),
+                recent_window=timedelta(hours=args.recent_hours),
+                queued_overdue=timedelta(minutes=args.queued_overdue_minutes),
+                backup_directory=(
+                    args.backup_dir.expanduser().resolve() if args.backup_dir else None
+                ),
+                backup_max_age=timedelta(hours=args.backup_max_age_hours),
+            )
+        )
+    except (OpsCheckError, ValueError) as exc:
+        raise SystemExit(str(exc)) from exc
+    print(report_json(report))
+    raise SystemExit(report.exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ops_check.py
+++ b/tests/test_ops_check.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from veridra.backup_restore import create_backup
 from veridra.email_delivery import EmailStatus
 from veridra.identity_email_delivery import IdentityEmailAttempt, IdentityEmailKind
-from veridra.ops_check import CheckStatus, OpsCheckConfig, report_json, run_ops_check
+from veridra.ops_check import (
+    CheckStatus,
+    OpsCheckConfig,
+    OpsCheckReport,
+    report_json,
+    run_ops_check,
+)
 
 NOW = datetime(2026, 8, 20, 16, 30, tzinfo=UTC)
 
@@ -16,7 +22,10 @@ NOW = datetime(2026, 8, 20, 16, 30, tzinfo=UTC)
 def _identity(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(path) as connection:
+        connection.execute("CREATE TABLE tenants (id TEXT PRIMARY KEY)")
         connection.execute("CREATE TABLE users (id TEXT PRIMARY KEY)")
+        connection.execute("CREATE TABLE memberships (id TEXT PRIMARY KEY)")
+        connection.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
         connection.execute("INSERT INTO users VALUES ('user-1')")
 
 
@@ -63,9 +72,29 @@ def _base(tmp_path: Path) -> tuple[Path, Path]:
     return identity, tenants
 
 
-def _check(report: object, name: str) -> dict[str, object]:
-    payload = json.loads(report_json(report))  # type: ignore[arg-type]
+def _check(report: OpsCheckReport, name: str) -> dict[str, object]:
+    payload = json.loads(report_json(report))
     return next(check for check in payload["checks"] if check["name"] == name)
+
+
+def _backup(
+    *,
+    identity: Path,
+    tenants: Path,
+    directory: Path,
+    created_at: datetime,
+    name: str = "snapshot.zip",
+) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    archive = directory / name
+    create_backup(
+        identity_database=identity,
+        tenant_data_root=tenants,
+        output=archive,
+        confirm_quiesced=True,
+        now=created_at,
+    )
+    return archive
 
 
 def test_healthy_uninitialized_runtime_is_ok(tmp_path: Path) -> None:
@@ -80,6 +109,23 @@ def test_healthy_uninitialized_runtime_is_ok(tmp_path: Path) -> None:
     assert report.exit_code == 0
     assert _check(report, "identity_database")["status"] == "ok"
     assert _check(report, "monitoring_jobs")["status"] == "ok"
+
+
+def test_identity_schema_gap_is_critical(tmp_path: Path) -> None:
+    identity = tmp_path / "identity" / "identity.sqlite3"
+    identity.parent.mkdir(parents=True)
+    with sqlite3.connect(identity) as connection:
+        connection.execute("CREATE TABLE users (id TEXT PRIMARY KEY)")
+    tenants = tmp_path / "tenants"
+    tenants.mkdir()
+
+    report = run_ops_check(
+        OpsCheckConfig(identity_database=identity, tenant_data_root=tenants),
+        now=NOW,
+    )
+
+    assert report.status is CheckStatus.critical
+    assert _check(report, "identity_database")["status"] == "critical"
 
 
 def test_recent_terminal_monitoring_job_is_critical(tmp_path: Path) -> None:
@@ -174,6 +220,22 @@ def test_recent_identity_email_failure_warns_without_exposing_recipient(tmp_path
     assert str(identity) not in encoded
 
 
+def test_malformed_identity_email_evidence_warns_independently(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+    directory = identity.parent / "identity-email-deliveries"
+    directory.mkdir()
+    (directory / "broken.json").write_text("not-json", encoding="utf-8")
+
+    report = run_ops_check(
+        OpsCheckConfig(identity_database=identity, tenant_data_root=tenants),
+        now=NOW,
+    )
+
+    assert report.status is CheckStatus.warning
+    assert _check(report, "identity_email_failures")["count"] == 0
+    assert _check(report, "identity_email_evidence")["count"] == 1
+
+
 def test_missing_explicit_backup_directory_is_critical(tmp_path: Path) -> None:
     identity, tenants = _base(tmp_path)
 
@@ -190,14 +252,15 @@ def test_missing_explicit_backup_directory_is_critical(tmp_path: Path) -> None:
     assert _check(report, "backup_freshness")["status"] == "critical"
 
 
-def test_backup_freshness_uses_newest_archive_mtime(tmp_path: Path) -> None:
+def test_recent_valid_backup_manifest_is_ok(tmp_path: Path) -> None:
     identity, tenants = _base(tmp_path)
     backups = tmp_path / "backups"
-    backups.mkdir()
-    archive = backups / "snapshot.zip"
-    archive.write_bytes(b"placeholder")
-    timestamp = (NOW - timedelta(hours=2)).timestamp()
-    os.utime(archive, (timestamp, timestamp))
+    _backup(
+        identity=identity,
+        tenants=tenants,
+        directory=backups,
+        created_at=NOW - timedelta(hours=2),
+    )
 
     report = run_ops_check(
         OpsCheckConfig(
@@ -212,14 +275,15 @@ def test_backup_freshness_uses_newest_archive_mtime(tmp_path: Path) -> None:
     assert _check(report, "backup_freshness")["status"] == "ok"
 
 
-def test_stale_backup_is_critical(tmp_path: Path) -> None:
+def test_stale_valid_backup_manifest_is_critical(tmp_path: Path) -> None:
     identity, tenants = _base(tmp_path)
     backups = tmp_path / "backups"
-    backups.mkdir()
-    archive = backups / "snapshot.zip"
-    archive.write_bytes(b"placeholder")
-    timestamp = (NOW - timedelta(days=2)).timestamp()
-    os.utime(archive, (timestamp, timestamp))
+    _backup(
+        identity=identity,
+        tenants=tenants,
+        directory=backups,
+        created_at=NOW - timedelta(days=2),
+    )
 
     report = run_ops_check(
         OpsCheckConfig(
@@ -227,6 +291,25 @@ def test_stale_backup_is_critical(tmp_path: Path) -> None:
             tenant_data_root=tenants,
             backup_directory=backups,
             backup_max_age=timedelta(hours=26),
+        ),
+        now=NOW,
+    )
+
+    assert report.status is CheckStatus.critical
+    assert _check(report, "backup_freshness")["status"] == "critical"
+
+
+def test_random_zip_does_not_satisfy_backup_freshness(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+    backups = tmp_path / "backups"
+    backups.mkdir()
+    (backups / "random.zip").write_bytes(b"not a Veridra snapshot")
+
+    report = run_ops_check(
+        OpsCheckConfig(
+            identity_database=identity,
+            tenant_data_root=tenants,
+            backup_directory=backups,
         ),
         now=NOW,
     )

--- a/tests/test_ops_check.py
+++ b/tests/test_ops_check.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from veridra.email_delivery import EmailStatus
+from veridra.identity_email_delivery import IdentityEmailAttempt, IdentityEmailKind
+from veridra.ops_check import CheckStatus, OpsCheckConfig, report_json, run_ops_check
+
+NOW = datetime(2026, 8, 20, 16, 30, tzinfo=UTC)
+
+
+def _identity(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.execute("CREATE TABLE users (id TEXT PRIMARY KEY)")
+        connection.execute("INSERT INTO users VALUES ('user-1')")
+
+
+def _monitoring_database(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    database = root / "monitoring-jobs.sqlite3"
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """CREATE TABLE monitoring_jobs (
+                state TEXT NOT NULL,
+                next_attempt_at TEXT NOT NULL,
+                lease_expires_at TEXT,
+                updated_at TEXT NOT NULL
+            )"""
+        )
+    return database
+
+
+def _insert_job(
+    database: Path,
+    *,
+    state: str,
+    next_attempt_at: datetime,
+    updated_at: datetime,
+    lease_expires_at: datetime | None = None,
+) -> None:
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "INSERT INTO monitoring_jobs VALUES (?, ?, ?, ?)",
+            (
+                state,
+                next_attempt_at.isoformat(),
+                lease_expires_at.isoformat() if lease_expires_at else None,
+                updated_at.isoformat(),
+            ),
+        )
+
+
+def _base(tmp_path: Path) -> tuple[Path, Path]:
+    identity = tmp_path / "identity" / "identity.sqlite3"
+    tenants = tmp_path / "tenants"
+    _identity(identity)
+    tenants.mkdir()
+    return identity, tenants
+
+
+def _check(report: object, name: str) -> dict[str, object]:
+    payload = json.loads(report_json(report))  # type: ignore[arg-type]
+    return next(check for check in payload["checks"] if check["name"] == name)
+
+
+def test_healthy_uninitialized_runtime_is_ok(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+
+    report = run_ops_check(
+        OpsCheckConfig(identity_database=identity, tenant_data_root=tenants),
+        now=NOW,
+    )
+
+    assert report.status is CheckStatus.ok
+    assert report.exit_code == 0
+    assert _check(report, "identity_database")["status"] == "ok"
+    assert _check(report, "monitoring_jobs")["status"] == "ok"
+
+
+def test_recent_terminal_monitoring_job_is_critical(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+    database = _monitoring_database(tenants)
+    _insert_job(
+        database,
+        state="failed",
+        next_attempt_at=NOW,
+        updated_at=NOW - timedelta(minutes=5),
+    )
+
+    report = run_ops_check(
+        OpsCheckConfig(identity_database=identity, tenant_data_root=tenants),
+        now=NOW,
+    )
+
+    assert report.status is CheckStatus.critical
+    assert report.exit_code == 2
+    assert _check(report, "monitoring_failed_recent")["count"] == 1
+
+
+def test_overdue_monitoring_queue_is_warning(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+    database = _monitoring_database(tenants)
+    _insert_job(
+        database,
+        state="queued",
+        next_attempt_at=NOW - timedelta(hours=2),
+        updated_at=NOW - timedelta(hours=2),
+    )
+
+    report = run_ops_check(
+        OpsCheckConfig(identity_database=identity, tenant_data_root=tenants),
+        now=NOW,
+    )
+
+    assert report.status is CheckStatus.warning
+    assert report.exit_code == 1
+    assert _check(report, "monitoring_queue_overdue")["count"] == 1
+
+
+def test_expired_monitoring_lease_is_critical(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+    database = _monitoring_database(tenants)
+    _insert_job(
+        database,
+        state="leased",
+        next_attempt_at=NOW - timedelta(minutes=20),
+        updated_at=NOW - timedelta(minutes=20),
+        lease_expires_at=NOW - timedelta(minutes=1),
+    )
+
+    report = run_ops_check(
+        OpsCheckConfig(identity_database=identity, tenant_data_root=tenants),
+        now=NOW,
+    )
+
+    assert report.status is CheckStatus.critical
+    assert _check(report, "monitoring_expired_leases")["count"] == 1
+
+
+def test_recent_identity_email_failure_warns_without_exposing_recipient(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+    attempt = IdentityEmailAttempt(
+        kind=IdentityEmailKind.password_reset,
+        recipient="customer@example.com",
+        attempted_at=NOW - timedelta(minutes=10),
+        status=EmailStatus.failed,
+        subject="Password reset",
+        message_sha256="a" * 64,
+        delivery_key="b" * 24,
+        error="provider secret detail",
+    )
+    directory = identity.parent / "identity-email-deliveries"
+    directory.mkdir()
+    (directory / "attempt.json").write_text(
+        attempt.model_dump_json(),
+        encoding="utf-8",
+    )
+
+    report = run_ops_check(
+        OpsCheckConfig(identity_database=identity, tenant_data_root=tenants),
+        now=NOW,
+    )
+    encoded = report_json(report)
+
+    assert report.status is CheckStatus.warning
+    assert _check(report, "identity_email_failures")["count"] == 1
+    assert "customer@example.com" not in encoded
+    assert "provider secret detail" not in encoded
+    assert str(identity) not in encoded
+
+
+def test_missing_explicit_backup_directory_is_critical(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+
+    report = run_ops_check(
+        OpsCheckConfig(
+            identity_database=identity,
+            tenant_data_root=tenants,
+            backup_directory=tmp_path / "missing-backups",
+        ),
+        now=NOW,
+    )
+
+    assert report.status is CheckStatus.critical
+    assert _check(report, "backup_freshness")["status"] == "critical"
+
+
+def test_backup_freshness_uses_newest_archive_mtime(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+    backups = tmp_path / "backups"
+    backups.mkdir()
+    archive = backups / "snapshot.zip"
+    archive.write_bytes(b"placeholder")
+    timestamp = (NOW - timedelta(hours=2)).timestamp()
+    os.utime(archive, (timestamp, timestamp))
+
+    report = run_ops_check(
+        OpsCheckConfig(
+            identity_database=identity,
+            tenant_data_root=tenants,
+            backup_directory=backups,
+            backup_max_age=timedelta(hours=4),
+        ),
+        now=NOW,
+    )
+
+    assert _check(report, "backup_freshness")["status"] == "ok"
+
+
+def test_stale_backup_is_critical(tmp_path: Path) -> None:
+    identity, tenants = _base(tmp_path)
+    backups = tmp_path / "backups"
+    backups.mkdir()
+    archive = backups / "snapshot.zip"
+    archive.write_bytes(b"placeholder")
+    timestamp = (NOW - timedelta(days=2)).timestamp()
+    os.utime(archive, (timestamp, timestamp))
+
+    report = run_ops_check(
+        OpsCheckConfig(
+            identity_database=identity,
+            tenant_data_root=tenants,
+            backup_directory=backups,
+            backup_max_age=timedelta(hours=26),
+        ),
+        now=NOW,
+    )
+
+    assert report.status is CheckStatus.critical
+    assert _check(report, "backup_freshness")["status"] == "critical"
+
+
+def test_corrupt_identity_database_is_critical_and_output_is_generic(tmp_path: Path) -> None:
+    identity = tmp_path / "secret-location" / "identity.sqlite3"
+    identity.parent.mkdir()
+    identity.write_bytes(b"not sqlite")
+    tenants = tmp_path / "tenants"
+    tenants.mkdir()
+
+    report = run_ops_check(
+        OpsCheckConfig(identity_database=identity, tenant_data_root=tenants),
+        now=NOW,
+    )
+    encoded = report_json(report)
+
+    assert report.status is CheckStatus.critical
+    assert _check(report, "identity_database")["status"] == "critical"
+    assert "secret-location" not in encoded


### PR DESCRIPTION
Adds a non-public, machine-readable operations check for production supervision without exposing tenant or customer details.

What changes:
- add `veridra-ops-check` with stable JSON output and exit codes 0=ok, 1=warning, 2=critical;
- validate identity SQLite integrity plus required identity schema and tenant-root availability;
- inspect durable monitoring-job state for recent terminal failures, overdue queued jobs, expired leases and malformed timestamps;
- aggregate recent identity-email failures and malformed delivery evidence without emitting recipients/provider errors;
- optionally validate backup freshness using a real Veridra snapshot manifest timestamp rather than arbitrary ZIP mtime;
- keep output aggregate-only: no tenant/project IDs, emails, provider error strings, secrets or filesystem paths;
- add tests for healthy state, schema gaps, monitoring failure/queue/lease cases, identity-email failures, backup freshness and random ZIP rejection;
- document how to use the check separately from `/health/live` and `/health/ready` in cron/systemd/cloud monitoring.

This is an operator CLI, not a public monitoring endpoint or a vendor-specific alert integration.

Do not merge until exact-head full CI succeeds.