### PR TITLE
Require legal links and Terms acceptance for public signup

### DIFF
--- a/docs/operations/signup-legal-links.md
+++ b/docs/operations/signup-legal-links.md
@@ -1,0 +1,30 @@
+# Signup legal links
+
+Veridra does not ship operator-specific legal text. A production deployment must publish its own reviewed Terms of Service and Privacy Notice and configure their public HTTPS URLs.
+
+Required production variables:
+
+```text
+VERIDRA_TERMS_URL=https://example.com/terms
+VERIDRA_PRIVACY_URL=https://example.com/privacy
+```
+
+Both variables must be present together and must use HTTPS. Production startup fails closed when they are absent or invalid. Development and test runtimes may omit both.
+
+## Signup behavior
+
+When legal links are configured, `/signup`:
+
+- links to the configured Privacy Notice at the point personal data are collected;
+- requires a separate explicit Terms-of-Service checkbox before a verification email can be issued;
+- does **not** describe the Privacy Notice itself as consent;
+- records the exact Terms URL, Privacy URL, owner name/email and UTC acceptance timestamp in the identity SQLite database;
+- stores only a SHA-256 hash of the signup verification token in legal evidence;
+- enriches the evidence with tenant ID, user ID and activation time after email verification;
+- removes pending legal evidence if SMTP delivery fails and the pending signup is cancelled.
+
+The evidence table is `signup_legal_acceptances` and is part of the identity database, so it is included by the existing identity-database backup/restore contract.
+
+## Operator responsibility
+
+The configured documents must be reviewed for the actual operator, jurisdiction, processing activities, subprocessors, retention, contact details, billing terms and other applicable obligations. Veridra validates only the link and acceptance mechanics; it does not certify that the legal documents themselves are complete or legally sufficient.

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -44,6 +44,7 @@ from .runtime_billing import configure_runtime_billing
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig
 from .runtime_email import configure_runtime_email
+from .runtime_legal import configure_runtime_legal
 from .security_headers import SecurityHeadersMiddleware
 from .session_api import router as session_router
 from .signup_web import router as signup_router
@@ -71,6 +72,7 @@ runtime_config.configure_directories()
 app.state.veridra_runtime_config = runtime_config
 if runtime_config.tenant_data_root is not None:
     app.state.veridra_tenant_data_root = runtime_config.tenant_data_root
