### PR TITLE
Add production configuration preflight

### DIFF
--- a/docs/operations/production-preflight.md
+++ b/docs/operations/production-preflight.md
@@ -1,0 +1,23 @@
+# Production configuration preflight
+
+Run the read-only preflight before starting a production Veridra runtime:
+
+```text
+veridra-production-preflight
+```
+
+The command validates production runtime, legal-link and SMTP configuration. Stripe is optional by default: if it is absent, the result is a warning because a Free-plan launch can still operate. For a paid launch, require Stripe explicitly:
+
+```text
+veridra-production-preflight --require-stripe
+```
+
+Exit codes follow the operational-check convention:
+
+- `0` — required configuration is ready;
+- `1` — ready with a warning, such as optional Stripe billing being absent;
+- `2` — critical configuration failure; do not start the production runtime as configured.
+
+Output is compact JSON containing only component names, statuses and generic messages. It does not emit configured paths, origins, legal URLs, SMTP credentials, Stripe keys, webhook secrets or Price IDs. The preflight is read-only: it does not create directories, contact SMTP or Stripe, resolve DNS, obtain TLS certificates or provision infrastructure.
+
+A successful preflight proves configuration shape only. Deployment still requires provider-side resources such as compute, durable storage, DNS/TLS, SMTP account/domain setup, edge controls and—when paid launch is required—Stripe Products/Prices, Portal and webhook configuration. Run deployment-specific acceptance after those resources are connected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ veridra-subscription-apply = "veridra.subscription_authority_cli:main"
 veridra-backup = "veridra.backup_restore_cli:main"
 veridra-ops-check = "veridra.ops_check_cli:main"
 veridra-tenant-offboard = "veridra.tenant_offboarding_cli:main"
