### PR TITLE
Add privacy-minimized production access logging

### DIFF
--- a/docs/operations/access-logging.md
+++ b/docs/operations/access-logging.md
@@ -1,0 +1,64 @@
+# Production access logging
+
+Veridra owns its HTTP access-log contract instead of relying on Uvicorn's default request-target logger.
+
+## Log event
+
+Each HTTP request emits one compact JSON event through the `veridra.access` logger:
+
+```json
+{"duration_ms":18,"event":"http_request","method":"GET","request_id":"4a9f...","route":"/projects/{project_id}","status":200,"timestamp":"2026-08-21T08:00:00+00:00"}
+```
+
+The event intentionally contains only:
+
+- UTC timestamp;
+- generated 24-hex-character request ID;
+- HTTP method;
+- matched route template, not the concrete request path;
+- response status;
+- bounded non-negative duration in milliseconds.
+
+The same generated request ID is returned as `X-Request-ID` on normal application responses so customer-visible failures can be correlated with the protected server log without exposing session or tenant identity.
+
+## Privacy boundary
+
+The application access logger never records:
+
+- query strings;
+- concrete path parameters such as tenant/project IDs;
+- request or response bodies;
+- cookies;
+- `Authorization` or other request headers;
+- client-supplied request IDs;
+- client IP addresses;
+- authenticated user or tenant identity;
+- password-reset/invitation tokens;
+- Stripe webhook bodies or signatures.
+
+Unmatched URLs are recorded as `<unmatched>` rather than echoing attacker-controlled path text.
+
+This is important for `/reset-password` and `/accept-invitation`, where one-time tokens can appear in the browser query string before being posted back.
+
+## Uvicorn and reverse-proxy logging
+
+`veridra-api` disables Uvicorn's built-in access logger because the default request-target format may include a query string and would bypass the application redaction contract.
+
+A reverse proxy, load balancer, CDN or hosting platform can still create its own request logs before traffic reaches Veridra. Configure every upstream layer to omit or redact query strings for sensitive routes, especially:
+
+- `/reset-password`;
+- `/accept-invitation`;
+- any future route carrying one-time credentials in a query parameter.
+
+Do not treat Veridra's application logger as proof that upstream access logs are safe.
+
+## Operations
+
+Capture the `veridra.access` stream in the same protected log sink as the web process. Recommended operational uses are:
+
+- correlate a user-reported error with `X-Request-ID`;
+- aggregate response status by route template;
+- inspect latency by route template;
+- detect bursts of `404`, `429`, `5xx`, or readiness failures.
+
+Do not enrich access events downstream with raw request URLs, query strings, cookies or personal identifiers merely for convenience. Keep retention and log access bounded to operational need.

--- a/src/veridra/access_logging.py
+++ b/src/veridra/access_logging.py
@@ -5,13 +5,28 @@ import logging
 import secrets
 import time
 from collections.abc import Callable
-from typing import Any
+from datetime import UTC, datetime
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 _LOGGER = logging.getLogger("veridra.access")
 _REQUEST_ID_BYTES = 12
 _UNMATCHED_ROUTE = "<unmatched>"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def configure_access_logger() -> None:
+    """Configure one stdout/stderr-friendly JSON message handler for the access logger."""
+
+    if not _LOGGER.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        _LOGGER.addHandler(handler)
+    _LOGGER.setLevel(logging.INFO)
+    _LOGGER.propagate = False
 
 
 def _route_template(scope: Scope) -> str:
@@ -29,6 +44,7 @@ def _event(
     route: str,
     status_code: int,
     duration_ms: int,
+    timestamp: datetime,
 ) -> str:
     return json.dumps(
         {
@@ -38,6 +54,7 @@ def _event(
             "request_id": request_id,
             "route": route,
             "status": status_code,
+            "timestamp": timestamp.astimezone(UTC).isoformat(),
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -45,7 +62,7 @@ def _event(
 
 
 class StructuredAccessLogMiddleware:
-    """Emit privacy-minimized JSON access events for production HTTP requests."""
+    """Emit privacy-minimized JSON access events for HTTP requests."""
 
     def __init__(
         self,
@@ -53,10 +70,12 @@ class StructuredAccessLogMiddleware:
         *,
         logger: logging.Logger | None = None,
         clock: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], datetime] = _utc_now,
     ) -> None:
         self.app = app
         self.logger = logger or _LOGGER
         self.clock = clock
+        self.wall_clock = wall_clock
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -93,6 +112,7 @@ class StructuredAccessLogMiddleware:
                     route=_route_template(scope),
                     status_code=status_code,
                     duration_ms=duration_ms,
+                    timestamp=self.wall_clock(),
                 )
             )
 