+configure_runtime_legal(app, runtime_config)
 configure_runtime_email(app, runtime_config)
 configure_runtime_billing(app, runtime_config)
 app.add_middleware(

--- a/src/veridra/runtime_legal.py
+++ b/src/veridra/runtime_legal.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from fastapi import FastAPI
+
+from .runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
+
+
+@dataclass(frozen=True)
+class LegalLinks:
+    privacy_url: str
+    terms_url: str
+
+    @staticmethod
+    def _https_url(value: str, *, name: str) -> str:
+        parsed = urlparse(value)
+        if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+            raise RuntimeConfigurationError(f"{name} must be an HTTPS URL.")
+        return value
+
+    @classmethod
+    def from_environment(cls, env: Mapping[str, str] | None = None) -> LegalLinks | None:
+        values = os.environ if env is None else env
+        privacy = values.get("VERIDRA_PRIVACY_URL", "").strip()
+        terms = values.get("VERIDRA_TERMS_URL", "").strip()
+        if not privacy and not terms:
+            return None
+        if not privacy or not terms:
+            raise RuntimeConfigurationError(
+                "VERIDRA_PRIVACY_URL and VERIDRA_TERMS_URL must be configured together."
+            )
+        return cls(
+            privacy_url=cls._https_url(privacy, name="VERIDRA_PRIVACY_URL"),
+            terms_url=cls._https_url(terms, name="VERIDRA_TERMS_URL"),
+        )
+
+
+def configure_runtime_legal(app: FastAPI, runtime: RuntimeConfig) -> None:
+    links = LegalLinks.from_environment()
+    if runtime.environment is RuntimeEnvironment.production and links is None:
+        raise RuntimeConfigurationError(
+            "VERIDRA_PRIVACY_URL and VERIDRA_TERMS_URL are required in production."
+        )
+    if links is not None:
+        app.state.veridra_legal_links = links

--- a/src/veridra/signup_legal_evidence.py
+++ b/src/veridra/signup_legal_evidence.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+class SignupLegalEvidenceError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SignupLegalAcceptance:
+    token_hash: str
+    tenant_slug: str
+    owner_email: str
+    owner_name: str
+    terms_url: str
+    privacy_url: str
+    accepted_at: datetime
+    activated_at: datetime | None
+    tenant_id: str | None
+    user_id: str | None
+
+
+class SQLiteSignupLegalEvidenceStore:
+    def __init__(self, database: Path) -> None:
+        self.database = database
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.database)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
+
+    @staticmethod
+    def _token_hash(token: str) -> str:
+        if len(token) < 32:
+            raise SignupLegalEvidenceError("Signup token is invalid.")
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def initialize(self) -> None:
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    """CREATE TABLE IF NOT EXISTS signup_legal_acceptances (
+                        token_hash TEXT PRIMARY KEY,
+                        tenant_slug TEXT NOT NULL,
+                        owner_email TEXT NOT NULL,
+                        owner_name TEXT NOT NULL,
+                        terms_url TEXT NOT NULL,
+                        privacy_url TEXT NOT NULL,
+                        accepted_at TEXT NOT NULL,
+                        activated_at TEXT,
+                        tenant_id TEXT,
+                        user_id TEXT
+                    )"""
+                )
+                connection.execute(
+                    """CREATE INDEX IF NOT EXISTS signup_legal_acceptances_email_idx
+                    ON signup_legal_acceptances(owner_email, accepted_at)"""
+                )
+        except sqlite3.Error as exc:
+            raise SignupLegalEvidenceError(
+                "Signup legal evidence store could not be initialized."
+            ) from exc
+
+    def record_pending(
+        self,
+        *,
+        token: str,
+        tenant_slug: str,
+        owner_email: str,
+        owner_name: str,
+        terms_url: str,
+        privacy_url: str,
+        accepted_at: datetime | None = None,
+    ) -> None:
+        recorded_at = (accepted_at or datetime.now(UTC)).astimezone(UTC)
+        token_hash = self._token_hash(token)
+        self.initialize()
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    """INSERT INTO signup_legal_acceptances
+                    (token_hash, tenant_slug, owner_email, owner_name, terms_url,
+                     privacy_url, accepted_at, activated_at, tenant_id, user_id)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)""",
+                    (
+                        token_hash,
+                        tenant_slug,
+                        owner_email,
+                        owner_name,
+                        terms_url,
+                        privacy_url,
+                        recorded_at.isoformat(),
+                    ),
+                )
+        except sqlite3.Error as exc:
+            raise SignupLegalEvidenceError(
+                "Signup legal acceptance could not be recorded."
+            ) from exc
+
+    def cancel(self, token: str) -> None:
+        token_hash = self._token_hash(token)
+        self.initialize()
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    "DELETE FROM signup_legal_acceptances WHERE token_hash = ?",
+                    (token_hash,),
+                )
+        except sqlite3.Error as exc:
+            raise SignupLegalEvidenceError(
+                "Signup legal acceptance could not be discarded."
+            ) from exc
+
+    def mark_activated(
+        self,
+        *,
+        token: str,
+        tenant_id: str,
+        user_id: str,
+        activated_at: datetime | None = None,
+    ) -> None:
+        token_hash = self._token_hash(token)
+        recorded_at = (activated_at or datetime.now(UTC)).astimezone(UTC)
+        self.initialize()
+        try:
+            with self._connect() as connection:
+                updated = connection.execute(
+                    """UPDATE signup_legal_acceptances
+                    SET activated_at = ?, tenant_id = ?, user_id = ?
+                    WHERE token_hash = ? AND activated_at IS NULL""",
+                    (recorded_at.isoformat(), tenant_id, user_id, token_hash),
+                )
+                if updated.rowcount != 1:
+                    raise SignupLegalEvidenceError(
+                        "Signup legal acceptance is unavailable for activation."
+                    )
+        except sqlite3.Error as exc:
+            raise SignupLegalEvidenceError(
+                "Signup legal acceptance could not be activated."
+            ) from exc
+
+    def latest_for_email(self, owner_email: str) -> SignupLegalAcceptance | None:
+        self.initialize()
+        try:
+            with self._connect() as connection:
+                row = connection.execute(
+                    """SELECT * FROM signup_legal_acceptances
+                    WHERE owner_email = ? ORDER BY accepted_at DESC LIMIT 1""",
+                    (owner_email,),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            raise SignupLegalEvidenceError(
+                "Signup legal acceptance could not be read."
+            ) from exc
+        if row is None:
+            return None
+        return SignupLegalAcceptance(
+            token_hash=row["token_hash"],
+            tenant_slug=row["tenant_slug"],
+            owner_email=row["owner_email"],
+            owner_name=row["owner_name"],
+            terms_url=row["terms_url"],
+            privacy_url=row["privacy_url"],
+            accepted_at=datetime.fromisoformat(row["accepted_at"]),
+            activated_at=(
+                datetime.fromisoformat(row["activated_at"])
+                if row["activated_at"] is not None
+                else None
+            ),
+            tenant_id=row["tenant_id"],
+            user_id=row["user_id"],
+        )

--- a/src/veridra/signup_legal_evidence.py
+++ b/src/veridra/signup_legal_evidence.py
@@ -117,14 +117,14 @@ class SQLiteSignupLegalEvidenceStore:
                 "Signup legal acceptance could not be discarded."
             ) from exc
 
