### PR TITLE
Add verified tenant offboarding workflow

### DIFF
--- a/docs/operations/tenant-offboarding.md
+++ b/docs/operations/tenant-offboarding.md
@@ -1,0 +1,93 @@
+# Tenant offboarding
+
+`veridra-tenant-offboard` is the operator boundary for permanently removing one Veridra tenant context. It is intentionally not exposed as a browser self-service delete button.
+
+## Scope
+
+The command removes tenant-owned state from:
+
+- active/revoked sessions scoped to the selected tenant;
+- tenant invitations;
+- tenant memberships;
+- the tenant identity row;
+- global monitoring-job rows for that tenant;
+- the complete durable tenant directory under `VERIDRA_TENANT_DATA_ROOT/<tenant_id>`.
+
+It does **not** delete user accounts, password credentials, password-reset history or other user-level state. A Veridra user can belong to more than one tenant, so user/account erasure is a separate lifecycle operation.
+
+## Mandatory recovery backup
+
+Every offboarding operation requires a new `--backup-output`. Before any tenant state is mutated, Veridra creates a complete verified quiesced backup using the same backup contract as `veridra-backup`.
+
+The backup contains the pre-offboarding identity database and complete tenant root. Keep it according to the organization's approved recovery/retention policy. Do not place it under the durable identity or tenant source directories.
+
+If the backup cannot be created and validated, offboarding stops without mutation.
+
+## Quiescence
+
+The command requires `--confirm-quiesced`.
+
+Before running it, stop or quiesce:
+
+- `veridra-api` web writers;
+- the monitoring worker/scheduler;
+- billing reconciliation/webhook writers;
+- any operator process that can modify the same identity or tenant stores.
+
+The application cannot prove externally that every process is stopped. The flag is an operator assertion.
+
+## Stripe/provider boundary
+
+If the tenant has `workspace/billing/stripe.json`, offboarding refuses to proceed unless `--confirm-provider-billing-handled` is supplied.
+
+That flag means the operator has already handled the external Stripe subscription/customer relationship as required, for example cancellation or transfer. The offboarding command does not call Stripe and does not claim that deleting local state cancels billing.
+
+Do not use the confirmation flag merely to bypass the guard.
+
+## Execution
+
+Example:
+
+```text
+veridra-tenant-offboard \
+  --tenant-id <24-hex-tenant-id> \
+  --backup-output /secure/recovery/veridra-before-offboarding.zip \
+  --confirm-quiesced
+```
+
+When a Stripe binding exists, add `--confirm-provider-billing-handled` only after provider-side handling is complete.
+
+The identity and tenant paths default to `VERIDRA_IDENTITY_DB` and `VERIDRA_TENANT_DATA_ROOT`; they can also be supplied with `--identity-db` and `--tenant-data-root`.
+
+## Cross-store safety
+
+Veridra's tenant state spans an identity SQLite database, a global monitoring-job SQLite database and tenant filesystem state. Those stores do not share one transaction.
+
+The command therefore:
+
+1. validates the tenant and provider guard;
+2. creates and verifies the full recovery backup;
+3. stages the tenant directory under an inaccessible quarantine name;
+4. captures and removes the tenant's monitoring rows;
+5. deletes invitations, sessions, memberships and the tenant identity in one identity transaction;
+6. removes the quarantined tenant directory only after database mutation succeeds.
+
+If identity deletion fails after monitoring cleanup, Veridra attempts to restore the captured monitoring rows and staged tenant directory. If compensation is incomplete, the error explicitly directs the operator to recover from the verified backup.
+
+If database removal succeeds but final filesystem erasure fails, the tenant is already unavailable to the application but a quarantined directory may remain. Treat that as a cleanup/privacy incident: keep writers stopped, locate and erase the `.offboarding-<tenant-id>-...` directory, then perform the post-checks below.
+
+## Post-offboarding checks
+
+Before resuming normal service:
+
+- confirm the tenant ID no longer exists in `tenants`, `memberships`, `sessions` or `tenant_invitations`;
+- confirm no `monitoring_jobs` rows remain for the tenant;
+- confirm `VERIDRA_TENANT_DATA_ROOT/<tenant_id>` is absent;
+- confirm any shared user can still access their other tenant memberships;
+- run `veridra-ops-check`;
+- start the web/worker processes and confirm `/health/ready` is healthy;
+- retain the pre-offboarding backup only for the approved recovery/retention window.
+
+## Not a complete data-subject erasure workflow
+
+Tenant offboarding removes the workspace/customer context. It is not a claim that every item associated with every human user has been erased. Identity email delivery evidence and other operational/security records may also have independent retention requirements. User-level export/erasure should be implemented and governed separately so shared accounts and legitimate security/audit retention are handled correctly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ veridra-monitoring-worker = "veridra.monitoring_worker_cli:main"
 veridra-subscription-apply = "veridra.subscription_authority_cli:main"
 veridra-backup = "veridra.backup_restore_cli:main"
 veridra-ops-check = "veridra.ops_check_cli:main"