--- a/src/veridra/access_logging.py
+++ b/src/veridra/access_logging.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import time
+from collections.abc import Callable
+from typing import Any
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_LOGGER = logging.getLogger("veridra.access")
+_REQUEST_ID_BYTES = 12
+_UNMATCHED_ROUTE = "<unmatched>"
+
+
+def _route_template(scope: Scope) -> str:
+    route = scope.get("route")
+    path = getattr(route, "path", None)
+    if isinstance(path, str) and path.startswith("/"):
+        return path
+    return _UNMATCHED_ROUTE
+
+
+def _event(
+    *,
+    request_id: str,
+    method: str,
+    route: str,
+    status_code: int,
+    duration_ms: int,
+) -> str:
+    return json.dumps(
+        {
+            "duration_ms": max(0, duration_ms),
+            "event": "http_request",
+            "method": method,
+            "request_id": request_id,
+            "route": route,
+            "status": status_code,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+class StructuredAccessLogMiddleware:
+    """Emit privacy-minimized JSON access events for production HTTP requests."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        logger: logging.Logger | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.app = app
+        self.logger = logger or _LOGGER
+        self.clock = clock
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = secrets.token_hex(_REQUEST_ID_BYTES)
+        started = self.clock()
+        status_code = 500
+
+        async def send_with_request_id(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = int(message["status"])
+                headers: list[tuple[bytes, bytes]] = [
+                    (name, value)
+                    for name, value in message.get("headers", [])
+                    if name.lower() != b"x-request-id"
+                ]
+                headers.append((b"x-request-id", request_id.encode("ascii")))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_request_id)
+        finally:
+            elapsed = self.clock() - started
+            duration_ms = int(max(0.0, elapsed) * 1000)
+            method = str(scope.get("method", "UNKNOWN"))[:16]
+            self._write(
+                _event(
+                    request_id=request_id,
+                    method=method,
+                    route=_route_template(scope),
+                    status_code=status_code,
+                    duration_ms=duration_ms,
+                )
+            )
+
+    def _write(self, payload: str) -> None:
+        try:
+            self.logger.info("%s", payload)
+        except Exception:  # pragma: no cover - logging must never break request handling
+            return

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -5,6 +5,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 
 from . import app as app_module
 from . import public_web
+from .access_logging import StructuredAccessLogMiddleware, configure_access_logger
 from .agency_conversion_web import router as agency_conversion_router
 from .agency_crawl_profile_web import router as agency_crawl_profile_router
 from .agency_lead_form_web import router as agency_lead_form_router
@@ -80,6 +81,8 @@ app.add_middleware(
     SecurityHeadersMiddleware,
     environment=runtime_config.environment,
 )
+configure_access_logger()
+app.add_middleware(StructuredAccessLogMiddleware)
 
 if "Accessibility" not in app_module._AREAS:
     vars(app_module)["_AREAS"] = (*app_module._AREAS, "Accessibility")
@@ -157,6 +160,7 @@ def main() -> None:
         host=runtime_config.bind_host,
         port=runtime_config.bind_port,
         proxy_headers=False,
+        access_log=False,
     )
 
 

--- a/tests/test_access_logging.py
+++ b/tests/test_access_logging.py
@@ -4,6 +4,7 @@ import io
 import json
 import logging
 from datetime import UTC, datetime
+from typing import cast
 
 import pytest
 from fastapi import FastAPI, Request
@@ -128,7 +129,7 @@ def test_runtime_uses_structured_logger_and_disables_uvicorn_access_log(
     runtime.main()
 
     assert any(
-        middleware.cls is StructuredAccessLogMiddleware
+        cast(object, middleware.cls) is cast(object, StructuredAccessLogMiddleware)
         for middleware in runtime.app.user_middleware
     )
     assert seen["access_log"] is False

--- a/tests/test_access_logging.py
+++ b/tests/test_access_logging.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import io
+import json
+import logging
+from datetime import UTC, datetime
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from veridra.access_logging import StructuredAccessLogMiddleware
+
+NOW = datetime(2026, 8, 21, 8, 0, tzinfo=UTC)
+
+
+def _logger() -> tuple[logging.Logger, io.StringIO]:
+    stream = io.StringIO()
+    logger = logging.Logger("veridra.access.test", level=logging.INFO)
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger, stream
+
+
+def _client() -> tuple[TestClient, io.StringIO]:
+    logger, stream = _logger()
+    ticks = iter((10.0, 10.125, 20.0, 20.010, 30.0, 30.020))
+    app = FastAPI()
+
+    @app.post("/projects/{project_id}")
+    async def project(project_id: str, request: Request) -> dict[str, str]:
+        await request.body()
+        return {"project_id": project_id}
+
+    @app.get("/accept-invitation")
+    def invitation() -> dict[str, bool]:
+        return {"ok": True}
+
+    app.add_middleware(
+        StructuredAccessLogMiddleware,
+        logger=logger,
+        clock=lambda: next(ticks),
+        wall_clock=lambda: NOW,
+    )
+    return TestClient(app), stream
+
+
+def _events(stream: io.StringIO) -> list[dict[str, object]]:
+    return [json.loads(line) for line in stream.getvalue().splitlines() if line.strip()]
+
+
+def test_access_log_uses_route_template_and_omits_sensitive_request_data() -> None:
+    client, stream = _client()
+
+    response = client.post(
+        "/projects/project-secret-123?token=query-secret-456",
+        headers={
+            "authorization": "Bearer header-secret-789",
+            "cookie": "session=cookie-secret-012",
+            "x-request-id": "attacker-controlled-request-id",
+        },
+        content=b"body-secret-345",
+    )
+
+    assert response.status_code == 200
+    event = _events(stream)[0]
+    encoded = stream.getvalue()
+    assert event["event"] == "http_request"
+    assert event["method"] == "POST"
+    assert event["route"] == "/projects/{project_id}"
+    assert event["status"] == 200
+    assert event["duration_ms"] == 125
+    assert event["timestamp"] == NOW.isoformat()
+    assert response.headers["x-request-id"] == event["request_id"]
+    assert len(str(event["request_id"])) == 24
+    for secret in (
+        "project-secret-123",
+        "query-secret-456",
+        "header-secret-789",
+        "cookie-secret-012",
+        "attacker-controlled-request-id",
+        "body-secret-345",
+    ):
+        assert secret not in encoded
+
+
+def test_invitation_query_token_is_never_logged() -> None:
+    client, stream = _client()
+
+    response = client.get("/accept-invitation?token=invitation-secret-token")
+
+    assert response.status_code == 200
+    event = _events(stream)[0]
+    assert event["route"] == "/accept-invitation"
+    assert "invitation-secret-token" not in stream.getvalue()
+    assert "?token=" not in stream.getvalue()
+
+
+def test_unmatched_path_does_not_echo_attacker_controlled_path() -> None:
+    client, stream = _client()
+
+    response = client.get("/unknown/path-secret-value?token=query-secret-value")
+
+    assert response.status_code == 404
+    event = _events(stream)[0]
+    assert event["route"] == "<unmatched>"
+    assert event["status"] == 404
+    assert "path-secret-value" not in stream.getvalue()
+    assert "query-secret-value" not in stream.getvalue()

--- a/tests/test_access_logging.py
+++ b/tests/test_access_logging.py
@@ -5,6 +5,7 @@ import json
 import logging
 from datetime import UTC, datetime
 
+import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
@@ -108,3 +109,27 @@ def test_unmatched_path_does_not_echo_attacker_controlled_path() -> None:
     assert event["status"] == 404
     assert "path-secret-value" not in stream.getvalue()
     assert "query-secret-value" not in stream.getvalue()
+
+
+def test_runtime_uses_structured_logger_and_disables_uvicorn_access_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import uvicorn
+
+    import veridra.runtime as runtime
+
+    seen: dict[str, object] = {}
+
+    def fake_run(app: object, **kwargs: object) -> None:
+        seen.update(kwargs)
+
+    monkeypatch.setattr(uvicorn, "run", fake_run)
+
+    runtime.main()
+
+    assert any(
+        middleware.cls is StructuredAccessLogMiddleware
+        for middleware in runtime.app.user_middleware
+    )
+    assert seen["access_log"] is False
+    assert seen["proxy_headers"] is False


### PR DESCRIPTION
Adds an application-owned HTTP access-log contract that is safe for Veridra's token-bearing browser flows.

What changes:
- add `StructuredAccessLogMiddleware` emitting compact JSON access events;
- generate a server-side request ID and return it as `X-Request-ID` on normal responses;
- log only UTC timestamp, request ID, method, matched route template, status and duration;
- never log query strings, concrete path parameters, request/response bodies, cookies, authorization headers, client IPs, authenticated user/tenant IDs or client-supplied request IDs;
- record unmatched attacker-controlled URLs as `<unmatched>` instead of echoing the raw path;
- disable Uvicorn's built-in access log so it cannot separately record raw request targets/query strings;
- add regression coverage proving project IDs, invitation tokens, query tokens, headers, cookies and request bodies never reach the structured access event;
- document the reverse-proxy caveat: upstream/CDN logs must independently omit/redact sensitive query strings.

This does not replace the operator health/ops checks or prescribe a log vendor. It establishes the safe application log boundary those systems can ingest.

Do not merge until exact-head full CI succeeds.