-    def mark_activated(
+    def mark_activated_if_present(
         self,
         *,
         token: str,
         tenant_id: str,
         user_id: str,
         activated_at: datetime | None = None,
-    ) -> None:
+    ) -> bool:
         token_hash = self._token_hash(token)
         recorded_at = (activated_at or datetime.now(UTC)).astimezone(UTC)
         self.initialize()
@@ -136,10 +136,7 @@ class SQLiteSignupLegalEvidenceStore:
                     WHERE token_hash = ? AND activated_at IS NULL""",
                     (recorded_at.isoformat(), tenant_id, user_id, token_hash),
                 )
-                if updated.rowcount != 1:
-                    raise SignupLegalEvidenceError(
-                        "Signup legal acceptance is unavailable for activation."
-                    )
+                return updated.rowcount == 1
         except sqlite3.Error as exc:
             raise SignupLegalEvidenceError(
                 "Signup legal acceptance could not be activated."

--- a/src/veridra/signup_web.py
+++ b/src/veridra/signup_web.py
@@ -12,9 +12,14 @@ from starlette.concurrency import run_in_threadpool
 
 from .identity_email_delivery import TenantSignupDelivery, TenantSignupEmailAdapter
 from .runtime_config import RuntimeConfig
+from .runtime_legal import LegalLinks
 from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
 from .session_api import set_session_cookie
 from .session_lifecycle import SessionLifecycleService
+from .signup_legal_evidence import (
+    SQLiteSignupLegalEvidenceStore,
+    SignupLegalEvidenceError,
+)
 from .sqlite_identity_store import SQLiteIdentityRecordStore
 from .tenant_signup import (
     SQLiteTenantSignupService,
@@ -25,7 +30,7 @@ from .tenant_signup import (
 router = APIRouter(tags=["signup"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:760px;margin:48px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:12px;padding:28px}h1{margin-top:0}label{display:block;font-weight:700;margin:14px 0 5px}input{width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px}button{margin-top:20px;border:0;border-radius:7px;background:#22272d;color:#fff;padding:11px 16px;cursor:pointer}.muted{color:#68707a}.error{border-left:4px solid #b42318;background:#fff1f0;color:#7a271a;padding:12px;margin-bottom:16px}.success{border-left:4px solid #16794a;background:#f0faf5;padding:12px 14px}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:760px;margin:48px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:12px;padding:28px}h1{margin-top:0}label{display:block;font-weight:700;margin:14px 0 5px}input{width:100%;padding:11px;border:1px solid #cfd4da;border-radius:7px}input[type=checkbox]{width:auto;padding:0}.legal{margin-top:18px;padding:14px;background:#f4f6f8;border-radius:8px;line-height:1.5}.legal label{display:flex;gap:9px;align-items:flex-start;margin:0 0 8px}.legal p{margin:0}.legal a{font-weight:700}button{margin-top:20px;border:0;border-radius:7px;background:#22272d;color:#fff;padding:11px 16px;cursor:pointer}.muted{color:#68707a}.error{border-left:4px solid #b42318;background:#fff1f0;color:#7a271a;padding:12px;margin-bottom:16px}.success{border-left:4px solid #16794a;background:#f0faf5;padding:12px 14px}
 """
 
 _HEADERS = {
@@ -43,9 +48,22 @@ def _page(title: str, body: str, *, status_code: int = 200) -> HTMLResponse:
     )
 
 
