### PR TITLE
Expire abandoned signup legal evidence

### DIFF
--- a/docs/operations/signup-legal-links.md
+++ b/docs/operations/signup-legal-links.md
@@ -20,11 +20,15 @@ When legal links are configured, `/signup`:
 - does **not** describe the Privacy Notice itself as consent;
 - records the exact Terms URL, Privacy URL, owner name/email and UTC acceptance timestamp in the identity SQLite database;
 - stores only a SHA-256 hash of the signup verification token in legal evidence;
-- enriches the evidence with tenant ID, user ID and activation time after email verification;
-- removes pending legal evidence if SMTP delivery fails and the pending signup is cancelled.
+- gives pending, unverified legal evidence the same expiry as the signup verification token;
+- opportunistically prunes expired, unactivated evidence during later legal-evidence activity;
+- enriches activated evidence with tenant ID, user ID and activation time after email verification and retains that activated acceptance evidence;
+- removes pending legal evidence immediately if SMTP delivery fails and the pending signup is cancelled.
 
-The evidence table is `signup_legal_acceptances` and is part of the identity database, so it is included by the existing identity-database backup/restore contract.
+The evidence table is `signup_legal_acceptances` and is part of the identity database, so it is included by the existing identity-database backup/restore contract. Expiry pruning is activity-driven rather than a guarantee that an abandoned row is physically deleted at the exact expiry second; a deployment may also invoke normal application activity or future maintenance tooling to trigger pruning.
+
+Legacy evidence rows created before expiry tracking was introduced have no inferred expiry and are not deleted automatically because Veridra cannot safely reconstruct the historical token lifetime.
 
 ## Operator responsibility
 
-The configured documents must be reviewed for the actual operator, jurisdiction, processing activities, subprocessors, retention, contact details, billing terms and other applicable obligations. Veridra validates only the link and acceptance mechanics; it does not certify that the legal documents themselves are complete or legally sufficient.
+The configured documents must be reviewed for the actual operator, jurisdiction, processing activities, subprocessors, retention, contact details, billing terms and other applicable obligations. Veridra validates only the link, acceptance, evidence and retention mechanics; it does not certify that the legal documents themselves are complete or legally sufficient.

--- a/src/veridra/signup_legal_evidence.py
+++ b/src/veridra/signup_legal_evidence.py
@@ -20,6 +20,7 @@ class SignupLegalAcceptance:
     terms_url: str
     privacy_url: str
     accepted_at: datetime
+    expires_at: datetime | None
     activated_at: datetime | None
     tenant_id: str | None
     user_id: str | None
@@ -53,18 +54,51 @@ class SQLiteSignupLegalEvidenceStore:
                         terms_url TEXT NOT NULL,
                         privacy_url TEXT NOT NULL,
                         accepted_at TEXT NOT NULL,