+veridra-tenant-offboard = "veridra.tenant_offboarding_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/tenant_offboarding.py
+++ b/src/veridra/tenant_offboarding.py
@@ -27,7 +27,9 @@ class TenantOffboardingResult:
 def _tenant_id(value: str) -> str:
     normalized = value.strip().lower()
     if len(normalized) != 24 or any(char not in "0123456789abcdef" for char in normalized):
-        raise TenantOffboardingError("Tenant identifier must be 24 lowercase hexadecimal characters.")
+        raise TenantOffboardingError(
+            "Tenant identifier must be 24 lowercase hexadecimal characters."
+        )
     return normalized
 
 
@@ -63,7 +65,10 @@ def _require_tenant(database: Path, tenant_id: str) -> None:
         raise TenantOffboardingError("Tenant was not found.")
 
 
-def _monitoring_rows(database: Path, tenant_id: str) -> tuple[list[str], list[tuple[object, ...]]]:
+def _monitoring_rows(
+    database: Path,
+    tenant_id: str,
+) -> tuple[list[str], list[tuple[object, ...]]]:
     if not database.exists():
         return [], []
     if not database.is_file() or database.is_symlink():
@@ -78,7 +83,7 @@ def _monitoring_rows(database: Path, tenant_id: str) -> tuple[list[str], list[tu
                 return [], []
             quoted = ",".join(f'"{column}"' for column in columns)
             rows = connection.execute(
-                f"SELECT {quoted} FROM monitoring_jobs WHERE tenant_id = ?",  # noqa: S608
+                f"SELECT {quoted} FROM monitoring_jobs WHERE tenant_id = ?",
                 (tenant_id,),
             ).fetchall()
     except sqlite3.Error as exc:
@@ -91,6 +96,8 @@ def _delete_monitoring(database: Path, tenant_id: str) -> int:
         return 0
     try:
         with sqlite3.connect(database) as connection:
+            if not _table_exists(connection, "monitoring_jobs"):
+                return 0
             cursor = connection.execute(
                 "DELETE FROM monitoring_jobs WHERE tenant_id = ?",
                 (tenant_id,),
@@ -112,7 +119,7 @@ def _restore_monitoring(
     try:
         with sqlite3.connect(database) as connection:
             connection.executemany(
-                f"INSERT INTO monitoring_jobs ({quoted}) VALUES ({placeholders})",  # noqa: S608
+                f"INSERT INTO monitoring_jobs ({quoted}) VALUES ({placeholders})",
                 rows,
             )
     except sqlite3.Error as exc:
@@ -165,7 +172,8 @@ def offboard_tenant(
 ) -> TenantOffboardingResult:
     if not confirm_quiesced:
         raise TenantOffboardingError(
-            "Tenant offboarding requires explicit confirmation that web, worker and billing writers are quiesced."
+            "Tenant offboarding requires explicit confirmation that web, worker and "
+            "billing writers are quiesced."
         )
     identity_database = identity_database.expanduser().resolve()
     tenant_data_root = tenant_data_root.expanduser().resolve()
@@ -182,7 +190,8 @@ def offboard_tenant(
         raise TenantOffboardingError("Tenant billing binding could not be validated.") from exc
     if binding is not None and not confirm_provider_billing_handled:
         raise TenantOffboardingError(
-            "Tenant has a Stripe subscription binding; confirm provider-side cancellation or transfer before offboarding."
+            "Tenant has a Stripe subscription binding; confirm provider-side cancellation "
+            "or transfer before offboarding."
         )
 
     try:
@@ -193,7 +202,9 @@ def offboard_tenant(
             confirm_quiesced=True,
         )
     except BackupRestoreError as exc:
-        raise TenantOffboardingError("Verified pre-offboarding backup could not be created.") from exc
+        raise TenantOffboardingError(
+            "Verified pre-offboarding backup could not be created."
+        ) from exc
 
     monitoring_database = tenant_data_root / "monitoring-jobs.sqlite3"
     columns, monitoring_rows = _monitoring_rows(monitoring_database, resolved_tenant)
@@ -201,7 +212,9 @@ def offboard_tenant(
     try:
         tenant_directory.replace(quarantine)
     except OSError as exc:
-        raise TenantOffboardingError("Tenant durable state could not be staged for deletion.") from exc
+        raise TenantOffboardingError(
+            "Tenant durable state could not be staged for deletion."
+        ) from exc
 
     monitoring_deleted = False
     try:
@@ -225,17 +238,21 @@ def offboard_tenant(
             rollback_errors.append(rollback_exc)
         if rollback_errors:
             raise TenantOffboardingError(
-                "Tenant offboarding failed and rollback was incomplete; recover from the verified backup."
+                "Tenant offboarding failed and rollback was incomplete; recover from the "
+                "verified backup."
             ) from exc
         if isinstance(exc, TenantOffboardingError):
             raise
-        raise TenantOffboardingError("Tenant offboarding failed; staged state was restored.") from exc
+        raise TenantOffboardingError(
+            "Tenant offboarding failed; staged state was restored."
+        ) from exc
 
     try:
         shutil.rmtree(quarantine)
     except OSError as exc:
         raise TenantOffboardingError(
-            "Tenant identity was removed but quarantined durable state could not be erased; remove the quarantine directory manually."
+            "Tenant identity was removed but quarantined durable state could not be erased; "
+            "remove the quarantine directory manually."
         ) from exc
 
     return TenantOffboardingResult(

--- a/src/veridra/tenant_offboarding.py
+++ b/src/veridra/tenant_offboarding.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import secrets
+import shutil
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from .backup_restore import BackupRestoreError, create_backup
+from .stripe_billing import StripeBillingError, StripeTenantBindingStore
+
+
+class TenantOffboardingError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class TenantOffboardingResult:
+    tenant_id: str
+    backup_archive: Path
+    deleted_sessions: int
+    deleted_invitations: int
+    deleted_memberships: int
+    deleted_monitoring_jobs: int
+
+
+def _tenant_id(value: str) -> str:
+    normalized = value.strip().lower()
+    if len(normalized) != 24 or any(char not in "0123456789abcdef" for char in normalized):
+        raise TenantOffboardingError("Tenant identifier must be 24 lowercase hexadecimal characters.")
+    return normalized
+
+
+def _identity_connect(database: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(database)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def _table_exists(connection: sqlite3.Connection, table: str) -> bool:
+    return (
+        connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _require_tenant(database: Path, tenant_id: str) -> None:
+    if not database.is_file() or database.is_symlink():
+        raise TenantOffboardingError("Identity database is unavailable.")
+    try:
+        with _identity_connect(database) as connection:
+            row = connection.execute(
+                "SELECT 1 FROM tenants WHERE id = ?",
+                (tenant_id,),
+            ).fetchone()
+    except sqlite3.Error as exc:
+        raise TenantOffboardingError("Tenant identity could not be validated.") from exc
+    if row is None:
+        raise TenantOffboardingError("Tenant was not found.")
+
+
+def _monitoring_rows(database: Path, tenant_id: str) -> tuple[list[str], list[tuple[object, ...]]]:
+    if not database.exists():
+        return [], []
+    if not database.is_file() or database.is_symlink():
+        raise TenantOffboardingError("Monitoring job store is unavailable.")
+    try:
+        with sqlite3.connect(database) as connection:
+            columns = [
+                str(row[1])
+                for row in connection.execute("PRAGMA table_info(monitoring_jobs)").fetchall()
+            ]
+            if not columns:
+                return [], []
+            quoted = ",".join(f'"{column}"' for column in columns)
+            rows = connection.execute(
+                f"SELECT {quoted} FROM monitoring_jobs WHERE tenant_id = ?",  # noqa: S608
+                (tenant_id,),
+            ).fetchall()
+    except sqlite3.Error as exc:
+        raise TenantOffboardingError("Monitoring jobs could not be inspected.") from exc
+    return columns, [tuple(row) for row in rows]
+
+
+def _delete_monitoring(database: Path, tenant_id: str) -> int:
+    if not database.exists():
+        return 0
+    try:
+        with sqlite3.connect(database) as connection:
+            cursor = connection.execute(
+                "DELETE FROM monitoring_jobs WHERE tenant_id = ?",
+                (tenant_id,),
+            )
+            return cursor.rowcount
+    except sqlite3.Error as exc:
+        raise TenantOffboardingError("Monitoring jobs could not be removed.") from exc
+
+
+def _restore_monitoring(
+    database: Path,
+    columns: list[str],
+    rows: list[tuple[object, ...]],
+) -> None:
+    if not rows:
+        return
+    quoted = ",".join(f'"{column}"' for column in columns)
+    placeholders = ",".join("?" for _ in columns)
+    try:
+        with sqlite3.connect(database) as connection:
+            connection.executemany(
+                f"INSERT INTO monitoring_jobs ({quoted}) VALUES ({placeholders})",  # noqa: S608
+                rows,
+            )
+    except sqlite3.Error as exc:
+        raise TenantOffboardingError(
+            "Monitoring rollback failed; recover from the verified pre-offboarding backup."
+        ) from exc
+
+
+def _delete_identity(database: Path, tenant_id: str) -> tuple[int, int, int]:
+    connection = _identity_connect(database)
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        invitations = 0
+        if _table_exists(connection, "tenant_invitations"):
+            invitations = connection.execute(
+                "DELETE FROM tenant_invitations WHERE tenant_id = ?",
+                (tenant_id,),
+            ).rowcount
+        sessions = connection.execute(
+            "DELETE FROM sessions WHERE tenant_id = ?",
+            (tenant_id,),
+        ).rowcount
+        memberships = connection.execute(
+            "DELETE FROM memberships WHERE tenant_id = ?",
+            (tenant_id,),
+        ).rowcount
+        tenant = connection.execute(
+            "DELETE FROM tenants WHERE id = ?",
+            (tenant_id,),
+        )
+        if tenant.rowcount != 1:
+            raise TenantOffboardingError("Tenant identity changed concurrently.")
+        connection.commit()
+        return sessions, invitations, memberships
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def offboard_tenant(
+    *,
+    identity_database: Path,
+    tenant_data_root: Path,
+    tenant_id: str,
+    backup_output: Path,
+    confirm_quiesced: bool,
+    confirm_provider_billing_handled: bool = False,
+) -> TenantOffboardingResult:
+    if not confirm_quiesced:
+        raise TenantOffboardingError(
+            "Tenant offboarding requires explicit confirmation that web, worker and billing writers are quiesced."
+        )
+    identity_database = identity_database.expanduser().resolve()
+    tenant_data_root = tenant_data_root.expanduser().resolve()
+    backup_output = backup_output.expanduser().resolve()
+    resolved_tenant = _tenant_id(tenant_id)
+    _require_tenant(identity_database, resolved_tenant)
+
+    tenant_directory = tenant_data_root / resolved_tenant
+    if not tenant_directory.is_dir() or tenant_directory.is_symlink():
+        raise TenantOffboardingError("Tenant durable directory is unavailable.")
+    try:
+        binding = StripeTenantBindingStore(tenant_data_root).load(resolved_tenant)
+    except StripeBillingError as exc:
+        raise TenantOffboardingError("Tenant billing binding could not be validated.") from exc
+    if binding is not None and not confirm_provider_billing_handled:
+        raise TenantOffboardingError(
+            "Tenant has a Stripe subscription binding; confirm provider-side cancellation or transfer before offboarding."
+        )
+
+    try:
+        backup = create_backup(
+            identity_database=identity_database,
+            tenant_data_root=tenant_data_root,
+            output=backup_output,
+            confirm_quiesced=True,
+        )
+    except BackupRestoreError as exc:
+        raise TenantOffboardingError("Verified pre-offboarding backup could not be created.") from exc
+
+    monitoring_database = tenant_data_root / "monitoring-jobs.sqlite3"
+    columns, monitoring_rows = _monitoring_rows(monitoring_database, resolved_tenant)
+    quarantine = tenant_data_root / f".offboarding-{resolved_tenant}-{secrets.token_hex(6)}"
+    try:
+        tenant_directory.replace(quarantine)
+    except OSError as exc:
+        raise TenantOffboardingError("Tenant durable state could not be staged for deletion.") from exc
+
+    monitoring_deleted = False
+    try:
+        deleted_monitoring = _delete_monitoring(monitoring_database, resolved_tenant)
+        monitoring_deleted = True
+        deleted_sessions, deleted_invitations, deleted_memberships = _delete_identity(
+            identity_database,
+            resolved_tenant,
+        )
+    except Exception as exc:
+        rollback_errors: list[Exception] = []
+        if monitoring_deleted:
+            try:
+                _restore_monitoring(monitoring_database, columns, monitoring_rows)
+            except Exception as rollback_exc:
+                rollback_errors.append(rollback_exc)
+        try:
+            if quarantine.exists() and not tenant_directory.exists():
+                quarantine.replace(tenant_directory)
+        except OSError as rollback_exc:
+            rollback_errors.append(rollback_exc)
+        if rollback_errors:
+            raise TenantOffboardingError(
+                "Tenant offboarding failed and rollback was incomplete; recover from the verified backup."
+            ) from exc
+        if isinstance(exc, TenantOffboardingError):
+            raise
+        raise TenantOffboardingError("Tenant offboarding failed; staged state was restored.") from exc
+
+    try:
+        shutil.rmtree(quarantine)
+    except OSError as exc:
+        raise TenantOffboardingError(
+            "Tenant identity was removed but quarantined durable state could not be erased; remove the quarantine directory manually."
+        ) from exc
+
+    return TenantOffboardingResult(
+        tenant_id=resolved_tenant,
+        backup_archive=backup.archive,
+        deleted_sessions=deleted_sessions,
+        deleted_invitations=deleted_invitations,
+        deleted_memberships=deleted_memberships,
+        deleted_monitoring_jobs=deleted_monitoring,
+    )

--- a/src/veridra/tenant_offboarding_cli.py
+++ b/src/veridra/tenant_offboarding_cli.py
@@ -8,7 +8,8 @@ from .tenant_offboarding import TenantOffboardingError, offboard_tenant
 
 
 def _configured_path(explicit: Path | None, environment_name: str) -> Path:
-    value = explicit or (Path(os.environ[environment_name]) if os.environ.get(environment_name) else None)
+    environment_value = os.environ.get(environment_name)
+    value = explicit or (Path(environment_value) if environment_value else None)
     if value is None:
         raise TenantOffboardingError(
             f"Required path is missing; provide the CLI option or {environment_name}."
@@ -62,7 +63,8 @@ def main() -> None:
     print(
         f"tenant={result.tenant_id} backup={result.backup_archive} "
         f"sessions={result.deleted_sessions} invitations={result.deleted_invitations} "
-        f"memberships={result.deleted_memberships} monitoring_jobs={result.deleted_monitoring_jobs}"
+        f"memberships={result.deleted_memberships} "
+        f"monitoring_jobs={result.deleted_monitoring_jobs}"
     )
 
 

--- a/src/veridra/tenant_offboarding_cli.py
+++ b/src/veridra/tenant_offboarding_cli.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from .tenant_offboarding import TenantOffboardingError, offboard_tenant
+
+
+def _configured_path(explicit: Path | None, environment_name: str) -> Path:
+    value = explicit or (Path(os.environ[environment_name]) if os.environ.get(environment_name) else None)
+    if value is None:
+        raise TenantOffboardingError(
+            f"Required path is missing; provide the CLI option or {environment_name}."
+        )
+    return value.expanduser().resolve()
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Remove one Veridra tenant context after creating a verified recovery backup. "
+            "User accounts are preserved because they may belong to other tenants."
+        )
+    )
+    parser.add_argument("--tenant-id", required=True)
+    parser.add_argument("--backup-output", type=Path, required=True)
+    parser.add_argument("--identity-db", type=Path, default=None)
+    parser.add_argument("--tenant-data-root", type=Path, default=None)
+    parser.add_argument(
+        "--confirm-quiesced",
+        action="store_true",
+        help="Assert that web, monitoring-worker and billing writers are stopped/quiesced.",
+    )
+    parser.add_argument(
+        "--confirm-provider-billing-handled",
+        action="store_true",
+        help=(
+            "Assert that any provider-side Stripe subscription has already been cancelled, "
+            "transferred or otherwise handled. Required only when a Stripe binding exists."
+        ),
+    )
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    try:
+        result = offboard_tenant(
+            identity_database=_configured_path(args.identity_db, "VERIDRA_IDENTITY_DB"),
+            tenant_data_root=_configured_path(
+                args.tenant_data_root,
+                "VERIDRA_TENANT_DATA_ROOT",
+            ),
+            tenant_id=args.tenant_id,
+            backup_output=args.backup_output,
+            confirm_quiesced=args.confirm_quiesced,
+            confirm_provider_billing_handled=args.confirm_provider_billing_handled,
+        )
+    except TenantOffboardingError as exc:
+        raise SystemExit(str(exc)) from exc
+    print(
+        f"tenant={result.tenant_id} backup={result.backup_archive} "
+        f"sessions={result.deleted_sessions} invitations={result.deleted_invitations} "
+        f"memberships={result.deleted_memberships} monitoring_jobs={result.deleted_monitoring_jobs}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tenant_offboarding.py
+++ b/tests/test_tenant_offboarding.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import sqlite3
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+import veridra.tenant_offboarding as offboarding_module
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.monitoring_jobs import SQLiteMonitoringJobStore
+from veridra.stripe_billing import StripeTenantBinding, StripeTenantBindingStore
+from veridra.tenant_invitations import SQLiteTenantInvitationService
+from veridra.tenant_offboarding import TenantOffboardingError, offboard_tenant
+
+NOW = datetime(2026, 8, 21, 8, 30, tzinfo=UTC)
+SECOND_TENANT = "b" * 24
+PROJECT_ID = "c" * 24
+
+
+def _setup(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    identity = tmp_path / "identity" / "identity.sqlite3"
+    tenants = tmp_path / "tenants"
+    created = SQLiteIdentityBootstrap(identity, tenant_data_root=tenants).create_first_owner(
+        tenant_slug="target",
+        tenant_name="Target tenant",
+        owner_email="owner@example.com",
+        owner_name="Owner",
+        password="correct-horse-battery-owner",
+        confirmation=BOOTSTRAP_CONFIRMATION,
+        created_at=NOW,
+    )
+    with sqlite3.connect(identity) as connection:
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute(
+            """INSERT INTO tenants (id, slug, display_name, status, created_at)
+            VALUES (?, 'other', 'Other tenant', 'active', ?)""",
+            (SECOND_TENANT, NOW.isoformat()),
+        )
+        connection.execute(
+            """INSERT INTO memberships (tenant_id, user_id, role, active, created_at)
+            VALUES (?, ?, 'owner', 1, ?)""",
+            (SECOND_TENANT, created.user_id, NOW.isoformat()),
+        )
+        connection.execute(
+            """INSERT INTO sessions
+            (id, credential_hash, user_id, tenant_id, status, issued_at, expires_at, revoked_at)
+            VALUES (?, ?, ?, ?, 'active', ?, ?, NULL)""",
+            (
+                "d" * 24,
+                "e" * 64,
+                created.user_id,
+                created.tenant_id,
+                NOW.isoformat(),
+                datetime(2026, 8, 22, 8, 30, tzinfo=UTC).isoformat(),
+            ),
+        )
+    invitation_service = SQLiteTenantInvitationService(identity, tenants)
+    invitation_service.issue(
+        tenant_id=created.tenant_id,
+        created_by_user_id=created.user_id,
+        email="invitee@example.com",
+        role=offboarding_module.TenantRole.analyst,
+        now=NOW,
+    )
+    monitoring = SQLiteMonitoringJobStore(tenants / "monitoring-jobs.sqlite3")
+    monitoring.enqueue(
+        tenant_id=created.tenant_id,
+        project_id=PROJECT_ID,
+        run_window="2026-08-21",
+        now=NOW,
+    )
+    target_marker = tenants / created.tenant_id / "customer-data.txt"
+    target_marker.write_text("customer-secret-state", encoding="utf-8")
+    return identity, tenants, created.tenant_id, created.user_id
+
+
+def _count(database: Path, sql: str, parameters: tuple[str, ...]) -> int:
+    with sqlite3.connect(database) as connection:
+        return int(connection.execute(sql, parameters).fetchone()[0])
+
+
+def test_offboarding_creates_backup_and_removes_only_tenant_context(tmp_path: Path) -> None:
+    identity, tenants, tenant_id, user_id = _setup(tmp_path)
+    backup = tmp_path / "recovery" / "before-offboarding.zip"
+
+    result = offboard_tenant(
+        identity_database=identity,
+        tenant_data_root=tenants,
+        tenant_id=tenant_id,
+        backup_output=backup,
+        confirm_quiesced=True,
+    )
+
+    assert result.tenant_id == tenant_id
+    assert result.backup_archive == backup
+    assert result.deleted_sessions == 1
+    assert result.deleted_invitations == 1
+    assert result.deleted_memberships == 1
+    assert result.deleted_monitoring_jobs == 1
+    assert backup.is_file()
+    with zipfile.ZipFile(backup) as archive:
+        names = set(archive.namelist())
+        assert "manifest.json" in names
+        assert f"tenants/{tenant_id}/customer-data.txt" in names
+    assert not (tenants / tenant_id).exists()
+    assert _count(identity, "SELECT COUNT(*) FROM tenants WHERE id = ?", (tenant_id,)) == 0
+    assert _count(identity, "SELECT COUNT(*) FROM sessions WHERE tenant_id = ?", (tenant_id,)) == 0
+    assert _count(identity, "SELECT COUNT(*) FROM memberships WHERE tenant_id = ?", (tenant_id,)) == 0
+    assert _count(identity, "SELECT COUNT(*) FROM tenant_invitations WHERE tenant_id = ?", (tenant_id,)) == 0
+    assert _count(identity, "SELECT COUNT(*) FROM users WHERE id = ?", (user_id,)) == 1
+    assert _count(
+        identity,
+        "SELECT COUNT(*) FROM memberships WHERE tenant_id = ? AND user_id = ?",
+        (SECOND_TENANT, user_id),
+    ) == 1
+    assert _count(
+        tenants / "monitoring-jobs.sqlite3",
+        "SELECT COUNT(*) FROM monitoring_jobs WHERE tenant_id = ?",
+        (tenant_id,),
+    ) == 0
+
+
+def test_offboarding_refuses_stripe_bound_tenant_without_provider_acknowledgement(
+    tmp_path: Path,
+) -> None:
+    identity, tenants, tenant_id, _ = _setup(tmp_path)
+    StripeTenantBindingStore(tenants).save(
+        StripeTenantBinding(
+            tenant_id=tenant_id,
+            customer_id="cus_target",
+            subscription_id="sub_target",
+            updated_at=NOW,
+        )
+    )
+    backup = tmp_path / "recovery.zip"
+
+    with pytest.raises(TenantOffboardingError, match="Stripe subscription binding"):
+        offboard_tenant(
+            identity_database=identity,
+            tenant_data_root=tenants,
+            tenant_id=tenant_id,
+            backup_output=backup,
+            confirm_quiesced=True,
+        )
+
+    assert not backup.exists()
+    assert (tenants / tenant_id).is_dir()
+    assert _count(identity, "SELECT COUNT(*) FROM tenants WHERE id = ?", (tenant_id,)) == 1
+
+
+def test_offboarding_requires_quiescence_before_backup_or_mutation(tmp_path: Path) -> None:
+    identity, tenants, tenant_id, _ = _setup(tmp_path)
+    backup = tmp_path / "recovery.zip"
+
+    with pytest.raises(TenantOffboardingError, match="quiesced"):
+        offboard_tenant(
+            identity_database=identity,
+            tenant_data_root=tenants,
+            tenant_id=tenant_id,
+            backup_output=backup,
+            confirm_quiesced=False,
+        )
+
+    assert not backup.exists()
+    assert (tenants / tenant_id).is_dir()
+
+
+def test_identity_failure_restores_staged_files_and_monitoring_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity, tenants, tenant_id, _ = _setup(tmp_path)
+    backup = tmp_path / "recovery.zip"
+
+    def fail_identity(database: Path, selected_tenant: str) -> tuple[int, int, int]:
+        raise RuntimeError("simulated identity failure")
+
+    monkeypatch.setattr(offboarding_module, "_delete_identity", fail_identity)
+
+    with pytest.raises(TenantOffboardingError, match="staged state was restored"):
+        offboard_tenant(
+            identity_database=identity,
+            tenant_data_root=tenants,
+            tenant_id=tenant_id,
+            backup_output=backup,
+            confirm_quiesced=True,
+        )
+
+    assert backup.is_file()
+    assert (tenants / tenant_id / "customer-data.txt").read_text(encoding="utf-8") == (
+        "customer-secret-state"
+    )
+    assert _count(identity, "SELECT COUNT(*) FROM tenants WHERE id = ?", (tenant_id,)) == 1
+    assert _count(
+        tenants / "monitoring-jobs.sqlite3",
+        "SELECT COUNT(*) FROM monitoring_jobs WHERE tenant_id = ?",
+        (tenant_id,),
+    ) == 1

--- a/tests/test_tenant_offboarding.py
+++ b/tests/test_tenant_offboarding.py
@@ -106,9 +106,21 @@ def test_offboarding_creates_backup_and_removes_only_tenant_context(tmp_path: Pa
         assert "manifest.json" in names
         assert f"tenants/{tenant_id}/customer-data.txt" in names
     assert not (tenants / tenant_id).exists()
-    assert _count(identity, "SELECT COUNT(*) FROM tenants WHERE id = ?", (tenant_id,)) == 0
-    assert _count(identity, "SELECT COUNT(*) FROM sessions WHERE tenant_id = ?", (tenant_id,)) == 0
-    assert _count(identity, "SELECT COUNT(*) FROM memberships WHERE tenant_id = ?", (tenant_id,)) == 0
+    assert _count(
+        identity,
+        "SELECT COUNT(*) FROM tenants WHERE id = ?",
+        (tenant_id,),
+    ) == 0
+    assert _count(
+        identity,
+        "SELECT COUNT(*) FROM sessions WHERE tenant_id = ?",
+        (tenant_id,),
+    ) == 0
+    assert _count(
+        identity,
+        "SELECT COUNT(*) FROM memberships WHERE tenant_id = ?",
+        (tenant_id,),
+    ) == 0
     assert _count(
         identity,
         "SELECT COUNT(*) FROM tenant_invitations WHERE tenant_id = ?",

--- a/tests/test_tenant_offboarding.py
+++ b/tests/test_tenant_offboarding.py
@@ -9,6 +9,7 @@ import pytest
 
 import veridra.tenant_offboarding as offboarding_module
 from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_tenancy import TenantRole
 from veridra.monitoring_jobs import SQLiteMonitoringJobStore
 from veridra.stripe_billing import StripeTenantBinding, StripeTenantBindingStore
 from veridra.tenant_invitations import SQLiteTenantInvitationService
@@ -61,7 +62,7 @@ def _setup(tmp_path: Path) -> tuple[Path, Path, str, str]:
         tenant_id=created.tenant_id,
         created_by_user_id=created.user_id,
         email="invitee@example.com",
-        role=offboarding_module.TenantRole.analyst,
+        role=TenantRole.analyst,
         now=NOW,
     )
     monitoring = SQLiteMonitoringJobStore(tenants / "monitoring-jobs.sqlite3")
@@ -108,7 +109,11 @@ def test_offboarding_creates_backup_and_removes_only_tenant_context(tmp_path: Pa
     assert _count(identity, "SELECT COUNT(*) FROM tenants WHERE id = ?", (tenant_id,)) == 0
     assert _count(identity, "SELECT COUNT(*) FROM sessions WHERE tenant_id = ?", (tenant_id,)) == 0
     assert _count(identity, "SELECT COUNT(*) FROM memberships WHERE tenant_id = ?", (tenant_id,)) == 0
-    assert _count(identity, "SELECT COUNT(*) FROM tenant_invitations WHERE tenant_id = ?", (tenant_id,)) == 0
+    assert _count(
+        identity,
+        "SELECT COUNT(*) FROM tenant_invitations WHERE tenant_id = ?",
+        (tenant_id,),
+    ) == 0
     assert _count(identity, "SELECT COUNT(*) FROM users WHERE id = ?", (user_id,)) == 1
     assert _count(
         identity,


### PR DESCRIPTION
Adds an operator-only tenant offboarding boundary for removing a Veridra workspace without conflating tenant deletion with shared user-account erasure.

What changes:
- add `veridra-tenant-offboard` operator CLI;
- require explicit writer quiescence before any destructive action;
- require a new verified full recovery backup before mutation begins;
- remove tenant-scoped sessions, invitations, memberships, tenant identity, global monitoring jobs and the complete tenant filesystem subtree;
- preserve user accounts/password credentials/reset state because users may belong to other tenants;
- refuse Stripe-bound tenant deletion unless the operator explicitly confirms provider-side cancellation/transfer has already been handled;
- stage the tenant directory under quarantine and compensate monitoring/filesystem state if identity deletion fails;
- keep the verified pre-offboarding backup as the cross-store recovery point;
- add tests for successful offboarding, shared-user preservation, mandatory quiescence, Stripe-binding refusal and rollback after identity failure;
- document recovery, provider-billing, privacy and post-offboarding checks.

This is intentionally not a browser self-service delete button and is not presented as complete data-subject erasure. User-level export/erasure remains a separate lifecycle because identity can be shared across workspaces and some operational/security evidence may have independent retention requirements.

Do not merge until exact-head full CI succeeds.