### PR TITLE
Add public root entry point

### DIFF
--- a/src/veridra/landing_web.py
+++ b/src/veridra/landing_web.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+from fastapi.responses import RedirectResponse
+
+router = APIRouter(tags=["landing"])
+
+
+@router.get("/", response_model=None)
+def landing() -> RedirectResponse:
+    return RedirectResponse("/free", status_code=302)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -28,6 +28,7 @@ from .finding_task_api import router as finding_task_router
 from .health_web import router as health_router
 from .invitation_api import router as invitation_router
 from .invitation_web import router as invitation_web_router
+from .landing_web import router as landing_router
 from .lead_form_tenant_binding_api import router as lead_form_tenant_binding_router
 from .lead_project_conversion_api import router as lead_project_conversion_router
 from .member_assignments_web import router as member_assignments_router
@@ -107,6 +108,7 @@ if _ACCESSIBILITY_TOOL.slug not in public_web._TOOL_BY_SLUG:
 app.middleware("http")(enforce_workspace_policy)
 configure_identity_middleware(app)
 app.include_router(health_router)
+app.include_router(landing_router)
 app.include_router(public_router)
 app.include_router(onboarding_router)
 app.include_router(signup_router)

--- a/tests/test_landing_web.py
+++ b/tests/test_landing_web.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.landing_web import router
+
+
+def test_public_root_redirects_to_free_tools() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/free"


### PR DESCRIPTION
Ensures the composed production runtime has an intentional public domain entry point instead of requiring visitors to know `/free`.

What changes:
- add a small public landing router at `/`;
- redirect GET `/` to `/free` with a 302 response;
- mount the landing router in the composed runtime;
- add regression coverage for the redirect contract.

This does not restore or expose the legacy global dashboard routes; `/free` remains the intended public acquisition surface.

Do not merge until exact-head full CI succeeds.