### PR TITLE
Add reusable public agency signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The core evidence model is:
 - configurable multi-page crawl profiles with same-origin controls, sitemap discovery and page-level evidence;
 - findings covering technical SEO fundamentals, AI crawler policy, AI technical readiness, trust, accessibility heuristics, domain/email posture and passive public security;
 - authenticated users, tenants, memberships, roles, invitations, browser sign-in, password recovery/reset and server-side sessions;
-- transactional identity email through verified TLS SMTP for password recovery and tenant invitations, with sensitive tokens excluded from durable delivery evidence;
+- reusable public agency signup with email verification before tenant activation, non-enumerating existing-account handling, bounded signup attempts and Free-plan workspace creation;
+- transactional identity email through verified TLS SMTP for password recovery, tenant invitations and agency signup verification, with sensitive tokens excluded from durable delivery evidence;
 - complete invitation browser journeys for both new and existing users, including authenticated tenant acceptance;
 - tenant-qualified projects, leads, lead forms, remediation tasks, monitoring configuration, report profiles, assessments and report artifacts;
 - explicit conversion from completed quick audits or qualified leads into tenant-qualified client projects;
@@ -34,8 +35,11 @@ The core evidence model is:
 - durable monitoring jobs with idempotent enqueueing, worker leases, stale-lease recovery, bounded retries and a separate worker CLI;
 - plan feature, usage and user-seat entitlement enforcement, including downgrade behavior;
 - a provider-neutral subscription authority with replay, ordering, evidence and rollback protections;
-- an optional Stripe adapter providing authenticated hosted subscription Checkout, Billing Portal management, raw-body webhook-signature verification, server-side Price-to-plan mapping, current-subscription reconciliation and replacement-subscription safety;
+- an optional Stripe adapter providing authenticated hosted subscription Checkout, Billing Portal management, raw-body webhook-signature verification, server-side Price-to-plan mapping, current-subscription reconciliation, replacement-subscription safety and bounded webhook-secret rotation overlap;
 - health and readiness endpoints, trusted hosts, explicit proxy boundaries, bounded request bodies and fail-closed production runtime validation;
+- privacy-minimized structured HTTP access logging with generated request IDs and raw query-string suppression;
+- verified production backup/restore tooling plus aggregate operational health checks for identity, monitoring jobs, identity-email delivery and backup freshness;
+- verified operator tenant offboarding with pre-delete recovery backup, Stripe-binding guard, shared-user preservation and compensating rollback;
 - a provider-neutral non-root production container with Chromium support, durable-storage guidance and secret/state build-context exclusions;
 - global response hardening with content-type, referrer, permissions, anti-framing and production HSTS controls while preserving the intentional public embed surface;
 - an agency workflow home that separates temporary quick audits from persistent client projects and exposes only tenant-qualified normal-user operations;
@@ -51,7 +55,7 @@ These checks verify repository behavior; they do not replace deployment-specific
 
 ## Production foundation and remaining deployment work
 
-The application provides explicit development, test and production modes; mandatory durable paths and trusted origins in production; trusted-host and proxy boundaries; bounded request bodies; health/readiness endpoints; global security headers; browser authentication/recovery; transactional SMTP identity email; invitation acceptance; Stripe billing integration; and separate web and monitoring-worker processes.
+The application provides explicit development, test and production modes; mandatory durable paths and trusted origins in production; trusted-host and proxy boundaries; bounded request bodies; health/readiness endpoints; global security headers; browser authentication/recovery; transactional SMTP identity email; reusable agency signup; invitation acceptance; Stripe billing integration; backup/restore; operational checks; access logging; tenant offboarding; and separate web and monitoring-worker processes.
 
 The composed runtime exposes the tenant-native agency and API workflow rather than the old standalone global browser trees. Compatibility router modules remain in the repository for isolated migration or compatibility use.
 
@@ -61,7 +65,7 @@ The repository includes a non-root provider-neutral Docker image and explicit li
 
 The current persistence model combines SQLite with filesystem tenant state and should be treated as single-writer unless shared persistence and concurrency are explicitly redesigned and tested.
 
-Remaining production work is primarily operational: provision and validate a hosted environment; configure SMTP and Stripe provider resources; establish tested backups/restores, monitoring/alerting and secret rotation; and run deployment-specific acceptance/security validation.
+Remaining production work is now primarily external and deployment-specific: provision a hosted environment; configure DNS/TLS, durable storage, SMTP and Stripe resources; configure upstream access-log redaction and edge abuse controls; schedule backups/ops checks; and run deployment-specific acceptance/security validation.
 
 ## Important AI terminology
 
@@ -95,9 +99,9 @@ For the packaged Windows operational workflow, use the root helper scripts such 
 
 The Windows launcher defaults to `http://127.0.0.1:8010` to avoid common local conflicts. Override it with `VERIDRA_LOCAL_PORT` when needed.
 
-Browser sign-in is served at `/login`; password recovery starts at `/forgot-password`, and reset emails point to `/reset-password?token=...` on the configured trusted origin.
+Browser signup is served at `/signup`; signup verification emails point to `/verify-signup?token=...`. Browser sign-in is served at `/login`; password recovery starts at `/forgot-password`, and reset emails point to `/reset-password?token=...` on the configured trusted origin.
 
-Production configuration is documented in `docs/operations/production-deployment.md`, `docs/operations/stripe-billing.md`, `docs/operations/security-headers.md` and `docs/architecture/production-runtime-hardening.md`.
+Production configuration is documented under `docs/operations/`, including deployment, Stripe billing, security headers, access logging, backup/restore and tenant offboarding.
 
 ## Safety boundary
 
@@ -107,10 +111,10 @@ Passive security findings describe observable public posture only. Accessibility
 
 ## Current product priority
 
-The authenticated agency workflow now covers the original commercial parity path:
+The authenticated agency workflow covers the commercial parity path:
 
 > audit → project → white-label report → lead capture/qualification → remediation → monitoring/proof of improvement.
 
-The major code-side commercial foundations are also present: invitation email/browser acceptance, subscription authority, Stripe adapter, customer subscription management, production containerization, health/readiness and response hardening.
+The code-side commercial and production foundations now also cover customer signup, invitation email/browser acceptance, subscription authority, Stripe customer billing flows, production containerization, health/readiness, response hardening, verified backup/restore, operational checks, structured access logging and tenant offboarding.
 
-The next coherent priority is production operations rather than another broad feature layer: tested backup/restore tooling, monitoring/alerting and secret-rotation procedures, followed by deployment of a real hosted environment with SMTP/Stripe provider configuration and deployment-specific acceptance/security validation.
+The next coherent priority is deployment validation rather than another broad feature layer: stand up a real hosted environment, connect SMTP and Stripe provider resources, configure DNS/TLS/persistent storage/edge controls, and prove the complete signup → billing → agency workflow on the deployed origin.

--- a/docs/operations/access-logging.md
+++ b/docs/operations/access-logging.md
@@ -33,12 +33,12 @@ The application access logger never records:
 - client-supplied request IDs;
 - client IP addresses;
 - authenticated user or tenant identity;
