### PR TITLE
Support safe Stripe webhook secret rotation

### DIFF
--- a/docs/operations/stripe-billing.md
+++ b/docs/operations/stripe-billing.md
@@ -15,12 +15,18 @@ Billing is disabled unless all of these are configured:
 
 Do not commit live or test secrets. Configure the webhook endpoint in Stripe as `/api/billing/stripe/webhook` on the trusted HTTPS origin.
 
+An optional rotation-overlap setting is supported:
+
+- `VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS`
+
+It is valid only while Stripe billing is otherwise configured, must contain a distinct `whsec_...` value, and should be removed after the old Stripe signing secret has expired.
+
 ## Trust boundary
 
 1. Checkout and Billing Portal requests require an authenticated tenant identity with `manage_tenant` capability.
 2. Veridra creates hosted Stripe sessions server-side with the secret key. Price IDs come only from server configuration; the browser never supplies arbitrary Stripe prices.
 3. Checkout stores the Veridra tenant identifier and requested plan in Stripe subscription metadata.
-4. Webhooks are verified against the raw request body, `Stripe-Signature`, and the configured webhook secret before JSON is trusted.
+4. Webhooks are verified against the raw request body and `Stripe-Signature` before JSON is trusted. During an explicit signing-secret rotation overlap, either the current or configured previous endpoint signing secret may verify the delivery.
 5. For subscription create/update events, Veridra retrieves the current subscription from Stripe after verification instead of trusting webhook delivery order.
 6. The Stripe Price ID is mapped back to a Veridra plan using server configuration. Unmapped prices cannot grant entitlements.
 7. The resulting provider-neutral `SubscriptionUpdate` is applied through `SubscriptionAuthority`, retaining its replay, stale-state, evidence and rollback protections.
@@ -34,13 +40,35 @@ The tenant workspace stores only operational Stripe identifiers needed for recon
 
 Veridra's quota ledger supports cycle anchor days 1–28 so every month has the anchor. Stripe billing-cycle days 29–31 are therefore normalized to day 28 for Veridra quota periods; Stripe remains authoritative for actual invoice dates.
 
+## Webhook signing-secret rotation
+
+Stripe can keep the old endpoint signing secret active temporarily while a new secret is introduced. Use that overlap rather than creating a verification outage.
+
+A controlled rotation is:
+
+1. In Stripe, start a webhook endpoint signing-secret roll with delayed expiry for the old secret.
+2. Put the newly generated secret into `VERIDRA_STRIPE_WEBHOOK_SECRET`.
+3. Put the still-active old secret into `VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS`.
+4. Deploy/restart Veridra and verify that webhook deliveries continue to return successful responses.
+5. Exercise a controlled Stripe test-mode event and confirm normal entitlement reconciliation.
+6. After Stripe expires the old secret, remove `VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS` and deploy/restart again.
+
+Do not leave the previous secret configured indefinitely. If a signing secret is believed compromised, do not use a long overlap merely to avoid a restart; rotate according to the incident response and Stripe-side expiration policy.
+
+`VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS` is only for endpoint signing-secret rotation. It is not a second Stripe API key and is never used to authenticate Checkout, Portal or subscription retrieval calls.
+
+## API-key rotation
+
+`VERIDRA_STRIPE_SECRET_KEY` remains a single current server-side Stripe API credential. Rotate it through the external secret store and a controlled deployment/restart, then expire the old key in Stripe after the new deployment has been validated. Do not store old API keys in tenant state or add them as webhook fallback secrets.
+
 ## Operational checks before live billing
 
 - Use Stripe test mode first.
 - Confirm each configured Price is recurring and represents the intended Veridra plan.
 - Exercise checkout, `customer.subscription.created`, plan change, payment-failure/suspension behavior, Billing Portal, cancellation, duplicate events and delayed/out-of-order events.
 - Confirm reverse-proxy/application logs do not record secret keys, webhook secrets or full request bodies.
-- Keep Stripe Dashboard access and webhook-secret rotation procedures under normal production secret-management controls.
+- Practice webhook signing-secret rotation before production launch.
+- Keep Stripe Dashboard access and secret rotation procedures under normal production secret-management controls.
 
 ## Scope of this adapter
 