+                        expires_at TEXT,
                         activated_at TEXT,
                         tenant_id TEXT,
                         user_id TEXT
                     )"""
                 )
+                columns = {
+                    str(row[1])
+                    for row in connection.execute(
+                        "PRAGMA table_info(signup_legal_acceptances)"
+                    ).fetchall()
+                }
+                if "expires_at" not in columns:
+                    connection.execute(
+                        "ALTER TABLE signup_legal_acceptances ADD COLUMN expires_at TEXT"
+                    )
                 connection.execute(
                     """CREATE INDEX IF NOT EXISTS signup_legal_acceptances_email_idx
                     ON signup_legal_acceptances(owner_email, accepted_at)"""
                 )
+                connection.execute(
+                    """CREATE INDEX IF NOT EXISTS signup_legal_acceptances_expiry_idx
+                    ON signup_legal_acceptances(expires_at, activated_at)"""
+                )
         except sqlite3.Error as exc:
             raise SignupLegalEvidenceError(
                 "Signup legal evidence store could not be initialized."
+            ) from exc
+
+    def prune_expired_pending(self, *, now: datetime | None = None) -> int:
+        checked_at = (now or datetime.now(UTC)).astimezone(UTC)
+        self.initialize()
+        try:
+            with self._connect() as connection:
+                deleted = connection.execute(
+                    """DELETE FROM signup_legal_acceptances
+                    WHERE activated_at IS NULL
+                    AND expires_at IS NOT NULL
+                    AND expires_at <= ?""",
+                    (checked_at.isoformat(),),
+                )
+                return deleted.rowcount
+        except sqlite3.Error as exc:
+            raise SignupLegalEvidenceError(
+                "Expired signup legal evidence could not be pruned."
             ) from exc
 
     def record_pending(
@@ -76,18 +110,24 @@ class SQLiteSignupLegalEvidenceStore:
         owner_name: str,
         terms_url: str,
         privacy_url: str,
+        expires_at: datetime,
         accepted_at: datetime | None = None,
     ) -> None:
         recorded_at = (accepted_at or datetime.now(UTC)).astimezone(UTC)
+        expiry = expires_at.astimezone(UTC)
+        if expiry <= recorded_at:
+            raise SignupLegalEvidenceError(
+                "Signup legal evidence expiry must follow acceptance."
+            )
         token_hash = self._token_hash(token)
-        self.initialize()
+        self.prune_expired_pending(now=recorded_at)
         try:
             with self._connect() as connection:
                 connection.execute(
                     """INSERT INTO signup_legal_acceptances
                     (token_hash, tenant_slug, owner_email, owner_name, terms_url,
-                     privacy_url, accepted_at, activated_at, tenant_id, user_id)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)""",
+                     privacy_url, accepted_at, expires_at, activated_at, tenant_id, user_id)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL)""",
                     (
                         token_hash,
                         tenant_slug,
@@ -96,6 +136,7 @@ class SQLiteSignupLegalEvidenceStore:
                         terms_url,
                         privacy_url,
                         recorded_at.isoformat(),
+                        expiry.isoformat(),
                     ),
                 )
         except sqlite3.Error as exc:
@@ -142,8 +183,13 @@ class SQLiteSignupLegalEvidenceStore:
                 "Signup legal acceptance could not be activated."
             ) from exc
 