-def _signup_form(error: str = "", *, status_code: int = 200) -> HTMLResponse:
+def _legal_block(legal: LegalLinks | None) -> str:
+    if legal is None:
+        return ""
+    terms = html.escape(legal.terms_url, quote=True)
+    privacy = html.escape(legal.privacy_url, quote=True)
+    return f"""<div class='legal'><label for='terms_accepted'><input id='terms_accepted' name='terms_accepted' type='checkbox' value='yes' required><span>I agree to the <a href='{terms}' target='_blank' rel='noopener'>Terms of Service</a>.</span></label><p class='muted'>Before creating an account, read the <a href='{privacy}' target='_blank' rel='noopener'>Privacy Notice</a>, which explains how personal data are handled.</p></div>"""
+
+
+def _signup_form(
+    error: str = "",
+    *,
+    status_code: int = 200,
+    legal: LegalLinks | None = None,
+) -> HTMLResponse:
     error_html = f"<div class='error' role='alert'>{html.escape(error)}</div>" if error else ""
-    body = f"""<h1>Create your Veridra agency workspace</h1><p class='muted'>Start on the Free plan. No payment is created during signup.</p>{error_html}<form method='post' action='/signup'><label for='tenant_name'>Agency or organisation name</label><input id='tenant_name' name='tenant_name' maxlength='160' required><label for='tenant_slug'>Workspace slug</label><input id='tenant_slug' name='tenant_slug' minlength='3' maxlength='80' pattern='[a-z0-9]+(?:-[a-z0-9]+)*' required><label for='owner_name'>Your name</label><input id='owner_name' name='owner_name' maxlength='120' required><label for='owner_email'>Email</label><input id='owner_email' name='owner_email' type='email' maxlength='254' autocomplete='email' required><label for='password'>Password</label><input id='password' name='password' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><label for='password_confirm'>Repeat password</label><input id='password_confirm' name='password_confirm' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><button type='submit'>Send verification email</button></form><p class='muted'>Already have an account? <a href='/login'>Sign in</a>.</p>"""
+    body = f"""<h1>Create your Veridra agency workspace</h1><p class='muted'>Start on the Free plan. No payment is created during signup.</p>{error_html}<form method='post' action='/signup'><label for='tenant_name'>Agency or organisation name</label><input id='tenant_name' name='tenant_name' maxlength='160' required><label for='tenant_slug'>Workspace slug</label><input id='tenant_slug' name='tenant_slug' minlength='3' maxlength='80' pattern='[a-z0-9]+(?:-[a-z0-9]+)*' required><label for='owner_name'>Your name</label><input id='owner_name' name='owner_name' maxlength='120' required><label for='owner_email'>Email</label><input id='owner_email' name='owner_email' type='email' maxlength='254' autocomplete='email' required><label for='password'>Password</label><input id='password' name='password' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required><label for='password_confirm'>Repeat password</label><input id='password_confirm' name='password_confirm' type='password' minlength='12' maxlength='1024' autocomplete='new-password' required>{_legal_block(legal)}<button type='submit'>Send verification email</button></form><p class='muted'>Already have an account? <a href='/login'>Sign in</a>.</p>"""
     return _page("Create Veridra workspace", body, status_code=status_code)
 
 
@@ -54,6 +72,11 @@ def _runtime(request: Request) -> RuntimeConfig:
     if not isinstance(value, RuntimeConfig) or not value.trusted_origin:
         raise HTTPException(status_code=503, detail="Signup is not configured.")
     return value
+
+
+def _legal(request: Request) -> LegalLinks | None:
+    value = getattr(request.app.state, "veridra_legal_links", None)
+    return value if isinstance(value, LegalLinks) else None
 
 
 def _database(request: Request) -> Path:
@@ -88,6 +111,10 @@ def _service(request: Request) -> SQLiteTenantSignupService:
     return SQLiteTenantSignupService(_database(request), _tenant_root(request))
 
 
+def _legal_evidence(request: Request) -> SQLiteSignupLegalEvidenceStore:
+    return SQLiteSignupLegalEvidenceStore(_database(request))
+
+
 def _same_origin(request: Request) -> None:
     try:
         TrustedSameOriginPolicy(_runtime(request).trusted_origin or "").validate(request)
@@ -116,7 +143,7 @@ def signup(request: Request) -> HTMLResponse:
     _database(request)
     _tenant_root(request)
     _delivery(request)