+veridra-production-preflight = "veridra.production_preflight_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/production_preflight.py
+++ b/src/veridra/production_preflight.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .email_delivery import EmailDeliveryError, SmtpConfig
+from .runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
+from .runtime_legal import LegalLinks
+from .stripe_billing import StripeBillingConfig, StripeBillingError
+
+
+class PreflightStatus(StrEnum):
+    ok = "ok"
+    warning = "warning"
+    critical = "critical"
+
+
+@dataclass(frozen=True)
+class PreflightCheck:
+    name: str
+    status: PreflightStatus
+    message: str
+
+
+@dataclass(frozen=True)
+class ProductionPreflightResult:
+    status: PreflightStatus
+    checks: tuple[PreflightCheck, ...]
+
+    @property
+    def ready(self) -> bool:
+        return self.status is not PreflightStatus.critical
+
+    @property
+    def exit_code(self) -> int:
+        return {
+            PreflightStatus.ok: 0,
+            PreflightStatus.warning: 1,
+            PreflightStatus.critical: 2,
+        }[self.status]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "ready": self.ready,
+            "status": self.status.value,
+            "checks": [
+                {
+                    "name": check.name,
+                    "status": check.status.value,
+                    "message": check.message,
+                }
+                for check in self.checks
+            ],
+        }
+
+
+def _overall(checks: list[PreflightCheck]) -> PreflightStatus:
+    if any(check.status is PreflightStatus.critical for check in checks):
+        return PreflightStatus.critical
+    if any(check.status is PreflightStatus.warning for check in checks):
+        return PreflightStatus.warning
+    return PreflightStatus.ok
+
+
+def run_production_preflight(*, require_stripe: bool = False) -> ProductionPreflightResult:
+    checks: list[PreflightCheck] = []
+    runtime: RuntimeConfig | None = None
+
+    try:
+        runtime = RuntimeConfig.from_environment()
+    except RuntimeConfigurationError:
+        checks.append(
+            PreflightCheck(
+                name="runtime",
+                status=PreflightStatus.critical,
+                message="Production runtime configuration is invalid or incomplete.",
+            )
+        )
+    else:
+        if runtime.environment is not RuntimeEnvironment.production:
+            checks.append(
+                PreflightCheck(
+                    name="runtime",
+                    status=PreflightStatus.critical,
+                    message="VERIDRA_ENV must be production for production preflight.",
+                )
+            )
+        else:
+            checks.append(
+                PreflightCheck(
+                    name="runtime",
+                    status=PreflightStatus.ok,
+                    message="Production runtime configuration is valid.",
+                )
+            )
+
+    try:
+        legal = LegalLinks.from_environment()
+    except RuntimeConfigurationError:
+        checks.append(
+            PreflightCheck(
+                name="legal",
+                status=PreflightStatus.critical,
+                message="Production legal-link configuration is invalid.",
+            )
+        )
+    else:
+        checks.append(
+            PreflightCheck(
+                name="legal",
+                status=(
+                    PreflightStatus.ok if legal is not None else PreflightStatus.critical
+                ),
+                message=(
+                    "Terms and Privacy URLs are configured."
+                    if legal is not None
+                    else "Terms and Privacy URLs are required for production signup."
+                ),
+            )
+        )
+
+    try:
+        smtp = SmtpConfig.from_environment()
+    except EmailDeliveryError:
+        checks.append(
+            PreflightCheck(
+                name="smtp",
+                status=PreflightStatus.critical,
+                message="SMTP configuration is invalid.",
+            )
+        )
+    else:
+        if smtp is None:
+            checks.append(
+                PreflightCheck(
+                    name="smtp",
+                    status=PreflightStatus.critical,
+                    message="SMTP delivery is required for production identity flows.",
+                )
+            )
+        elif smtp.username and smtp.password() is None:
+            checks.append(
+                PreflightCheck(
+                    name="smtp",
+                    status=PreflightStatus.critical,
+                    message="Configured SMTP authentication is missing its password secret.",
+                )
+            )
+        else:
+            checks.append(
+                PreflightCheck(
+                    name="smtp",
+                    status=PreflightStatus.ok,
+                    message="SMTP configuration is complete.",
+                )
+            )
+
+    try:
+        stripe = StripeBillingConfig.from_environment()
+    except StripeBillingError:
+        checks.append(
+            PreflightCheck(
+                name="stripe",
+                status=PreflightStatus.critical,
+                message="Stripe configuration is present but invalid or incomplete.",
+            )
+        )
+    else:
+        if stripe is None:
+            checks.append(
+                PreflightCheck(
+                    name="stripe",
+                    status=(
+                        PreflightStatus.critical
+                        if require_stripe
+                        else PreflightStatus.warning
+                    ),
+                    message=(
+                        "Stripe billing is required but not configured."
+                        if require_stripe
+                        else "Stripe billing is not configured; Free-plan launch remains possible."
+                    ),
+                )
+            )
+        elif runtime is not None and runtime.trusted_origin is not None and (
+            stripe.trusted_origin != runtime.trusted_origin.rstrip("/")
+        ):
+            checks.append(
+                PreflightCheck(
+                    name="stripe",
+                    status=PreflightStatus.critical,
+                    message="Stripe trusted origin does not match the runtime trusted origin.",
+                )
+            )
+        else:
+            checks.append(
+                PreflightCheck(
+                    name="stripe",
+                    status=PreflightStatus.ok,
+                    message="Stripe billing configuration is complete.",
+                )
+            )
+
+    return ProductionPreflightResult(status=_overall(checks), checks=tuple(checks))