-- password-reset/invitation tokens;
+- password-reset, invitation or signup-verification tokens;
 - Stripe webhook bodies or signatures.
 
 Unmatched URLs are recorded as `<unmatched>` rather than echoing attacker-controlled path text.
 
-This is important for `/reset-password` and `/accept-invitation`, where one-time tokens can appear in the browser query string before being posted back.
+This is important for `/reset-password`, `/accept-invitation` and `/verify-signup`, where one-time tokens can appear in the browser query string before being posted back.
 
 ## Uvicorn and reverse-proxy logging
 
@@ -48,6 +48,7 @@ A reverse proxy, load balancer, CDN or hosting platform can still create its own
 
 - `/reset-password`;
 - `/accept-invitation`;
+- `/verify-signup`;
 - any future route carrying one-time credentials in a query parameter.
 
 Do not treat Veridra's application logger as proof that upstream access logs are safe.

--- a/src/veridra/identity_email_delivery.py
+++ b/src/veridra/identity_email_delivery.py
@@ -24,6 +24,7 @@ _MAX_MESSAGE_BYTES = 128_000
 class IdentityEmailKind(StrEnum):
     password_reset = "password_reset"
     tenant_invitation = "tenant_invitation"
+    tenant_signup_verification = "tenant_signup_verification"
 
 
 class IdentityEmailAttempt(BaseModel):
@@ -92,6 +93,13 @@ IdentityEmailSender = Callable[[SmtpConfig, EmailMessage], None]
 
 @dataclass(frozen=True)
 class TenantInvitationDelivery:
+    email: str
+    token: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class TenantSignupDelivery:
     email: str
     token: str
     expires_at: datetime
@@ -217,6 +225,44 @@ class TenantInvitationEmailAdapter(_RecordedEmailAdapter):
         )
         return self._deliver(
             kind=IdentityEmailKind.tenant_invitation,
+            recipient=delivery.email,
+            subject=subject,
+            token=delivery.token,
+            message=message,
+        )
+
+
+class TenantSignupEmailAdapter(_RecordedEmailAdapter):
+    def __init__(
+        self,
+        *,
+        config: SmtpConfig,
+        store: IdentityEmailAttemptStore,
+        signup_origin: str,
+        sender: IdentityEmailSender = _default_sender,
+    ) -> None:
+        super().__init__(config=config, store=store, sender=sender)
+        self.signup_origin = signup_origin.rstrip("/")
+
+    def __call__(self, delivery: TenantSignupDelivery) -> bool:
+        subject = "Verify your Veridra agency signup"
+        verification_url = (
+            f"{self.signup_origin}/verify-signup?"
+            f"{urlencode({'token': delivery.token})}"
+        )
+        message = EmailMessage()
+        message["From"] = f"{self.config.sender_name} <{self.config.sender_email}>"
+        message["To"] = delivery.email
+        message["Subject"] = subject
+        message.set_content(
+            "Complete your Veridra agency workspace signup.\n\n"
+            f"Open this verification link:\n{verification_url}\n\n"
+            f"Expires: {delivery.expires_at.astimezone(UTC).isoformat()}\n\n"
+            "Opening the link does not create the workspace until you confirm in the browser.\n"
+            "If you did not request this signup, ignore this email."
+        )
+        return self._deliver(
+            kind=IdentityEmailKind.tenant_signup_verification,
             recipient=delivery.email,
             subject=subject,
             token=delivery.token,

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -44,6 +44,7 @@ from .runtime_config import RuntimeConfig
 from .runtime_email import configure_runtime_email
 from .security_headers import SecurityHeadersMiddleware
 from .session_api import router as session_router
+from .signup_web import router as signup_router
 from .stripe_billing_web import router as stripe_billing_router
 from .tenant_assessment_routes import router as tenant_assessment_router
 from .tenant_bound_lead_capture import router as tenant_bound_lead_capture_router
@@ -108,6 +109,7 @@ configure_identity_middleware(app)
 app.include_router(health_router)
 app.include_router(public_router)
 app.include_router(onboarding_router)
+app.include_router(signup_router)
 app.include_router(browser_auth_router)
 app.include_router(invitation_web_router)
 app.include_router(stripe_billing_router)

--- a/src/veridra/runtime_email.py
+++ b/src/veridra/runtime_email.py
@@ -7,6 +7,7 @@ from .identity_email_delivery import (
     IdentityEmailAttemptStore,
     PasswordResetEmailAdapter,
     TenantInvitationEmailAdapter,
+    TenantSignupEmailAdapter,
 )
 from .runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
 
@@ -46,4 +47,9 @@ def configure_runtime_email(app: FastAPI, config: RuntimeConfig) -> None:
             config=smtp,
             store=store,
             invitation_origin=config.trusted_origin,
+        )
+        app.state.veridra_tenant_signup_delivery = TenantSignupEmailAdapter(
+            config=smtp,
+            store=store,
+            signup_origin=config.trusted_origin,
         )

--- a/src/veridra/signup_web.py
+++ b/src/veridra/signup_web.py
@@ -42,10 +42,10 @@ def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
     )
 
 
-def _signup_form(error: str = "") -> HTMLResponse:
+def _signup_form(error: str = "", *, status_code: int = 200) -> HTMLResponse:
     error_html = f"<div class='error' role='alert'>{html.escape(error)}</div>" if error else ""
     body = f"""<h1>Create your Veridra agency workspace</h1><p class='muted'>Start on the Free plan. No payment is created during signup.</p>{error_html}<form method='post' action='/signup'><label for='tenant_name'>Agency or organisation name</label><input id='tenant_name' name='tenant_name' maxlength='160' required><label for='tenant_slug'>Workspace slug</label><input id='tenant_slug' name='tenant_slug' minlength='3' maxlength='80' pattern='[a-z0-9]+(?:-[a-z0-9]+)*' required><label for='owner_name'>Your name</label><input id='owner_name' name='owner_name' maxlength='120' required><label for='owner_email'>Email</label><input id='owner_email' name='owner_email' type='email' maxlength='254' autocomplete='email' required><label for='password'>Password</label><input id='password' name='password' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><label for='password_confirm'>Repeat password</label><input id='password_confirm' name='password_confirm' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><button type='submit'>Send verification email</button></form><p class='muted'>Already have an account? <a href='/login'>Sign in</a>.</p>"""
-    return _page("Create Veridra workspace", body)
+    return _page("Create Veridra workspace", body, status_code=status_code)
 
 
 def _runtime(request: Request) -> RuntimeConfig:
@@ -126,7 +126,7 @@ async def request_signup(request: Request) -> HTMLResponse:
     password = values.get("password", [""])[0]
     confirmation = values.get("password_confirm", [""])[0]
     if password != confirmation:
-        return _signup_form("Passwords do not match.").replace(status_code=400)
+        return _signup_form("Passwords do not match.", status_code=400)
     try:
         issued = _service(request).issue(
             tenant_slug=_one(values, "tenant_slug"),

--- a/src/veridra/signup_web.py
+++ b/src/veridra/signup_web.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from starlette.concurrency import run_in_threadpool
 
 from .identity_email_delivery import TenantSignupDelivery, TenantSignupEmailAdapter
 from .runtime_config import RuntimeConfig
@@ -122,13 +123,15 @@ def signup(request: Request) -> HTMLResponse:
 async def request_signup(request: Request) -> HTMLResponse:
     _same_origin(request)
     delivery = _delivery(request)
+    service = _service(request)
     values = _values(await request.body())
     password = values.get("password", [""])[0]
     confirmation = values.get("password_confirm", [""])[0]
     if password != confirmation:
         return _signup_form("Passwords do not match.", status_code=400)
     try:
-        issued = _service(request).issue(
+        issued = await run_in_threadpool(
+            service.issue,
             tenant_slug=_one(values, "tenant_slug"),
             tenant_name=_one(values, "tenant_name"),
             owner_email=_one(values, "owner_email"),
@@ -148,14 +151,23 @@ async def request_signup(request: Request) -> HTMLResponse:
             status_code=400,
         )
     if issued is not None:
-        sent = delivery(
+        sent = await run_in_threadpool(
+            delivery,
             TenantSignupDelivery(
                 email=issued.email,
                 token=issued.token,
                 expires_at=issued.expires_at,
-            )
+            ),
         )
         if not sent:
+            try:
+                await run_in_threadpool(service.cancel, issued.token)
+            except TenantSignupError:
+                return _page(
+                    "Signup state unavailable",
+                    "<h1>Signup could not be completed safely</h1><p>Contact the operator before retrying.</p>",
+                    status_code=503,
+                )
             return _page(
                 "Signup email unavailable",
                 "<h1>Verification email could not be sent</h1><p>Try signup again after email delivery is restored.</p>",
@@ -169,7 +181,7 @@ async def request_signup(request: Request) -> HTMLResponse:
 
 
 @router.get("/verify-signup", response_class=HTMLResponse)
-def verify_signup(request: Request, token: str = "") -> HTMLResponse:
+async def verify_signup(request: Request, token: str = "") -> HTMLResponse:
     try:
         checked = _token(token)
     except TenantSignupError:
@@ -178,7 +190,7 @@ def verify_signup(request: Request, token: str = "") -> HTMLResponse:
             "<h1>Signup link is invalid or expired</h1><p><a href='/signup'>Start again</a>.</p>",
             status_code=400,
         )
-    if not _service(request).is_valid(checked):
+    if not await run_in_threadpool(_service(request).is_valid, checked):
         return _page(
             "Invalid signup",
             "<h1>Signup link is invalid or expired</h1><p><a href='/signup'>Start again</a>.</p>",
@@ -194,7 +206,7 @@ async def complete_signup(request: Request) -> HTMLResponse | RedirectResponse:
     values = _values(await request.body())
     try:
         token = _token(_one(values, "token"))
-        accepted = _service(request).accept(token=token)
+        accepted = await run_in_threadpool(_service(request).accept, token=token)
     except (TenantSignupError, ValueError):
         return _page(
             "Invalid signup",
@@ -202,7 +214,8 @@ async def complete_signup(request: Request) -> HTMLResponse | RedirectResponse:
             status_code=400,
         )
     lifetime = timedelta(hours=8)
-    issued = SessionLifecycleService(_identity_store(request)).issue(
+    issued = await run_in_threadpool(
+        SessionLifecycleService(_identity_store(request)).issue,
         user_id=accepted.user_id,
         tenant_id=accepted.tenant_id,
         lifetime=lifetime,

--- a/src/veridra/signup_web.py
+++ b/src/veridra/signup_web.py
@@ -1,0 +1,212 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from datetime import timedelta
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from .identity_email_delivery import TenantSignupDelivery, TenantSignupEmailAdapter
+from .runtime_config import RuntimeConfig
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .session_api import set_session_cookie
+from .session_lifecycle import SessionLifecycleService
+from .sqlite_identity_store import SQLiteIdentityRecordStore
+from .tenant_signup import (
+    SQLiteTenantSignupService,
+    TenantSignupError,
+    TenantSignupSlugUnavailable,
+)
+
+router = APIRouter(tags=["signup"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:760px;margin:48px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:12px;padding:28px}h1{margin-top:0}label{display:block;font-weight:700;margin:14px 0 5px}input{width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px}button{margin-top:20px;border:0;border-radius:7px;background:#22272d;color:#fff;padding:11px 16px;cursor:pointer}.muted{color:#68707a}.error{border-left:4px solid #b42318;background:#fff1f0;color:#7a271a;padding:12px;margin-bottom:16px}.success{border-left:4px solid #16794a;background:#f0faf5;padding:12px 14px}
+"""
+
+_HEADERS = {
+    "Cache-Control": "no-store",
+    "Referrer-Policy": "no-referrer",
+    "X-Frame-Options": "DENY",
+}
+
+
+def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
+    return HTMLResponse(
+        f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main><section>{body}</section></main></body></html>",
+        status_code=status_code,
+        headers=_HEADERS,
+    )
+
+
+def _signup_form(error: str = "") -> HTMLResponse:
+    error_html = f"<div class='error' role='alert'>{html.escape(error)}</div>" if error else ""
+    body = f"""<h1>Create your Veridra agency workspace</h1><p class='muted'>Start on the Free plan. No payment is created during signup.</p>{error_html}<form method='post' action='/signup'><label for='tenant_name'>Agency or organisation name</label><input id='tenant_name' name='tenant_name' maxlength='160' required><label for='tenant_slug'>Workspace slug</label><input id='tenant_slug' name='tenant_slug' minlength='3' maxlength='80' pattern='[a-z0-9]+(?:-[a-z0-9]+)*' required><label for='owner_name'>Your name</label><input id='owner_name' name='owner_name' maxlength='120' required><label for='owner_email'>Email</label><input id='owner_email' name='owner_email' type='email' maxlength='254' autocomplete='email' required><label for='password'>Password</label><input id='password' name='password' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><label for='password_confirm'>Repeat password</label><input id='password_confirm' name='password_confirm' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><button type='submit'>Send verification email</button></form><p class='muted'>Already have an account? <a href='/login'>Sign in</a>.</p>"""
+    return _page("Create Veridra workspace", body)
+
+
+def _runtime(request: Request) -> RuntimeConfig:
+    value = getattr(request.app.state, "veridra_runtime_config", None)
+    if not isinstance(value, RuntimeConfig) or not value.trusted_origin:
+        raise HTTPException(status_code=503, detail="Signup is not configured.")
+    return value
+
+
+def _database(request: Request) -> Path:
+    value = getattr(request.app.state, "veridra_identity_database", None)
+    if not isinstance(value, Path):
+        raise HTTPException(status_code=503, detail="Signup is not configured.")
+    return value
+
+
+def _tenant_root(request: Request) -> Path:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    if not isinstance(value, Path):
+        raise HTTPException(status_code=503, detail="Signup is not configured.")
+    return value
+
+
+def _identity_store(request: Request) -> SQLiteIdentityRecordStore:
+    value = getattr(request.app.state, "veridra_identity_store", None)
+    if not isinstance(value, SQLiteIdentityRecordStore):
+        raise HTTPException(status_code=503, detail="Signup is not configured.")
+    return value
+
+
+def _delivery(request: Request) -> TenantSignupEmailAdapter:
+    value = getattr(request.app.state, "veridra_tenant_signup_delivery", None)
+    if not isinstance(value, TenantSignupEmailAdapter):
+        raise HTTPException(status_code=503, detail="Signup email is not configured.")
+    return value
+
+
+def _service(request: Request) -> SQLiteTenantSignupService:
+    return SQLiteTenantSignupService(_database(request), _tenant_root(request))
+
+
+def _same_origin(request: Request) -> None:
+    try:
+        TrustedSameOriginPolicy(_runtime(request).trusted_origin or "").validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Signup request is not permitted.") from exc
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _token(value: str) -> str:
+    token = value.strip()
+    if not 32 <= len(token) <= 512:
+        raise TenantSignupError("Signup verification token is invalid.")
+    return token
+
+
+@router.get("/signup", response_class=HTMLResponse)
+def signup(request: Request) -> HTMLResponse:
+    _runtime(request)
+    _database(request)
+    _tenant_root(request)
+    _delivery(request)
+    return _signup_form()
+
+
+@router.post("/signup", response_model=None)
+async def request_signup(request: Request) -> HTMLResponse:
+    _same_origin(request)
+    delivery = _delivery(request)
+    values = _values(await request.body())
+    password = values.get("password", [""])[0]
+    confirmation = values.get("password_confirm", [""])[0]
+    if password != confirmation:
+        return _signup_form("Passwords do not match.").replace(status_code=400)
+    try:
+        issued = _service(request).issue(
+            tenant_slug=_one(values, "tenant_slug"),
+            tenant_name=_one(values, "tenant_name"),
+            owner_email=_one(values, "owner_email"),
+            owner_name=_one(values, "owner_name"),
+            password=password,
+        )
+    except TenantSignupSlugUnavailable:
+        return _page(
+            "Workspace unavailable",
+            "<h1>Workspace slug unavailable</h1><p>Choose a different workspace slug and try again.</p><p><a href='/signup'>Back to signup</a></p>",
+            status_code=409,
+        )
+    except (TenantSignupError, ValueError) as exc:
+        return _page(
+            "Signup error",
+            f"<h1>Check your signup details</h1><div class='error'>{html.escape(str(exc))}</div><p><a href='/signup'>Back to signup</a></p>",
+            status_code=400,
+        )
+    if issued is not None:
+        sent = delivery(
+            TenantSignupDelivery(
+                email=issued.email,
+                token=issued.token,
+                expires_at=issued.expires_at,
+            )
+        )
+        if not sent:
+            return _page(
+                "Signup email unavailable",
+                "<h1>Verification email could not be sent</h1><p>Try signup again after email delivery is restored.</p>",
+                status_code=503,
+            )
+    return _page(
+        "Check your email",
+        "<h1>Check your email</h1><div class='success'>If these details can be registered, a verification link has been sent. The workspace is not created until that link is confirmed.</div>",
+        status_code=202,
+    )
+
+
+@router.get("/verify-signup", response_class=HTMLResponse)
+def verify_signup(request: Request, token: str = "") -> HTMLResponse:
+    try:
+        checked = _token(token)
+    except TenantSignupError:
+        return _page(
+            "Invalid signup",
+            "<h1>Signup link is invalid or expired</h1><p><a href='/signup'>Start again</a>.</p>",
+            status_code=400,
+        )
+    if not _service(request).is_valid(checked):
+        return _page(
+            "Invalid signup",
+            "<h1>Signup link is invalid or expired</h1><p><a href='/signup'>Start again</a>.</p>",
+            status_code=400,
+        )
+    body = f"""<h1>Confirm agency workspace</h1><p>The email address has received the signup link. Confirm below to create the Veridra workspace.</p><form method='post' action='/verify-signup'><input type='hidden' name='token' value='{html.escape(checked, quote=True)}'><button type='submit'>Create my workspace</button></form>"""
+    return _page("Confirm Veridra signup", body)
+
+
+@router.post("/verify-signup", response_model=None)
+async def complete_signup(request: Request) -> HTMLResponse | RedirectResponse:
+    _same_origin(request)
+    values = _values(await request.body())
+    try:
+        token = _token(_one(values, "token"))
+        accepted = _service(request).accept(token=token)
+    except (TenantSignupError, ValueError):
+        return _page(
+            "Invalid signup",
+            "<h1>Signup link is invalid, expired or no longer available</h1><p><a href='/signup'>Start again</a>.</p>",
+            status_code=400,
+        )
+    lifetime = timedelta(hours=8)
+    issued = SessionLifecycleService(_identity_store(request)).issue(
+        user_id=accepted.user_id,
+        tenant_id=accepted.tenant_id,
+        lifetime=lifetime,
+    )
+    response = RedirectResponse("/agency", status_code=303)
+    set_session_cookie(response, issued.credential, max_age=int(lifetime.total_seconds()))
+    return response

--- a/src/veridra/tenant_signup.py
+++ b/src/veridra/tenant_signup.py
@@ -223,6 +223,18 @@ class SQLiteTenantSignupService:
             expires_at=expires_at,
         )
 
+    def cancel(self, token: str) -> None:
+        token_hash = self._token_hash(token)
+        self.initialize()
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    "DELETE FROM tenant_signup_requests WHERE token_hash = ?",
+                    (token_hash,),
+                )
+        except sqlite3.Error as exc:
+            raise TenantSignupError("Pending signup could not be discarded safely.") from exc
+
     def is_valid(self, token: str, *, now: datetime | None = None) -> bool:
         checked_at = (now or datetime.now(UTC)).astimezone(UTC)
         try:

--- a/src/veridra/tenant_signup.py
+++ b/src/veridra/tenant_signup.py
@@ -41,6 +41,7 @@ class AcceptedTenantSignup:
 
 class SQLiteTenantSignupService:
     _MAX_EMAIL_REQUESTS = 3
+    _MAX_GLOBAL_REQUESTS = 30
     _REQUEST_WINDOW = timedelta(minutes=15)
 
     def __init__(self, database: Path, tenant_data_root: Path) -> None:
@@ -75,12 +76,86 @@ class SQLiteTenantSignupService:
                 """CREATE INDEX IF NOT EXISTS tenant_signup_requests_expiry_idx
                 ON tenant_signup_requests(expires_at)"""
             )
+            connection.execute(
+                """CREATE TABLE IF NOT EXISTS tenant_signup_attempts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    email_hash TEXT NOT NULL,
+                    attempted_at TEXT NOT NULL
+                )"""
+            )
+            connection.execute(
+                """CREATE INDEX IF NOT EXISTS tenant_signup_attempts_email_idx
+                ON tenant_signup_attempts(email_hash, attempted_at)"""
+            )
 
     @staticmethod
     def _token_hash(token: str) -> str:
         if len(token) < 32:
             raise TenantSignupError("Signup verification token is invalid.")
         return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _email_hash(email: str) -> str:
+        return hashlib.sha256(email.encode("utf-8")).hexdigest()
+
+    def _reserve_attempt(
+        self,
+        *,
+        tenant: Tenant,
+        user: AuthenticatedUser,
+        issued_at: datetime,
+    ) -> bool:
+        email = str(user.email)
+        email_hash = self._email_hash(email)
+        cutoff = issued_at - self._REQUEST_WINDOW
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                "DELETE FROM tenant_signup_requests WHERE expires_at <= ?",
+                (issued_at.isoformat(),),
+            )
+            connection.execute(
+                "DELETE FROM tenant_signup_attempts WHERE attempted_at < ?",
+                (cutoff.isoformat(),),
+            )
+            if connection.execute(
+                "SELECT 1 FROM tenants WHERE slug = ?",
+                (tenant.slug,),
+            ).fetchone() is not None:
+                raise TenantSignupSlugUnavailable("Workspace slug is already in use.")
+            if connection.execute(
+                "SELECT 1 FROM users WHERE email = ?",
+                (email,),
+            ).fetchone() is not None:
+                connection.rollback()
+                return False
+            email_attempts = int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM tenant_signup_attempts WHERE email_hash = ?",
+                    (email_hash,),
+                ).fetchone()[0]
+            )
+            global_attempts = int(
+                connection.execute("SELECT COUNT(*) FROM tenant_signup_attempts").fetchone()[0]
+            )
+            if (
+                email_attempts >= self._MAX_EMAIL_REQUESTS
+                or global_attempts >= self._MAX_GLOBAL_REQUESTS
+            ):
+                connection.rollback()
+                return False
+            connection.execute(
+                "INSERT INTO tenant_signup_attempts (email_hash, attempted_at) VALUES (?, ?)",
+                (email_hash, issued_at.isoformat()),
+            )
+            connection.commit()
+            return True
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
 
     def issue(
         self,
@@ -99,39 +174,25 @@ class SQLiteTenantSignupService:
         expires_at = issued_at + lifetime
         tenant = Tenant.build(slug=tenant_slug, display_name=tenant_name, now=issued_at)
         user = AuthenticatedUser.build(email=owner_email, display_name=owner_name, now=issued_at)
+        self.initialize()
+        if not self._reserve_attempt(tenant=tenant, user=user, issued_at=issued_at):
+            return None
+
         encoded_password = hash_password(password)
         token = secrets.token_urlsafe(48)
         token_hash = self._token_hash(token)
-        self.initialize()
         connection = self._connect()
         try:
             connection.execute("BEGIN IMMEDIATE")
-            connection.execute(
-                "DELETE FROM tenant_signup_requests WHERE expires_at <= ?",
-                (issued_at.isoformat(),),
-            )
-            existing_tenant = connection.execute(
+            if connection.execute(
                 "SELECT 1 FROM tenants WHERE slug = ?",
                 (tenant.slug,),
-            ).fetchone()
-            if existing_tenant is not None:
+            ).fetchone() is not None:
                 raise TenantSignupSlugUnavailable("Workspace slug is already in use.")
-            existing_user = connection.execute(
+            if connection.execute(
                 "SELECT 1 FROM users WHERE email = ?",
                 (str(user.email),),
-            ).fetchone()
-            if existing_user is not None:
-                connection.rollback()
-                return None
-            cutoff = issued_at - self._REQUEST_WINDOW
-            recent = int(
-                connection.execute(
-                    """SELECT COUNT(*) FROM tenant_signup_requests
-                    WHERE owner_email = ? AND issued_at >= ?""",
-                    (str(user.email), cutoff.isoformat()),
-                ).fetchone()[0]
-            )
-            if recent >= self._MAX_EMAIL_REQUESTS:
+            ).fetchone() is not None:
                 connection.rollback()
                 return None
             connection.execute(
@@ -279,6 +340,7 @@ class SQLiteTenantSignupService:
             if deleted.rowcount != 1:
                 raise TenantSignupError("Signup verification changed concurrently.")
             connection.commit()
+            return AcceptedTenantSignup(tenant_id=tenant.id, user_id=user.id)
         except Exception:
             connection.rollback()
             if workspace_path is not None:
@@ -286,4 +348,3 @@ class SQLiteTenantSignupService:
             raise
         finally:
             connection.close()
-        return AcceptedTenantSignup(tenant_id=tenant.id, user_id=user.id)

--- a/src/veridra/tenant_signup.py
+++ b/src/veridra/tenant_signup.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from .identity_tenancy import (
+    AccountStatus,
+    AuthenticatedUser,
+    Tenant,
+    TenantMembership,
+    TenantRole,
+)
+from .password_auth import hash_password
+from .workspace_policy import PlanName, WorkspaceConfig, WorkspaceStore
+
+
+class TenantSignupError(RuntimeError):
+    pass
+
+
+class TenantSignupSlugUnavailable(TenantSignupError):
+    pass
+
+
+@dataclass(frozen=True)
+class IssuedTenantSignup:
+    token: str
+    email: str
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class AcceptedTenantSignup:
+    tenant_id: str
+    user_id: str
+
+
+class SQLiteTenantSignupService:
+    _MAX_EMAIL_REQUESTS = 3
+    _REQUEST_WINDOW = timedelta(minutes=15)
+
+    def __init__(self, database: Path, tenant_data_root: Path) -> None:
+        self.database = database
+        self.tenant_data_root = tenant_data_root
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
+
+    def initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """CREATE TABLE IF NOT EXISTS tenant_signup_requests (
+                    token_hash TEXT PRIMARY KEY,
+                    tenant_slug TEXT NOT NULL,
+                    tenant_name TEXT NOT NULL,
+                    owner_email TEXT NOT NULL,
+                    owner_name TEXT NOT NULL,
+                    password_hash TEXT NOT NULL,
+                    issued_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL
+                )"""
+            )
+            connection.execute(
+                """CREATE INDEX IF NOT EXISTS tenant_signup_requests_email_idx
+                ON tenant_signup_requests(owner_email, issued_at)"""
+            )
+            connection.execute(
+                """CREATE INDEX IF NOT EXISTS tenant_signup_requests_expiry_idx
+                ON tenant_signup_requests(expires_at)"""
+            )
+
+    @staticmethod
+    def _token_hash(token: str) -> str:
+        if len(token) < 32:
+            raise TenantSignupError("Signup verification token is invalid.")
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def issue(
+        self,
+        *,
+        tenant_slug: str,
+        tenant_name: str,
+        owner_email: str,
+        owner_name: str,
+        password: str,
+        now: datetime | None = None,
+        lifetime: timedelta = timedelta(minutes=30),
+    ) -> IssuedTenantSignup | None:
+        if lifetime <= timedelta(0):
+            raise ValueError("Signup verification lifetime must be positive.")
+        issued_at = (now or datetime.now(UTC)).astimezone(UTC)
+        expires_at = issued_at + lifetime
+        tenant = Tenant.build(slug=tenant_slug, display_name=tenant_name, now=issued_at)
+        user = AuthenticatedUser.build(email=owner_email, display_name=owner_name, now=issued_at)
+        encoded_password = hash_password(password)
+        token = secrets.token_urlsafe(48)
+        token_hash = self._token_hash(token)
+        self.initialize()
+        connection = self._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                "DELETE FROM tenant_signup_requests WHERE expires_at <= ?",
+                (issued_at.isoformat(),),
+            )
+            existing_tenant = connection.execute(
+                "SELECT 1 FROM tenants WHERE slug = ?",
+                (tenant.slug,),
+            ).fetchone()
+            if existing_tenant is not None:
+                raise TenantSignupSlugUnavailable("Workspace slug is already in use.")
+            existing_user = connection.execute(
+                "SELECT 1 FROM users WHERE email = ?",
+                (str(user.email),),
+            ).fetchone()
+            if existing_user is not None:
+                connection.rollback()
+                return None
+            cutoff = issued_at - self._REQUEST_WINDOW
+            recent = int(
+                connection.execute(
+                    """SELECT COUNT(*) FROM tenant_signup_requests
+                    WHERE owner_email = ? AND issued_at >= ?""",
+                    (str(user.email), cutoff.isoformat()),
+                ).fetchone()[0]
+            )
+            if recent >= self._MAX_EMAIL_REQUESTS:
+                connection.rollback()
+                return None
+            connection.execute(
+                """INSERT INTO tenant_signup_requests
+                (token_hash, tenant_slug, tenant_name, owner_email, owner_name,
+                 password_hash, issued_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    token_hash,
+                    tenant.slug,
+                    tenant.display_name,
+                    str(user.email),
+                    user.display_name,
+                    encoded_password,
+                    issued_at.isoformat(),
+                    expires_at.isoformat(),
+                ),
+            )
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+        return IssuedTenantSignup(
+            token=token,
+            email=str(user.email),
+            expires_at=expires_at,
+        )
+
+    def is_valid(self, token: str, *, now: datetime | None = None) -> bool:
+        checked_at = (now or datetime.now(UTC)).astimezone(UTC)
+        try:
+            token_hash = self._token_hash(token)
+        except TenantSignupError:
+            return False
+        self.initialize()
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT expires_at FROM tenant_signup_requests WHERE token_hash = ?",
+                (token_hash,),
+            ).fetchone()
+        return row is not None and datetime.fromisoformat(row["expires_at"]) > checked_at
+
+    def accept(
+        self,
+        *,
+        token: str,
+        now: datetime | None = None,
+    ) -> AcceptedTenantSignup:
+        accepted_at = (now or datetime.now(UTC)).astimezone(UTC)
+        token_hash = self._token_hash(token)
+        self.initialize()
+        connection = self._connect()
+        workspace_path: Path | None = None
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM tenant_signup_requests WHERE token_hash = ?",
+                (token_hash,),
+            ).fetchone()
+            if row is None or datetime.fromisoformat(row["expires_at"]) <= accepted_at:
+                raise TenantSignupError("Signup verification token is invalid or expired.")
+            tenant = Tenant.build(
+                slug=row["tenant_slug"],
+                display_name=row["tenant_name"],
+                now=accepted_at,
+            )
+            user = AuthenticatedUser.build(
+                email=row["owner_email"],
+                display_name=row["owner_name"],
+                now=accepted_at,
+            ).model_copy(
+                update={
+                    "status": AccountStatus.active,
+                    "email_verified_at": accepted_at,
+                }
+            )
+            membership = TenantMembership(
+                tenant_id=tenant.id,
+                user_id=user.id,
+                role=TenantRole.owner,
+                active=True,
+                created_at=accepted_at,
+            )
+            if connection.execute(
+                "SELECT 1 FROM tenants WHERE slug = ?",
+                (tenant.slug,),
+            ).fetchone() is not None:
+                raise TenantSignupError("Signup verification token is no longer available.")
+            if connection.execute(
+                "SELECT 1 FROM users WHERE email = ?",
+                (str(user.email),),
+            ).fetchone() is not None:
+                raise TenantSignupError("Signup verification token is no longer available.")
+
+            workspace_store = WorkspaceStore(self.tenant_data_root / tenant.id / "workspace")
+            workspace_path = workspace_store.path
+            workspace_store.save(
+                WorkspaceConfig(display_name=tenant.display_name, plan=PlanName.free)
+            )
+            connection.execute(
+                """INSERT INTO tenants (id, slug, display_name, status, created_at)
+                VALUES (?, ?, ?, ?, ?)""",
+                (
+                    tenant.id,
+                    tenant.slug,
+                    tenant.display_name,
+                    tenant.status.value,
+                    tenant.created_at.isoformat(),
+                ),
+            )
+            connection.execute(
+                """INSERT INTO users
+                (id, email, display_name, status, email_verified_at, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    user.id,
+                    str(user.email),
+                    user.display_name,
+                    user.status.value,
+                    accepted_at.isoformat(),
+                    user.created_at.isoformat(),
+                ),
+            )
+            connection.execute(
+                """INSERT INTO memberships (tenant_id, user_id, role, active, created_at)
+                VALUES (?, ?, ?, 1, ?)""",
+                (
+                    membership.tenant_id,
+                    membership.user_id,
+                    membership.role.value,
+                    membership.created_at.isoformat(),
+                ),
+            )
+            connection.execute(
+                """INSERT INTO password_credentials (user_id, password_hash, updated_at)
+                VALUES (?, ?, ?)""",
+                (user.id, row["password_hash"], accepted_at.isoformat()),
+            )
+            deleted = connection.execute(
+                "DELETE FROM tenant_signup_requests WHERE token_hash = ?",
+                (token_hash,),
+            )
+            if deleted.rowcount != 1:
+                raise TenantSignupError("Signup verification changed concurrently.")
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            if workspace_path is not None:
+                workspace_path.unlink(missing_ok=True)
+            raise
+        finally:
+            connection.close()
+        return AcceptedTenantSignup(tenant_id=tenant.id, user_id=user.id)

--- a/tests/test_runtime_email.py
+++ b/tests/test_runtime_email.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import pytest
 from fastapi import FastAPI
 
-from veridra.identity_email_delivery import PasswordResetEmailAdapter, TenantInvitationEmailAdapter
+from veridra.identity_email_delivery import (
+    PasswordResetEmailAdapter,
+    TenantInvitationEmailAdapter,
+    TenantSignupEmailAdapter,
+)
 from veridra.runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
 from veridra.runtime_email import configure_runtime_email
 
@@ -56,6 +60,7 @@ def test_development_can_run_without_transactional_email(
 
     assert not hasattr(app.state, "veridra_password_reset_delivery")
     assert not hasattr(app.state, "veridra_tenant_invitation_delivery")
+    assert not hasattr(app.state, "veridra_tenant_signup_delivery")
 
 
 def test_production_requires_smtp_configuration(
@@ -94,8 +99,11 @@ def test_configured_smtp_installs_identity_email_adapters(
 
     reset_adapter = app.state.veridra_password_reset_delivery
     invitation_adapter = app.state.veridra_tenant_invitation_delivery
+    signup_adapter = app.state.veridra_tenant_signup_delivery
     assert isinstance(reset_adapter, PasswordResetEmailAdapter)
     assert isinstance(invitation_adapter, TenantInvitationEmailAdapter)
+    assert isinstance(signup_adapter, TenantSignupEmailAdapter)
     assert reset_adapter.reset_origin == "https://app.example.com"
     assert invitation_adapter.invitation_origin == "https://app.example.com"
+    assert signup_adapter.signup_origin == "https://app.example.com"
     assert app.state.veridra_smtp_config.host == "smtp.example.test"

--- a/tests/test_signup_web.py
+++ b/tests/test_signup_web.py
@@ -192,3 +192,27 @@ def test_existing_workspace_slug_is_reported_without_sending_email(tmp_path: Pat
     assert "Workspace slug unavailable" in response.text
     assert messages == []
     assert _count(identity, "tenants") == 1
+
+
+def test_smtp_failure_discards_pending_signup_secret(tmp_path: Path) -> None:
+    client, identity, _, _, evidence = _client(tmp_path)
+
+    def fail(config: SmtpConfig, message: EmailMessage) -> None:
+        raise OSError("smtp unavailable")
+
+    client.app.state.veridra_tenant_signup_delivery = TenantSignupEmailAdapter(
+        config=_smtp(),
+        store=IdentityEmailAttemptStore(evidence),
+        signup_origin=ORIGIN,
+        sender=fail,
+    )
+
+    response = client.post("/signup", data=_form(), headers={"origin": ORIGIN})
+
+    assert response.status_code == 503
+    with sqlite3.connect(identity) as connection:
+        pending = int(connection.execute("SELECT COUNT(*) FROM tenant_signup_requests").fetchone()[0])
+    assert pending == 0
+    attempts = IdentityEmailAttemptStore(evidence).list()
+    assert len(attempts) == 1
+    assert attempts[0][1].kind is IdentityEmailKind.tenant_signup_verification

--- a/tests/test_signup_web.py
+++ b/tests/test_signup_web.py
@@ -4,6 +4,7 @@ import re
 import sqlite3
 from email.message import EmailMessage
 from pathlib import Path
+from typing import cast
 from urllib.parse import unquote
 
 from fastapi import FastAPI
@@ -197,7 +198,8 @@ def test_smtp_failure_discards_pending_signup_secret(tmp_path: Path) -> None:
     def fail(config: SmtpConfig, message: EmailMessage) -> None:
         raise OSError("smtp unavailable")
 
-    client.app.state.veridra_tenant_signup_delivery = TenantSignupEmailAdapter(
+    app = cast(FastAPI, client.app)
+    app.state.veridra_tenant_signup_delivery = TenantSignupEmailAdapter(
         config=_smtp(),
         store=IdentityEmailAttemptStore(evidence),
         signup_origin=ORIGIN,

--- a/tests/test_signup_web.py
+++ b/tests/test_signup_web.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from email.message import EmailMessage
+from pathlib import Path
+from urllib.parse import unquote
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.email_delivery import EmailEncryption, SmtpConfig
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_email_delivery import (
+    IdentityEmailAttemptStore,
+    IdentityEmailKind,
+    TenantSignupEmailAdapter,
+)
+from veridra.runtime_config import RuntimeConfig, RuntimeEnvironment
+from veridra.signup_web import router
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+from veridra.workspace_policy import PlanName, WorkspaceStore
+
+ORIGIN = "https://app.example.com"
+PASSWORD = "signup-correct-horse-battery"
+
+
+def _runtime(identity: Path, tenants: Path) -> RuntimeConfig:
+    return RuntimeConfig(
+        environment=RuntimeEnvironment.test,
+        identity_database=identity,
+        tenant_data_root=tenants,
+        trusted_origin=ORIGIN,
+        allowed_hosts=("app.example.com",),
+        trusted_proxy_ips=(),
+        max_request_body_bytes=1_000_000,
+        bind_host="127.0.0.1",
+        bind_port=8000,
+    )
+
+
+def _smtp() -> SmtpConfig:
+    return SmtpConfig(
+        host="smtp.example.test",
+        port=587,
+        encryption=EmailEncryption.starttls,
+        sender_email="security@example.com",
+        sender_name="Veridra",
+    )
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Path, Path, list[EmailMessage], Path]:
+    identity = tmp_path / "identity" / "identity.sqlite3"
+    tenants = tmp_path / "tenants"
+    SQLiteIdentityBootstrap(identity, tenant_data_root=tenants).create_first_owner(
+        tenant_slug="first-agency",
+        tenant_name="First agency",
+        owner_email="first@example.com",
+        owner_name="First Owner",
+        password="first-owner-password-123",
+        confirmation=BOOTSTRAP_CONFIRMATION,
+    )
+    messages: list[EmailMessage] = []
+    evidence = tmp_path / "identity" / "identity-email-deliveries"
+    delivery = TenantSignupEmailAdapter(
+        config=_smtp(),
+        store=IdentityEmailAttemptStore(evidence),
+        signup_origin=ORIGIN,
+        sender=lambda config, message: messages.append(message),
+    )
+    app = FastAPI()
+    app.state.veridra_runtime_config = _runtime(identity, tenants)
+    app.state.veridra_identity_database = identity
+    app.state.veridra_identity_store = SQLiteIdentityRecordStore(identity)
+    app.state.veridra_tenant_data_root = tenants
+    app.state.veridra_tenant_signup_delivery = delivery
+    app.include_router(router)
+    return TestClient(app, base_url=ORIGIN), identity, tenants, messages, evidence
+
+
+def _count(database: Path, table: str) -> int:
+    with sqlite3.connect(database) as connection:
+        return int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+
+def _token(message: EmailMessage) -> str:
+    match = re.search(r"/verify-signup\?token=([^\s]+)", message.get_content())
+    assert match is not None
+    return unquote(match.group(1))
+
+
+def _form(*, slug: str = "second-agency", email: str = "second@example.com") -> dict[str, str]:
+    return {
+        "tenant_name": "Second agency",
+        "tenant_slug": slug,
+        "owner_name": "Second Owner",
+        "owner_email": email,
+        "password": PASSWORD,
+        "password_confirm": PASSWORD,
+    }
+
+
+def test_second_agency_can_signup_only_after_email_confirmation(tmp_path: Path) -> None:
+    client, identity, tenants, messages, evidence = _client(tmp_path)
+
+    assert client.get("/signup").status_code == 200
+    missing_origin = client.post("/signup", data=_form())
+    assert missing_origin.status_code == 403
+
+    requested = client.post("/signup", data=_form(), headers={"origin": ORIGIN})
+
+    assert requested.status_code == 202
+    assert "Check your email" in requested.text
+    assert len(messages) == 1
+    assert _count(identity, "tenants") == 1
+    assert _count(identity, "users") == 1
+    token = _token(messages[0])
+    evidence_files = list(evidence.glob("*.json"))
+    assert len(evidence_files) == 1
+    assert token.encode("utf-8") not in evidence_files[0].read_bytes()
+    attempts = IdentityEmailAttemptStore(evidence).list()
+    assert attempts[0][1].kind is IdentityEmailKind.tenant_signup_verification
+
+    preview = client.get(f"/verify-signup?token={token}")
+
+    assert preview.status_code == 200
+    assert "Create my workspace" in preview.text
+    assert _count(identity, "tenants") == 1
+    assert _count(identity, "users") == 1
+
+    completed = client.post(
+        "/verify-signup",
+        data={"token": token},
+        headers={"origin": ORIGIN},
+        follow_redirects=False,
+    )
+
+    assert completed.status_code == 303
+    assert completed.headers["location"] == "/agency"
+    assert "set-cookie" in completed.headers
+    assert _count(identity, "tenants") == 2
+    assert _count(identity, "users") == 2
+    assert _count(identity, "memberships") == 2
+    with sqlite3.connect(identity) as connection:
+        row = connection.execute(
+            "SELECT id, email_verified_at, status FROM users WHERE email = ?",
+            ("second@example.com",),
+        ).fetchone()
+        tenant = connection.execute(
+            "SELECT id FROM tenants WHERE slug = ?",
+            ("second-agency",),
+        ).fetchone()
+        pending = int(connection.execute("SELECT COUNT(*) FROM tenant_signup_requests").fetchone()[0])
+    assert row is not None
+    assert row[1] is not None
+    assert row[2] == "active"
+    assert tenant is not None
+    workspace = WorkspaceStore(tenants / str(tenant[0]) / "workspace").load()
+    assert workspace.plan is PlanName.free
+    assert pending == 0
+    assert client.get(f"/verify-signup?token={token}").status_code == 400
+
+
+def test_existing_email_is_non_enumerating_and_sends_no_verification(tmp_path: Path) -> None:
+    client, identity, _, messages, _ = _client(tmp_path)
+
+    response = client.post(
+        "/signup",
+        data=_form(slug="another-agency", email="first@example.com"),
+        headers={"origin": ORIGIN},
+    )
+
+    assert response.status_code == 202
+    assert "Check your email" in response.text
+    assert messages == []
+    assert _count(identity, "tenants") == 1
+    with sqlite3.connect(identity) as connection:
+        pending = int(connection.execute("SELECT COUNT(*) FROM tenant_signup_requests").fetchone()[0])
+    assert pending == 0
+
+
+def test_existing_workspace_slug_is_reported_without_sending_email(tmp_path: Path) -> None:
+    client, identity, _, messages, _ = _client(tmp_path)
+
+    response = client.post(
+        "/signup",
+        data=_form(slug="first-agency", email="different@example.com"),
+        headers={"origin": ORIGIN},
+    )
+
+    assert response.status_code == 409
+    assert "Workspace slug unavailable" in response.text
+    assert messages == []
+    assert _count(identity, "tenants") == 1

--- a/tests/test_signup_web.py
+++ b/tests/test_signup_web.py
@@ -150,14 +150,13 @@ def test_second_agency_can_signup_only_after_email_confirmation(tmp_path: Path) 
             "SELECT id FROM tenants WHERE slug = ?",
             ("second-agency",),
         ).fetchone()
-        pending = int(connection.execute("SELECT COUNT(*) FROM tenant_signup_requests").fetchone()[0])
     assert row is not None
     assert row[1] is not None
     assert row[2] == "active"
     assert tenant is not None
     workspace = WorkspaceStore(tenants / str(tenant[0]) / "workspace").load()
     assert workspace.plan is PlanName.free
-    assert pending == 0
+    assert _count(identity, "tenant_signup_requests") == 0
     assert client.get(f"/verify-signup?token={token}").status_code == 400
 
 
@@ -174,9 +173,7 @@ def test_existing_email_is_non_enumerating_and_sends_no_verification(tmp_path: P
     assert "Check your email" in response.text
     assert messages == []
     assert _count(identity, "tenants") == 1
-    with sqlite3.connect(identity) as connection:
-        pending = int(connection.execute("SELECT COUNT(*) FROM tenant_signup_requests").fetchone()[0])
-    assert pending == 0
+    assert _count(identity, "tenant_signup_requests") == 0
 
 
 def test_existing_workspace_slug_is_reported_without_sending_email(tmp_path: Path) -> None:
@@ -210,9 +207,7 @@ def test_smtp_failure_discards_pending_signup_secret(tmp_path: Path) -> None:
     response = client.post("/signup", data=_form(), headers={"origin": ORIGIN})
 
     assert response.status_code == 503
-    with sqlite3.connect(identity) as connection:
-        pending = int(connection.execute("SELECT COUNT(*) FROM tenant_signup_requests").fetchone()[0])
-    assert pending == 0
+    assert _count(identity, "tenant_signup_requests") == 0
     attempts = IdentityEmailAttemptStore(evidence).list()
     assert len(attempts) == 1
     assert attempts[0][1].kind is IdentityEmailKind.tenant_signup_verification


### PR DESCRIPTION
Adds the missing multi-customer acquisition path so agencies beyond the first bootstrapped tenant can create their own Veridra workspace.

What changes:
- add reusable `/signup` and `/verify-signup` browser flows;
- keep existing `/onboarding` as the one-time empty-database installation bootstrap;
- require email verification before creating an active tenant, user, membership or workspace;
- consume signup only on same-origin POST confirmation so email security scanners cannot activate accounts by opening links;
- store only hashed one-time verification tokens and a scrypt password hash while signup is pending;
- delete pending signup state after successful activation or failed SMTP delivery;
- preserve non-enumerating behavior for already-registered email addresses;
- report already-used workspace slugs explicitly;
- bound signup attempts before expensive password hashing with per-address and global 15-minute limits using hashed email identifiers;
- run blocking scrypt, SQLite, SMTP and session issuance work in Starlette's threadpool;
- reuse recorded transactional identity-email delivery without persisting bearer tokens;
- start verified agencies on the Free plan and issue the normal 8-hour server-side session after confirmation;
- extend access-log guidance for `/verify-signup?token=...` and reconcile README with the production/operations work already merged;
- add regression coverage proving tenant #2 can self-register while tenant #1 already exists, no account/workspace exists before email confirmation, existing-email non-enumeration, slug conflicts and SMTP-failure cleanup.

This does not replace deployment-edge abuse controls. A real public deployment should still configure upstream/IP rate limiting or equivalent abuse protection, query-string redaction, SMTP and DNS/TLS/provider resources.

Do not merge until exact-head full CI succeeds.