-    return _signup_form()
+    return _signup_form(legal=_legal(request))
 
 
 @router.post("/signup", response_model=None)
@@ -124,11 +151,18 @@ async def request_signup(request: Request) -> HTMLResponse:
     _same_origin(request)
     delivery = _delivery(request)
     service = _service(request)
+    legal = _legal(request)
     values = _values(await request.body())
+    if legal is not None and _one(values, "terms_accepted") != "yes":
+        return _signup_form(
+            "You must agree to the Terms of Service to create a workspace.",
+            status_code=400,
+            legal=legal,
+        )
     password = values.get("password", [""])[0]
     confirmation = values.get("password_confirm", [""])[0]
     if password != confirmation:
-        return _signup_form("Passwords do not match.", status_code=400)
+        return _signup_form("Passwords do not match.", status_code=400, legal=legal)
     try:
         issued = await run_in_threadpool(
             service.issue,
@@ -151,6 +185,24 @@ async def request_signup(request: Request) -> HTMLResponse:
             status_code=400,
         )
     if issued is not None:
+        if legal is not None:
+            try:
+                await run_in_threadpool(
+                    _legal_evidence(request).record_pending,
+                    token=issued.token,
+                    tenant_slug=_one(values, "tenant_slug"),
+                    owner_email=issued.email,
+                    owner_name=_one(values, "owner_name"),
+                    terms_url=legal.terms_url,
+                    privacy_url=legal.privacy_url,
+                )
+            except SignupLegalEvidenceError:
+                await run_in_threadpool(service.cancel, issued.token)
+                return _page(
+                    "Signup state unavailable",
+                    "<h1>Signup could not be completed safely</h1><p>Try again after the operator restores signup evidence storage.</p>",
+                    status_code=503,
+                )
         sent = await run_in_threadpool(
             delivery,
             TenantSignupDelivery(
@@ -162,7 +214,9 @@ async def request_signup(request: Request) -> HTMLResponse:
         if not sent:
             try:
                 await run_in_threadpool(service.cancel, issued.token)
-            except TenantSignupError:
+                if legal is not None:
+                    await run_in_threadpool(_legal_evidence(request).cancel, issued.token)
+            except (TenantSignupError, SignupLegalEvidenceError):
                 return _page(
                     "Signup state unavailable",
                     "<h1>Signup could not be completed safely</h1><p>Contact the operator before retrying.</p>",
@@ -212,6 +266,19 @@ async def complete_signup(request: Request) -> HTMLResponse | RedirectResponse:
             "Invalid signup",
             "<h1>Signup link is invalid, expired or no longer available</h1><p><a href='/signup'>Start again</a>.</p>",
             status_code=400,
+        )
+    try:
+        await run_in_threadpool(
+            _legal_evidence(request).mark_activated_if_present,
+            token=token,
+            tenant_id=accepted.tenant_id,
+            user_id=accepted.user_id,
+        )
+    except SignupLegalEvidenceError:
+        return _page(
+            "Signup evidence unavailable",
+            "<h1>Your workspace was created, but signup evidence could not be finalized</h1><p>Contact the operator before continuing.</p>",
+            status_code=503,
         )
     lifetime = timedelta(hours=8)
     issued = await run_in_threadpool(

--- a/src/veridra/signup_web.py
+++ b/src/veridra/signup_web.py
@@ -17,8 +17,8 @@ from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
 from .session_api import set_session_cookie
 from .session_lifecycle import SessionLifecycleService
 from .signup_legal_evidence import (
-    SQLiteSignupLegalEvidenceStore,
     SignupLegalEvidenceError,
+    SQLiteSignupLegalEvidenceStore,
 )
 from .sqlite_identity_store import SQLiteIdentityRecordStore
 from .tenant_signup import (

--- a/tests/test_runtime_legal.py
+++ b/tests/test_runtime_legal.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+
+from veridra.runtime_config import (
+    RuntimeConfig,
+    RuntimeConfigurationError,
+    RuntimeEnvironment,
+)
+from veridra.runtime_legal import LegalLinks, configure_runtime_legal
+
+
+def _runtime(environment: RuntimeEnvironment) -> RuntimeConfig:
+    return RuntimeConfig(
+        environment=environment,
+        identity_database=Path("identity.sqlite3"),
+        tenant_data_root=Path("tenants"),
+        trusted_origin="https://app.example.com",
+        allowed_hosts=("app.example.com",),
+        trusted_proxy_ips=(),
+        max_request_body_bytes=1_000_000,
+        bind_host="127.0.0.1",
+        bind_port=8000,
+    )
+
+
+def test_legal_links_require_both_https_urls() -> None:
+    with pytest.raises(RuntimeConfigurationError):
+        LegalLinks.from_environment({"VERIDRA_PRIVACY_URL": "https://example.com/privacy"})
+    with pytest.raises(RuntimeConfigurationError):
+        LegalLinks.from_environment(
+            {
+                "VERIDRA_PRIVACY_URL": "http://example.com/privacy",
+                "VERIDRA_TERMS_URL": "https://example.com/terms",
+            }
+        )
+
+
+def test_production_requires_legal_links(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VERIDRA_PRIVACY_URL", raising=False)
+    monkeypatch.delenv("VERIDRA_TERMS_URL", raising=False)
+
+    with pytest.raises(RuntimeConfigurationError):
+        configure_runtime_legal(FastAPI(), _runtime(RuntimeEnvironment.production))
+
+
+def test_configured_links_are_exposed_on_app_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERIDRA_PRIVACY_URL", "https://example.com/privacy")
+    monkeypatch.setenv("VERIDRA_TERMS_URL", "https://example.com/terms")
+    app = FastAPI()
+
+    configure_runtime_legal(app, _runtime(RuntimeEnvironment.test))
+
+    assert app.state.veridra_legal_links == LegalLinks(
+        privacy_url="https://example.com/privacy",
+        terms_url="https://example.com/terms",
+    )

--- a/tests/test_signup_legal_web.py
+++ b/tests/test_signup_legal_web.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import re
+import sqlite3
 from email.message import EmailMessage
 from pathlib import Path
+from typing import cast
 from urllib.parse import unquote
 
 from fastapi import FastAPI
@@ -37,7 +39,17 @@ def _runtime(identity: Path, tenants: Path) -> RuntimeConfig:
     )
 
 
-def _client(tmp_path: Path) -> tuple[TestClient, Path, list[EmailMessage]]:
+def _smtp() -> SmtpConfig:
+    return SmtpConfig(
+        host="smtp.example.test",
+        port=587,
+        encryption=EmailEncryption.starttls,
+        sender_email="security@example.com",
+        sender_name="Veridra",
+    )
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Path, list[EmailMessage], Path]:
     identity = tmp_path / "identity" / "identity.sqlite3"
     tenants = tmp_path / "tenants"
     SQLiteIdentityBootstrap(identity, tenant_data_root=tenants).create_first_owner(
@@ -49,13 +61,7 @@ def _client(tmp_path: Path) -> tuple[TestClient, Path, list[EmailMessage]]:
         confirmation=BOOTSTRAP_CONFIRMATION,
     )
     messages: list[EmailMessage] = []
-    smtp = SmtpConfig(
-        host="smtp.example.test",
-        port=587,
-        encryption=EmailEncryption.starttls,
-        sender_email="security@example.com",
-        sender_name="Veridra",
-    )
+    email_evidence = tmp_path / "email-evidence"
     app = FastAPI()
     app.state.veridra_runtime_config = _runtime(identity, tenants)
     app.state.veridra_identity_database = identity
@@ -63,13 +69,13 @@ def _client(tmp_path: Path) -> tuple[TestClient, Path, list[EmailMessage]]:
     app.state.veridra_tenant_data_root = tenants
     app.state.veridra_legal_links = LegalLinks(privacy_url=PRIVACY, terms_url=TERMS)
     app.state.veridra_tenant_signup_delivery = TenantSignupEmailAdapter(
-        config=smtp,
-        store=IdentityEmailAttemptStore(tmp_path / "email-evidence"),
+        config=_smtp(),
+        store=IdentityEmailAttemptStore(email_evidence),
         signup_origin=ORIGIN,
         sender=lambda config, message: messages.append(message),
     )
     app.include_router(router)
-    return TestClient(app, base_url=ORIGIN), identity, messages
+    return TestClient(app, base_url=ORIGIN), identity, messages, email_evidence
 
 
 def _form(*, accepted: bool) -> dict[str, str]:
@@ -92,8 +98,13 @@ def _token(message: EmailMessage) -> str:
     return unquote(match.group(1))
 
 
+def _count(database: Path, table: str) -> int:
+    with sqlite3.connect(database) as connection:
+        return int(connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+
 def test_signup_displays_privacy_and_requires_terms(tmp_path: Path) -> None:
-    client, identity, messages = _client(tmp_path)
+    client, identity, messages, _ = _client(tmp_path)
 
     page = client.get("/signup")
     refused = client.post(
@@ -115,7 +126,7 @@ def test_signup_displays_privacy_and_requires_terms(tmp_path: Path) -> None:
 
 
 def test_accepted_terms_are_persisted_and_linked_after_activation(tmp_path: Path) -> None:
-    client, identity, messages = _client(tmp_path)
+    client, identity, messages, _ = _client(tmp_path)
 
     requested = client.post(
         "/signup",
@@ -151,3 +162,30 @@ def test_accepted_terms_are_persisted_and_linked_after_activation(tmp_path: Path
     assert activated.activated_at is not None
     assert activated.tenant_id is not None
     assert activated.user_id is not None
+
+
+def test_smtp_failure_removes_pending_signup_and_legal_evidence(tmp_path: Path) -> None:
+    client, identity, _, email_evidence = _client(tmp_path)
+
+    def fail(config: SmtpConfig, message: EmailMessage) -> None:
+        raise OSError("smtp unavailable")
+
+    app = cast(FastAPI, client.app)
+    app.state.veridra_tenant_signup_delivery = TenantSignupEmailAdapter(
+        config=_smtp(),
+        store=IdentityEmailAttemptStore(email_evidence),
+        signup_origin=ORIGIN,
+        sender=fail,
+    )
+
+    response = client.post(
+        "/signup",
+        data=_form(accepted=True),
+        headers={"origin": ORIGIN},
+    )
+
+    assert response.status_code == 503
+    assert _count(identity, "tenant_signup_requests") == 0
+    assert SQLiteSignupLegalEvidenceStore(identity).latest_for_email(
+        "second@example.com"
+    ) is None

--- a/tests/test_signup_legal_web.py
+++ b/tests/test_signup_legal_web.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import re
+from email.message import EmailMessage
+from pathlib import Path
+from urllib.parse import unquote
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.email_delivery import EmailEncryption, SmtpConfig
+from veridra.identity_bootstrap import BOOTSTRAP_CONFIRMATION, SQLiteIdentityBootstrap
+from veridra.identity_email_delivery import IdentityEmailAttemptStore, TenantSignupEmailAdapter
+from veridra.runtime_config import RuntimeConfig, RuntimeEnvironment
+from veridra.runtime_legal import LegalLinks
+from veridra.signup_legal_evidence import SQLiteSignupLegalEvidenceStore
+from veridra.signup_web import router
+from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
+
+ORIGIN = "https://app.example.com"
+PASSWORD = "signup-correct-horse-battery"
+TERMS = "https://legal.example.com/terms-v1"
+PRIVACY = "https://legal.example.com/privacy-v1"
+
+
+def _runtime(identity: Path, tenants: Path) -> RuntimeConfig:
+    return RuntimeConfig(
+        environment=RuntimeEnvironment.test,
+        identity_database=identity,
+        tenant_data_root=tenants,
+        trusted_origin=ORIGIN,
+        allowed_hosts=("app.example.com",),
+        trusted_proxy_ips=(),
+        max_request_body_bytes=1_000_000,
+        bind_host="127.0.0.1",
+        bind_port=8000,
+    )
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Path, list[EmailMessage]]:
+    identity = tmp_path / "identity" / "identity.sqlite3"
+    tenants = tmp_path / "tenants"
+    SQLiteIdentityBootstrap(identity, tenant_data_root=tenants).create_first_owner(
+        tenant_slug="first-agency",
+        tenant_name="First agency",
+        owner_email="first@example.com",
+        owner_name="First Owner",
+        password="first-owner-password-123",
+        confirmation=BOOTSTRAP_CONFIRMATION,
+    )
+    messages: list[EmailMessage] = []
+    smtp = SmtpConfig(
+        host="smtp.example.test",
+        port=587,
+        encryption=EmailEncryption.starttls,
+        sender_email="security@example.com",
+        sender_name="Veridra",
+    )
+    app = FastAPI()
+    app.state.veridra_runtime_config = _runtime(identity, tenants)
+    app.state.veridra_identity_database = identity
+    app.state.veridra_identity_store = SQLiteIdentityRecordStore(identity)
+    app.state.veridra_tenant_data_root = tenants
+    app.state.veridra_legal_links = LegalLinks(privacy_url=PRIVACY, terms_url=TERMS)
+    app.state.veridra_tenant_signup_delivery = TenantSignupEmailAdapter(
+        config=smtp,
+        store=IdentityEmailAttemptStore(tmp_path / "email-evidence"),
+        signup_origin=ORIGIN,
+        sender=lambda config, message: messages.append(message),
+    )
+    app.include_router(router)
+    return TestClient(app, base_url=ORIGIN), identity, messages
+
+
+def _form(*, accepted: bool) -> dict[str, str]:
+    data = {
+        "tenant_name": "Second agency",
+        "tenant_slug": "second-agency",
+        "owner_name": "Second Owner",
+        "owner_email": "second@example.com",
+        "password": PASSWORD,
+        "password_confirm": PASSWORD,
+    }
+    if accepted:
+        data["terms_accepted"] = "yes"
+    return data
+
+
+def _token(message: EmailMessage) -> str:
+    match = re.search(r"/verify-signup\?token=([^\s]+)", message.get_content())
+    assert match is not None
+    return unquote(match.group(1))
+
+
+def test_signup_displays_privacy_and_requires_terms(tmp_path: Path) -> None:
+    client, identity, messages = _client(tmp_path)
+
+    page = client.get("/signup")
+    refused = client.post(
+        "/signup",
+        data=_form(accepted=False),
+        headers={"origin": ORIGIN},
+    )
+
+    assert page.status_code == 200
+    assert TERMS in page.text
+    assert PRIVACY in page.text
+    assert "terms_accepted" in page.text
+    assert refused.status_code == 400
+    assert "must agree to the Terms of Service" in refused.text
+    assert messages == []
+    assert SQLiteSignupLegalEvidenceStore(identity).latest_for_email(
+        "second@example.com"
+    ) is None
+
+
+def test_accepted_terms_are_persisted_and_linked_after_activation(tmp_path: Path) -> None:
+    client, identity, messages = _client(tmp_path)
+
+    requested = client.post(
+        "/signup",
+        data=_form(accepted=True),
+        headers={"origin": ORIGIN},
+    )
+
+    assert requested.status_code == 202
+    assert len(messages) == 1
+    token = _token(messages[0])
+    evidence = SQLiteSignupLegalEvidenceStore(identity).latest_for_email(
+        "second@example.com"
+    )
+    assert evidence is not None
+    assert evidence.terms_url == TERMS
+    assert evidence.privacy_url == PRIVACY
+    assert evidence.owner_name == "Second Owner"
+    assert evidence.activated_at is None
+    assert token not in evidence.token_hash
+
+    completed = client.post(
+        "/verify-signup",
+        data={"token": token},
+        headers={"origin": ORIGIN},
+        follow_redirects=False,
+    )
+
+    assert completed.status_code == 303
+    activated = SQLiteSignupLegalEvidenceStore(identity).latest_for_email(
+        "second@example.com"
+    )
+    assert activated is not None
+    assert activated.activated_at is not None
+    assert activated.tenant_id is not None
+    assert activated.user_id is not None


### PR DESCRIPTION
Adds a deployment-owned legal-document boundary to reusable public agency signup without inventing operator-specific legal text.

What changes:
- add `VERIDRA_TERMS_URL` and `VERIDRA_PRIVACY_URL` as paired HTTPS legal-link configuration;
- fail production startup closed when those links are absent or invalid;
- show the configured Privacy Notice at the point signup personal data are collected;
- require a separate explicit Terms-of-Service checkbox when legal links are configured;
- do not frame the Privacy Notice itself as consent;
- persist the exact Terms URL, Privacy URL, owner name/email and UTC acceptance time in the identity SQLite database;
- persist only a SHA-256 hash of the signup verification token in legal evidence;
- enrich the evidence with tenant ID, user ID and activation time after email verification;
- remove pending legal evidence when SMTP delivery fails and the pending signup is cancelled;
- keep development/test signup backward compatible when both legal URLs are omitted;
- document that the operator remains responsible for the actual reviewed legal documents and their legal sufficiency;
- add focused regression tests for production configuration, Terms refusal, durable evidence, activation linkage and SMTP cleanup.

This does not ship generic legal boilerplate or claim legal compliance based on UI mechanics alone.

Do not merge until exact-head full CI succeeds.