--- a/src/veridra/production_preflight_cli.py
+++ b/src/veridra/production_preflight_cli.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from .production_preflight import run_production_preflight
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate Veridra production configuration without starting the runtime."
+    )
+    parser.add_argument(
+        "--require-stripe",
+        action="store_true",
+        help="Treat absent Stripe billing configuration as a critical failure.",
+    )
+    args = parser.parse_args()
+    result = run_production_preflight(require_stripe=args.require_stripe)
+    print(json.dumps(result.as_dict(), sort_keys=True, separators=(",", ":")))
+    raise SystemExit(result.exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_production_preflight.py
+++ b/tests/test_production_preflight.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from veridra.production_preflight import PreflightStatus, run_production_preflight
+
+
+def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    names = (
+        "VERIDRA_ENV",
+        "VERIDRA_IDENTITY_DB",
+        "VERIDRA_TENANT_DATA_ROOT",
+        "VERIDRA_TRUSTED_ORIGIN",
+        "VERIDRA_ALLOWED_HOSTS",
+        "VERIDRA_PRIVACY_URL",
+        "VERIDRA_TERMS_URL",
+        "VERIDRA_SMTP_HOST",
+        "VERIDRA_SMTP_SENDER",
+        "VERIDRA_SMTP_USERNAME",
+        "VERIDRA_SMTP_PASSWORD",
+        "VERIDRA_STRIPE_SECRET_KEY",
+        "VERIDRA_STRIPE_WEBHOOK_SECRET",
+        "VERIDRA_STRIPE_PRICE_SOLO",
+        "VERIDRA_STRIPE_PRICE_PROFESSIONAL",
+        "VERIDRA_STRIPE_PRICE_AGENCY",
+    )
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _valid_required(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear(monkeypatch)
+    monkeypatch.setenv("VERIDRA_ENV", "production")
+    monkeypatch.setenv(
+        "VERIDRA_IDENTITY_DB",
+        str((tmp_path / "identity" / "veridra.sqlite3").resolve()),
+    )
+    monkeypatch.setenv(
+        "VERIDRA_TENANT_DATA_ROOT",
+        str((tmp_path / "tenants").resolve()),
+    )
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", "https://app.example.com")
+    monkeypatch.setenv("VERIDRA_ALLOWED_HOSTS", "app.example.com")
+    monkeypatch.setenv("VERIDRA_PRIVACY_URL", "https://example.com/privacy")
+    monkeypatch.setenv("VERIDRA_TERMS_URL", "https://example.com/terms")
+    monkeypatch.setenv("VERIDRA_SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("VERIDRA_SMTP_SENDER", "security@example.com")
+
+
+def _enable_stripe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VERIDRA_STRIPE_SECRET_KEY", "sk_test_preflight")
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET", "whsec_preflight")
+    monkeypatch.setenv("VERIDRA_STRIPE_PRICE_SOLO", "price_solo")
+    monkeypatch.setenv("VERIDRA_STRIPE_PRICE_PROFESSIONAL", "price_professional")
+    monkeypatch.setenv("VERIDRA_STRIPE_PRICE_AGENCY", "price_agency")
+
+
+def test_invalid_production_configuration_is_critical(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear(monkeypatch)
+
+    result = run_production_preflight()
+
+    assert result.status is PreflightStatus.critical
+    assert result.exit_code == 2
+    assert not result.ready
+
+
+def test_valid_required_configuration_is_free_launch_ready_with_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _valid_required(monkeypatch, tmp_path)
+
+    result = run_production_preflight()
+
+    assert result.status is PreflightStatus.warning
+    assert result.exit_code == 1
+    assert result.ready
+    checks = {check.name: check.status for check in result.checks}
+    assert checks == {
+        "runtime": PreflightStatus.ok,
+        "legal": PreflightStatus.ok,
+        "smtp": PreflightStatus.ok,
+        "stripe": PreflightStatus.warning,
+    }
+
+
+def test_require_stripe_makes_absent_billing_critical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _valid_required(monkeypatch, tmp_path)
+
+    result = run_production_preflight(require_stripe=True)
+
+    assert result.status is PreflightStatus.critical
+    assert result.exit_code == 2
+    assert not result.ready
+
+
+def test_complete_paid_launch_configuration_is_ready_and_secret_free(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _valid_required(monkeypatch, tmp_path)
+    _enable_stripe(monkeypatch)
+
+    result = run_production_preflight(require_stripe=True)
+    payload = json.dumps(result.as_dict(), sort_keys=True)
+
+    assert result.status is PreflightStatus.ok
+    assert result.exit_code == 0
+    assert result.ready
+    assert all(check.status is PreflightStatus.ok for check in result.checks)
+    assert "sk_test_preflight" not in payload
+    assert "whsec_preflight" not in payload
+    assert "price_agency" not in payload
+    assert "app.example.com" not in payload


### PR DESCRIPTION
Adds a provider-neutral, read-only production configuration validator for deployment go/no-go checks.

What changes:
- add `veridra-production-preflight` as a machine-readable CLI;
- validate production runtime configuration without creating directories or starting the app;
- validate required Terms/Privacy link configuration;
- validate SMTP configuration and required password-secret presence when SMTP auth is enabled;
- validate Stripe configuration when present and report absent Stripe as a warning for Free-plan launch;
- add `--require-stripe` so paid launch treats missing Stripe as critical;
- return exit 0 ready, 1 warning, 2 critical, matching the operational-check convention;
- emit only component names, statuses and generic messages, never paths, origins, URLs, credentials, keys, webhook secrets or Price IDs;
- perform no network calls and no provider provisioning;
- add regression coverage for invalid config, Free-plan readiness, paid-launch Stripe requirement, complete paid config and output redaction;
- document the boundary between configuration-shape validation and real provider/deployment acceptance.

This does not choose or provision a hosting, DNS, SMTP or Stripe provider.

Do not merge until exact-head full CI succeeds.