--- a/src/veridra/runtime_billing.py
+++ b/src/veridra/runtime_billing.py
@@ -11,6 +11,7 @@ from .stripe_billing import (
     StripeBillingError,
     StripeSubscriptionAdapter,
 )
+from .stripe_webhook_verification import configured_webhook_secrets
 
 
 @dataclass(frozen=True)
@@ -18,11 +19,15 @@ class StripeBillingRuntime:
     config: StripeBillingConfig
     client: StripeApiClient
     adapter: StripeSubscriptionAdapter
+    webhook_secrets: tuple[str, ...]
 
 
 def configure_runtime_billing(app: FastAPI, runtime: RuntimeConfig) -> None:
     try:
         config = StripeBillingConfig.from_environment()
+        webhook_secrets = configured_webhook_secrets(
+            config.webhook_secret if config is not None else None
+        )
     except StripeBillingError as exc:
         raise RuntimeConfigurationError("Stripe billing configuration is invalid.") from exc
     if config is None:
@@ -45,4 +50,5 @@ def configure_runtime_billing(app: FastAPI, runtime: RuntimeConfig) -> None:
             tenant_root=runtime.tenant_data_root,
             client=client,
         ),
+        webhook_secrets=webhook_secrets,
     )

--- a/src/veridra/runtime_billing.py
+++ b/src/veridra/runtime_billing.py
@@ -19,7 +19,11 @@ class StripeBillingRuntime:
     config: StripeBillingConfig
     client: StripeApiClient
     adapter: StripeSubscriptionAdapter
-    webhook_secrets: tuple[str, ...]
+    webhook_secrets: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.webhook_secrets:
+            object.__setattr__(self, "webhook_secrets", (self.config.webhook_secret,))
 
 
 def configure_runtime_billing(app: FastAPI, runtime: RuntimeConfig) -> None:

--- a/src/veridra/stripe_billing_web.py
+++ b/src/veridra/stripe_billing_web.py
@@ -18,7 +18,8 @@ from .identity_tenancy import (
 from .request_security import require_request_identity
 from .runtime_billing import StripeBillingRuntime
 from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
-from .stripe_billing import StripeBillingError, verify_stripe_signature
+from .stripe_billing import StripeBillingError
+from .stripe_webhook_verification import verify_stripe_signature_with_secrets
 from .workspace_policy import PlanName, WorkspaceStore
 
 router = APIRouter(tags=["billing"])
@@ -167,7 +168,11 @@ async def stripe_webhook(request: Request) -> JSONResponse:
     raw_body = await request.body()
     signature = request.headers.get("stripe-signature", "")
     try:
-        verify_stripe_signature(raw_body, signature, runtime.config.webhook_secret)
+        verify_stripe_signature_with_secrets(
+            raw_body,
+            signature,
+            runtime.webhook_secrets,
+        )
         event = runtime.adapter.parse_event(raw_body)
     except StripeBillingError as exc:
         raise HTTPException(status_code=400, detail="Stripe webhook is invalid.") from exc

--- a/src/veridra/stripe_webhook_verification.py
+++ b/src/veridra/stripe_webhook_verification.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+
+from .stripe_billing import StripeBillingError, verify_stripe_signature
+
+_PREVIOUS_SECRET_ENV = "VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS"
+
+
+def configured_webhook_secrets(
+    primary_secret: str | None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> tuple[str, ...]:
+    values = os.environ if env is None else env
+    previous = values.get(_PREVIOUS_SECRET_ENV, "").strip()
+    if primary_secret is None:
+        if previous:
+            raise StripeBillingError(
+                f"{_PREVIOUS_SECRET_ENV} cannot be configured when Stripe billing is disabled."
+            )
+        return ()
+    if not primary_secret.startswith("whsec_"):
+        raise StripeBillingError("Primary Stripe webhook secret is invalid.")
+    if not previous:
+        return (primary_secret,)
+    if not previous.startswith("whsec_"):
+        raise StripeBillingError(f"{_PREVIOUS_SECRET_ENV} is not a webhook secret.")
+    if previous == primary_secret:
+        raise StripeBillingError(
+            f"{_PREVIOUS_SECRET_ENV} must differ from VERIDRA_STRIPE_WEBHOOK_SECRET."
+        )
+    return (primary_secret, previous)
+
+
+def verify_stripe_signature_with_secrets(
+    raw_body: bytes,
+    signature_header: str,
+    secrets: Sequence[str],
+    *,
+    now: datetime | None = None,
+    tolerance_seconds: int = 300,
+) -> None:
+    if not secrets:
+        raise StripeBillingError("Stripe webhook verification has no configured secret.")
+    for secret in secrets:
+        try:
+            verify_stripe_signature(
+                raw_body,
+                signature_header,
+                secret,
+                now=now,
+                tolerance_seconds=tolerance_seconds,
+            )
+        except StripeBillingError:
+            continue
+        return
+    raise StripeBillingError("Stripe webhook signature is invalid.")

--- a/tests/test_runtime_billing.py
+++ b/tests/test_runtime_billing.py
@@ -27,6 +27,7 @@ def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
     for name in (
         "VERIDRA_STRIPE_SECRET_KEY",
         "VERIDRA_STRIPE_WEBHOOK_SECRET",
+        "VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS",
         "VERIDRA_STRIPE_PRICE_SOLO",
         "VERIDRA_STRIPE_PRICE_PROFESSIONAL",
         "VERIDRA_STRIPE_PRICE_AGENCY",
@@ -37,7 +38,7 @@ def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _configure_stripe(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VERIDRA_STRIPE_SECRET_KEY", "sk_test_secret")
-    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET", "whsec_test")
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET", "whsec_current")
     monkeypatch.setenv("VERIDRA_STRIPE_PRICE_SOLO", "price_solo")
     monkeypatch.setenv("VERIDRA_STRIPE_PRICE_PROFESSIONAL", "price_professional")
     monkeypatch.setenv("VERIDRA_STRIPE_PRICE_AGENCY", "price_agency")
@@ -66,6 +67,41 @@ def test_partial_stripe_runtime_configuration_fails_closed(
         configure_runtime_billing(FastAPI(), _runtime(tmp_path))
 
 
+def test_previous_webhook_secret_without_stripe_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear(monkeypatch)
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS", "whsec_previous")
+
+    with pytest.raises(RuntimeConfigurationError, match="Stripe billing configuration"):
+        configure_runtime_billing(FastAPI(), _runtime(tmp_path))
+
+
+def test_invalid_previous_webhook_secret_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear(monkeypatch)
+    _configure_stripe(monkeypatch)
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS", "invalid")
+
+    with pytest.raises(RuntimeConfigurationError, match="Stripe billing configuration"):
+        configure_runtime_billing(FastAPI(), _runtime(tmp_path))
+
+
+def test_duplicate_previous_webhook_secret_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear(monkeypatch)
+    _configure_stripe(monkeypatch)
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS", "whsec_current")
+
+    with pytest.raises(RuntimeConfigurationError, match="Stripe billing configuration"):
+        configure_runtime_billing(FastAPI(), _runtime(tmp_path))
+
+
 def test_complete_stripe_configuration_installs_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -80,3 +116,20 @@ def test_complete_stripe_configuration_installs_runtime(
     assert isinstance(billing, StripeBillingRuntime)
     assert billing.config.price_professional == "price_professional"
     assert billing.adapter.tenant_root == tmp_path / "tenants"
+    assert billing.webhook_secrets == ("whsec_current",)
+
+
+def test_runtime_installs_current_and_previous_webhook_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear(monkeypatch)
+    _configure_stripe(monkeypatch)
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS", "whsec_previous")
+    app = FastAPI()
+
+    configure_runtime_billing(app, _runtime(tmp_path))
+
+    billing = app.state.veridra_stripe_billing
+    assert isinstance(billing, StripeBillingRuntime)
+    assert billing.webhook_secrets == ("whsec_current", "whsec_previous")

--- a/tests/test_stripe_webhook_verification.py
+++ b/tests/test_stripe_webhook_verification.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+from datetime import UTC, datetime
+
+import pytest
+
+from veridra.stripe_billing import StripeBillingError
+from veridra.stripe_webhook_verification import (
+    configured_webhook_secrets,
+    verify_stripe_signature_with_secrets,
+)
+
+NOW = datetime(2026, 8, 20, 16, 45, tzinfo=UTC)
+
+
+def _header(body: bytes, secret: str) -> str:
+    timestamp = int(NOW.timestamp())
+    digest = hmac.new(
+        secret.encode("utf-8"),
+        str(timestamp).encode("ascii") + b"." + body,
+        hashlib.sha256,
+    ).hexdigest()
+    return f"t={timestamp},v1={digest}"
+
+
+def test_single_primary_secret_is_configured() -> None:
+    assert configured_webhook_secrets("whsec_current", env={}) == ("whsec_current",)
+
+
+def test_previous_secret_is_optional_rotation_overlap() -> None:
+    assert configured_webhook_secrets(
+        "whsec_current",
+        env={"VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS": "whsec_previous"},
+    ) == ("whsec_current", "whsec_previous")
+
+
+def test_previous_secret_cannot_enable_stripe_by_itself() -> None:
+    with pytest.raises(StripeBillingError, match="cannot be configured"):
+        configured_webhook_secrets(
+            None,
+            env={"VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS": "whsec_previous"},
+        )
+
+
+def test_previous_secret_must_be_valid_and_distinct() -> None:
+    with pytest.raises(StripeBillingError, match="not a webhook secret"):
+        configured_webhook_secrets(
+            "whsec_current",
+            env={"VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS": "bad"},
+        )
+    with pytest.raises(StripeBillingError, match="must differ"):
+        configured_webhook_secrets(
+            "whsec_current",
+            env={"VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS": "whsec_current"},
+        )
+
+
+def test_signature_verification_accepts_current_secret() -> None:
+    body = b'{"id":"evt_current"}'
+
+    verify_stripe_signature_with_secrets(
+        body,
+        _header(body, "whsec_current"),
+        ("whsec_current", "whsec_previous"),
+        now=NOW,
+    )
+
+
+def test_signature_verification_accepts_previous_secret_during_overlap() -> None:
+    body = b'{"id":"evt_previous"}'
+
+    verify_stripe_signature_with_secrets(
+        body,
+        _header(body, "whsec_previous"),
+        ("whsec_current", "whsec_previous"),
+        now=NOW,
+    )
+
+
+def test_signature_verification_rejects_unknown_secret() -> None:
+    body = b'{"id":"evt_unknown"}'
+
+    with pytest.raises(StripeBillingError, match="signature"):
+        verify_stripe_signature_with_secrets(
+            body,
+            _header(body, "whsec_unknown"),
+            ("whsec_current", "whsec_previous"),
+            now=NOW,
+        )
+
+
+def test_signature_verification_keeps_timestamp_tolerance() -> None:
+    body = b'{"id":"evt_stale"}'
+
+    with pytest.raises(StripeBillingError, match="signature"):
+        verify_stripe_signature_with_secrets(
+            body,
+            _header(body, "whsec_previous"),
+            ("whsec_current", "whsec_previous"),
+            now=datetime(2026, 8, 20, 17, 0, tzinfo=UTC),
+        )


### PR DESCRIPTION
Adds bounded overlap support for Stripe endpoint signing-secret rotation without changing billing authority or customer subscription state.

What changes:
- add optional `VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS` for temporary rotation overlap;
- fail startup when the previous secret is malformed, duplicates the current secret, or is configured while Stripe billing is disabled;
- keep the current webhook secret as the default verifier when no overlap is configured;
- verify each delivery against the current and optional previous secret while preserving the existing raw-body signature and timestamp checks;
- keep Checkout/Portal/subscription API calls on the single current Stripe API key;
- add focused tests for current/previous verification, unknown/stale signatures and runtime fail-closed configuration;
- document the Stripe rotation sequence and removal of the previous secret after the provider-side overlap expires.

Stripe currently supports delayed expiration of the old webhook signing secret during rotation, with both secrets active for an overlap period. This PR maps that provider behavior into Veridra without persisting either secret.

Do not merge until exact-head full CI succeeds.