-    def latest_for_email(self, owner_email: str) -> SignupLegalAcceptance | None:
-        self.initialize()
+    def latest_for_email(
+        self,
+        owner_email: str,
+        *,
+        now: datetime | None = None,
+    ) -> SignupLegalAcceptance | None:
+        self.prune_expired_pending(now=now)
         try:
             with self._connect() as connection:
                 row = connection.execute(
@@ -165,6 +211,11 @@ class SQLiteSignupLegalEvidenceStore:
             terms_url=row["terms_url"],
             privacy_url=row["privacy_url"],
             accepted_at=datetime.fromisoformat(row["accepted_at"]),
+            expires_at=(
+                datetime.fromisoformat(row["expires_at"])
+                if row["expires_at"] is not None
+                else None
+            ),
             activated_at=(
                 datetime.fromisoformat(row["activated_at"])
                 if row["activated_at"] is not None

--- a/src/veridra/signup_web.py
+++ b/src/veridra/signup_web.py
@@ -195,6 +195,7 @@ async def request_signup(request: Request) -> HTMLResponse:
                     owner_name=_one(values, "owner_name"),
                     terms_url=legal.terms_url,
                     privacy_url=legal.privacy_url,
+                    expires_at=issued.expires_at,
                 )
             except SignupLegalEvidenceError:
                 await run_in_threadpool(service.cancel, issued.token)

--- a/tests/test_signup_legal_evidence.py
+++ b/tests/test_signup_legal_evidence.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+import sqlite3
 
 from veridra.signup_legal_evidence import SQLiteSignupLegalEvidenceStore
 

--- a/tests/test_signup_legal_evidence.py
+++ b/tests/test_signup_legal_evidence.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from veridra.signup_legal_evidence import SQLiteSignupLegalEvidenceStore
+
+
+TOKEN = "t" * 48
+EMAIL = "owner@example.com"
+TERMS = "https://legal.example.com/terms-v1"
+PRIVACY = "https://legal.example.com/privacy-v1"
+
+
+def _record(
+    store: SQLiteSignupLegalEvidenceStore,
+    *,
+    accepted_at: datetime,
+    expires_at: datetime,
+) -> None:
+    store.record_pending(
+        token=TOKEN,
+        tenant_slug="agency",
+        owner_email=EMAIL,
+        owner_name="Owner",
+        terms_url=TERMS,
+        privacy_url=PRIVACY,
+        accepted_at=accepted_at,
+        expires_at=expires_at,
+    )
+
+
+def test_pending_evidence_expires_with_signup_token(tmp_path: Path) -> None:
+    store = SQLiteSignupLegalEvidenceStore(tmp_path / "identity.sqlite3")
+    accepted_at = datetime(2026, 8, 21, 10, 0, tzinfo=UTC)
+    expires_at = accepted_at + timedelta(minutes=30)
+    _record(store, accepted_at=accepted_at, expires_at=expires_at)
+
+    before_expiry = store.latest_for_email(
+        EMAIL,
+        now=accepted_at + timedelta(minutes=29),
+    )
+    after_expiry = store.latest_for_email(
+        EMAIL,
+        now=accepted_at + timedelta(minutes=31),
+    )
+
+    assert before_expiry is not None
+    assert before_expiry.expires_at == expires_at
+    assert after_expiry is None
+
+
+def test_activated_evidence_survives_signup_expiry(tmp_path: Path) -> None:
+    store = SQLiteSignupLegalEvidenceStore(tmp_path / "identity.sqlite3")
+    accepted_at = datetime(2026, 8, 21, 10, 0, tzinfo=UTC)
+    expires_at = accepted_at + timedelta(minutes=30)
+    _record(store, accepted_at=accepted_at, expires_at=expires_at)
+    activated_at = accepted_at + timedelta(minutes=5)
+
+    assert store.mark_activated_if_present(
+        token=TOKEN,
+        tenant_id="a" * 24,
+        user_id="b" * 24,
+        activated_at=activated_at,
+    )
+    store.prune_expired_pending(now=accepted_at + timedelta(hours=1))
+    evidence = store.latest_for_email(
+        EMAIL,
+        now=accepted_at + timedelta(hours=1),
+    )
+
+    assert evidence is not None
+    assert evidence.activated_at == activated_at
+    assert evidence.tenant_id == "a" * 24
+    assert evidence.user_id == "b" * 24
+
+
+def test_initialize_migrates_legacy_table_without_expiry(tmp_path: Path) -> None:
+    database = tmp_path / "identity.sqlite3"
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """CREATE TABLE signup_legal_acceptances (
+                token_hash TEXT PRIMARY KEY,
+                tenant_slug TEXT NOT NULL,
+                owner_email TEXT NOT NULL,
+                owner_name TEXT NOT NULL,
+                terms_url TEXT NOT NULL,
+                privacy_url TEXT NOT NULL,
+                accepted_at TEXT NOT NULL,
+                activated_at TEXT,
+                tenant_id TEXT,
+                user_id TEXT
+            )"""
+        )
+
+    SQLiteSignupLegalEvidenceStore(database).initialize()
+
+    with sqlite3.connect(database) as connection:
+        columns = {
+            str(row[1])
+            for row in connection.execute(
+                "PRAGMA table_info(signup_legal_acceptances)"
+            ).fetchall()
+        }
+    assert "expires_at" in columns

--- a/tests/test_signup_legal_evidence.py
+++ b/tests/test_signup_legal_evidence.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-import sqlite3
 
 from veridra.signup_legal_evidence import SQLiteSignupLegalEvidenceStore
-
 
 TOKEN = "t" * 48
 EMAIL = "owner@example.com"


### PR DESCRIPTION
Tightens the retention boundary for the legal evidence introduced in public agency signup.

What changes:
- store the exact signup verification expiry on pending legal acceptance evidence;
- prune only expired, unactivated legal-evidence rows;
- retain activated Terms acceptance evidence after the signup token expires;
- migrate existing `signup_legal_acceptances` tables by adding nullable `expires_at` without guessing historical expiries;
- trigger pruning opportunistically during later evidence reads/writes;
- pass the actual issued signup-token expiry from the web flow into the evidence store;
- document that pruning is activity-driven, not an exact-time background deletion guarantee;
- add regression coverage for pre-expiry visibility, post-expiry deletion, activated-evidence retention and legacy schema migration.

This does not delete legacy rows whose historical expiry cannot be reconstructed safely.

Do not merge until exact-head full CI succeeds.