### PR TITLE
Harden billing, quotas, signup and outbound delivery

### DIFF
--- a/src/veridra/assessment_project_conversion_api.py
+++ b/src/veridra/assessment_project_conversion_api.py
@@ -11,10 +11,15 @@ from .crawl_profiles import CrawlProfileName
 from .identity_tenancy import RequestIdentity, TenantCapability
 from .project_store import ClientProject
 from .request_security import require_request_capability
-from .tenant_entitlements import require_tenant_project_capacity
+from .tenant_entitlements import tenant_workspace_active
 from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
-from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+from .tenant_project_store import (
+    TenantProjectCapacityError,
+    TenantProjectStore,
+    TenantProjectStoreError,
+)
 from .tenant_workspace_policy import TenantWorkspacePolicy
+from .workspace_policy import PLAN_CATALOGUE
 
 ProjectManager = Annotated[
     RequestIdentity,
@@ -52,11 +57,6 @@ def convert_assessment(
     root = _root(request)
     projects = TenantProjectStore(root)
     history = TenantHistoryStore(root)
-    require_tenant_project_capacity(
-        TenantWorkspacePolicy(root),
-        identity,
-        len(projects.list(identity)),
-    )
     project = ClientProject.build(
         name=payload.project_name,
         target_url=str(payload.assessment.target),
@@ -64,8 +64,22 @@ def convert_assessment(
         profile_id=payload.profile_id,
         crawl_profile=payload.crawl_profile,
     )
+    policy = TenantWorkspacePolicy(root)
     try:
-        project_id = projects.save(identity, project)
+        if tenant_workspace_active(policy, identity):
+            entitlement = PLAN_CATALOGUE[policy.load(identity).plan]
+            project_id = projects.save_with_capacity(
+                identity,
+                project,
+                max_projects=entitlement.max_projects,
+            )
+        else:
+            project_id = projects.save(identity, project)
+    except TenantProjectCapacityError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail="The active plan project allowance is exhausted.",
+        ) from exc
     except TenantProjectStoreError as exc:
         raise HTTPException(status_code=404, detail="Report profile not found.") from exc
     try:

--- a/src/veridra/atomic_fs_lock.py
+++ b/src/veridra/atomic_fs_lock.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import shutil
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+
+class AtomicFileLockError(RuntimeError):
+    pass
+
+
+@contextmanager
+def exclusive_directory_lock(
+    path: Path,
+    *,
+    timeout_seconds: float = 2.0,
+    stale_after_seconds: float = 30.0,
+) -> Iterator[None]:
+    if timeout_seconds <= 0 or stale_after_seconds <= 0:
+        raise ValueError("Filesystem lock timing values must be positive.")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout_seconds
+    acquired = False
+    while not acquired:
+        try:
+            path.mkdir()
+            acquired = True
+        except FileExistsError:
+            try:
+                age = time.time() - path.stat().st_mtime
+                if age > stale_after_seconds:
+                    shutil.rmtree(path)
+                    continue
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise AtomicFileLockError("Filesystem lock state could not be inspected.") from exc
+            if time.monotonic() >= deadline:
+                raise AtomicFileLockError("Filesystem lock could not be acquired.")
+            time.sleep(0.01)
+        except OSError as exc:
+            raise AtomicFileLockError("Filesystem lock could not be acquired.") from exc
+    try:
+        yield
+    finally:
+        if acquired:
+            try:
+                shutil.rmtree(path)
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                raise AtomicFileLockError("Filesystem lock could not be released.") from exc

--- a/src/veridra/atomic_fs_lock.py
+++ b/src/veridra/atomic_fs_lock.py
@@ -38,7 +38,7 @@ def exclusive_directory_lock(
             except OSError as exc:
                 raise AtomicFileLockError("Filesystem lock state could not be inspected.") from exc
             if time.monotonic() >= deadline:
-                raise AtomicFileLockError("Filesystem lock could not be acquired.")
+                raise AtomicFileLockError("Filesystem lock could not be acquired.") from None
             time.sleep(0.01)
         except OSError as exc:
             raise AtomicFileLockError("Filesystem lock could not be acquired.") from exc

--- a/src/veridra/lead_delivery.py
+++ b/src/veridra/lead_delivery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -99,14 +100,59 @@ def signature_header(payload: bytes, secret: str | None) -> str | None:
     return f"sha256={digest}"
 
 
-def validate_webhook_destination(url: str) -> str:
+@dataclass(frozen=True)
+class ValidatedWebhookDestination:
+    url: str
+    hostname: str
+    public_ips: tuple[str, ...]
+
+
+def _validated_webhook_destination(url: str) -> ValidatedWebhookDestination:
     parsed = urlparse(url)
     if parsed.scheme != "https" or not parsed.hostname:
         raise UnsafeTargetError("Lead webhooks require an HTTPS URL with a hostname.")
     if parsed.username or parsed.password:
         raise UnsafeTargetError("Credentials in webhook URLs are not allowed.")
-    resolve_public_ips(parsed.hostname)
-    return parsed._replace(fragment="").geturl()
+    public_ips = tuple(resolve_public_ips(parsed.hostname))
+    if not public_ips:
+        raise UnsafeTargetError("Lead webhook hostname resolved to no public addresses.")
+    return ValidatedWebhookDestination(
+        url=parsed._replace(fragment="").geturl(),
+        hostname=parsed.hostname,
+        public_ips=public_ips,
+    )
+
+
+def validate_webhook_destination(url: str) -> str:
+    return _validated_webhook_destination(url).url
+
+
+def _pin_webhook_request(
+    request: httpx.Request,
+    *,
+    hostname: str,
+    ip_address: str,
+) -> httpx.Request:
+    if request.url.host != hostname:
+        raise UnsafeTargetError("Webhook request hostname changed before delivery.")
+    request.extensions["sni_hostname"] = hostname
+    request.url = request.url.copy_with(host=ip_address)
+    return request
+
+
+class _PinnedWebhookTransport(httpx.AsyncHTTPTransport):
+    def __init__(self, *, hostname: str, ip_address: str) -> None:
+        super().__init__()
+        self.hostname = hostname
+        self.ip_address = ip_address
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        pinned = _pin_webhook_request(
+            request,
+            hostname=self.hostname,
+            ip_address=self.ip_address,
+        )
+        return await super().handle_async_request(pinned)
 
 
 async def deliver_lead_webhook(
@@ -130,7 +176,8 @@ async def deliver_lead_webhook(
     webhook_url = str(config.webhook_url)
 
     try:
-        destination = validate_webhook_destination(webhook_url)
+        validated = _validated_webhook_destination(webhook_url)
+        destination = validated.url
         headers = {
             "Content-Type": "application/json",
             "User-Agent": "Veridra-Lead-Webhook/2.9",
@@ -140,10 +187,14 @@ async def deliver_lead_webhook(
         signature = signature_header(payload, config.webhook_secret)
         if signature is not None:
             headers["X-Veridra-Signature"] = signature
+        active_transport = transport or _PinnedWebhookTransport(
+            hostname=validated.hostname,
+            ip_address=validated.public_ips[0],
+        )
         async with httpx.AsyncClient(
             timeout=_TIMEOUT_SECONDS,
             follow_redirects=False,
-            transport=transport,
+            transport=active_transport,
         ) as client:
             response = await client.post(destination, content=payload, headers=headers)
         if 200 <= response.status_code < 300:

--- a/src/veridra/signup_web.py
+++ b/src/veridra/signup_web.py
@@ -261,25 +261,16 @@ async def complete_signup(request: Request) -> HTMLResponse | RedirectResponse:
     values = _values(await request.body())
     try:
         token = _token(_one(values, "token"))
-        accepted = await run_in_threadpool(_service(request).accept, token=token)
+        accepted = await run_in_threadpool(
+            _service(request).accept,
+            token=token,
+            require_legal_evidence=_legal(request) is not None,
+        )
     except (TenantSignupError, ValueError):
         return _page(
             "Invalid signup",
             "<h1>Signup link is invalid, expired or no longer available</h1><p><a href='/signup'>Start again</a>.</p>",
             status_code=400,
-        )
-    try:
-        await run_in_threadpool(
-            _legal_evidence(request).mark_activated_if_present,
-            token=token,
-            tenant_id=accepted.tenant_id,
-            user_id=accepted.user_id,
-        )
-    except SignupLegalEvidenceError:
-        return _page(
-            "Signup evidence unavailable",
-            "<h1>Your workspace was created, but signup evidence could not be finalized</h1><p>Contact the operator before continuing.</p>",
-            status_code=503,
         )
     lifetime = timedelta(hours=8)
     issued = await run_in_threadpool(

--- a/src/veridra/stripe_billing.py
+++ b/src/veridra/stripe_billing.py
@@ -4,9 +4,10 @@ import hashlib
 import hmac
 import json
 import os
+import secrets
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import cast
@@ -174,6 +175,16 @@ class StripeTenantBinding(BaseModel):
     updated_at: datetime
 
 
+class StripeCheckoutReservation(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    tenant_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    plan: PlanName
+    idempotency_key: str = Field(min_length=24, max_length=255)
+    created_at: datetime
+    expires_at: datetime
+
+
 class StripeTenantBindingStore:
     def __init__(self, tenant_root: Path) -> None:
         self.tenant_root = tenant_root
@@ -214,6 +225,108 @@ class StripeTenantBindingStore:
         temporary_path.replace(path)
 
 
+class StripeCheckoutReservationStore:
+    def __init__(self, tenant_root: Path) -> None:
+        self.tenant_root = tenant_root
+
+    def _path(self, tenant_id: str) -> Path:
+        if len(tenant_id) != 24 or any(char not in "0123456789abcdef" for char in tenant_id):
+            raise StripeBillingError("Tenant identifier is invalid.")
+        return (
+            self.tenant_root
+            / tenant_id
+            / "workspace"
+            / "billing"
+            / "checkout-reservation.json"
+        )
+
+    def load(self, tenant_id: str) -> StripeCheckoutReservation | None:
+        path = self._path(tenant_id)
+        if not path.exists():
+            return None
+        try:
+            return StripeCheckoutReservation.model_validate_json(
+                path.read_text(encoding="utf-8")
+            )
+        except (OSError, ValueError) as exc:
+            raise StripeBillingError(
+                "Stripe Checkout reservation could not be read safely."
+            ) from exc
+
+    def reserve(
+        self,
+        *,
+        tenant_id: str,
+        plan: PlanName,
+        now: datetime | None = None,
+        lifetime: timedelta = timedelta(minutes=30),
+    ) -> StripeCheckoutReservation:
+        if lifetime <= timedelta(0):
+            raise ValueError("Stripe Checkout reservation lifetime must be positive.")
+        checked_at = (now or datetime.now(UTC)).astimezone(UTC)
+        path = self._path(tenant_id)
+        for _ in range(4):
+            current = self.load(tenant_id)
+            if current is not None:
+                if current.expires_at > checked_at:
+                    if current.plan is not plan:
+                        raise StripeBillingError(
+                            "A different Stripe Checkout is already in progress."
+                        )
+                    return current
+                try:
+                    path.unlink()
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    raise StripeBillingError(
+                        "Expired Stripe Checkout reservation could not be cleared."
+                    ) from exc
+
+            reservation = StripeCheckoutReservation(
+                tenant_id=tenant_id,
+                plan=plan,
+                idempotency_key=(
+                    f"veridra-checkout-{tenant_id}-{secrets.token_hex(16)}"
+                ),
+                created_at=checked_at,
+                expires_at=checked_at + lifetime,
+            )
+            content = json.dumps(
+                reservation.model_dump(mode="json"),
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                descriptor = os.open(
+                    path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+            except FileExistsError:
+                continue
+            except OSError as exc:
+                raise StripeBillingError(
+                    "Stripe Checkout reservation could not be created."
+                ) from exc
+            try:
+                os.write(descriptor, content)
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            return reservation
+        raise StripeBillingError("Stripe Checkout reservation could not be acquired.")
+
+    def clear(self, tenant_id: str) -> None:
+        try:
+            self._path(tenant_id).unlink(missing_ok=True)
+        except OSError as exc:
+            raise StripeBillingError(
+                "Stripe Checkout reservation could not be cleared."
+            ) from exc
+
+
 class StripeApiClient:
     def __init__(
         self,
@@ -232,7 +345,9 @@ class StripeApiClient:
         path: str,
         *,
         data: Mapping[str, str] | None = None,
+        idempotency_key: str | None = None,
     ) -> dict[str, object]:
+        headers = {"Idempotency-Key": idempotency_key} if idempotency_key else None
         try:
             with httpx.Client(
                 base_url=self.base_url,
@@ -240,7 +355,7 @@ class StripeApiClient:
                 timeout=15.0,
                 transport=self.transport,
             ) as client:
-                response = client.request(method, path, data=data)
+                response = client.request(method, path, data=data, headers=headers)
                 response.raise_for_status()
                 payload = response.json()
         except (httpx.HTTPError, ValueError) as exc:
@@ -255,6 +370,7 @@ class StripeApiClient:
         tenant_id: str,
         customer_email: str,
         plan: PlanName,
+        idempotency_key: str | None = None,
     ) -> StripeCheckoutSession:
         price_id = self.config.price_for_plan(plan)
         payload = self._request(
@@ -271,6 +387,7 @@ class StripeApiClient:
                 "subscription_data[metadata][veridra_tenant_id]": tenant_id,
                 "subscription_data[metadata][veridra_plan]": plan.value,
             },
+            idempotency_key=idempotency_key,
         )
         try:
             return StripeCheckoutSession.model_validate(payload)
@@ -361,6 +478,7 @@ class StripeSubscriptionAdapter:
         self.tenant_root = tenant_root
         self.client = client or StripeApiClient(config)
         self.bindings = StripeTenantBindingStore(tenant_root)
+        self.checkout_reservations = StripeCheckoutReservationStore(tenant_root)
         self.authority = SubscriptionAuthority(tenant_root)
 
     def parse_event(self, raw_body: bytes) -> StripeWebhookEvent:
@@ -469,6 +587,7 @@ class StripeSubscriptionAdapter:
                 updated_at=datetime.now(UTC),
             )
         )
+        self.checkout_reservations.clear(update.tenant_id)
         return StripeWebhookResult(
             True,
             result.applied if result is not None else False,

--- a/src/veridra/stripe_billing_web.py
+++ b/src/veridra/stripe_billing_web.py
@@ -99,6 +99,11 @@ def billing_page(request: Request, checkout: str = "") -> HTMLResponse:
         raise HTTPException(status_code=404, detail="Tenant workspace was not found.")
     workspace = workspace_store.load()
     binding = runtime.adapter.bindings.load(identity.tenant_id)
+    if binding is not None or checkout == "cancelled":
+        try:
+            runtime.adapter.checkout_reservations.clear(identity.tenant_id)
+        except StripeBillingError as exc:
+            raise HTTPException(status_code=503, detail="Billing state is unavailable.") from exc
     notice = ""
     if checkout == "success":
         notice = "<p class='notice'>Checkout completed. Stripe is reconciling the subscription; this page reflects only webhook-confirmed entitlement state.</p>"
@@ -135,10 +140,21 @@ def start_checkout(plan: PlanName, request: Request) -> RedirectResponse:
             detail="An existing Stripe subscription must be managed through the Billing Portal.",
         )
     try:
+        reservation = runtime.adapter.checkout_reservations.reserve(
+            tenant_id=identity.tenant_id,
+            plan=plan,
+        )
+    except StripeBillingError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="Another Stripe Checkout is already in progress for this workspace.",
+        ) from exc
+    try:
         session = runtime.client.create_checkout(
             tenant_id=identity.tenant_id,
             customer_email=_user_email(request, identity.user_id),
             plan=plan,
+            idempotency_key=reservation.idempotency_key,
         )
         destination = _stripe_redirect(session.url, host="checkout.stripe.com")
     except StripeBillingError as exc:

--- a/src/veridra/tenant_entitlements.py
+++ b/src/veridra/tenant_entitlements.py
@@ -13,8 +13,8 @@ from .workspace_policy import (
     UsageKind,
     UsageLedger,
     WorkspaceConfig,
+    WorkspacePolicyError,
     WorkspaceStore,
-    quota_decision,
 )
 
 
@@ -89,14 +89,14 @@ def reserve_tenant_usage(
     if not tenant_workspace_active(policy, identity):
         return
     workspace = policy.load(identity)
-    decision = quota_decision(
-        workspace,
-        policy.usage_ledger(identity),
-        kind,
-        requested=quantity,
-    )
-    if not decision.allowed:
-        raise HTTPException(status_code=429, detail=decision.reason)
+    try:
+        policy.usage_ledger(identity).reserve(
+            workspace,
+            kind,
+            quantity=quantity,
+        )
+    except WorkspacePolicyError as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from exc
 
 
 def record_tenant_usage(
@@ -167,9 +167,10 @@ def reserve_bound_tenant_usage(
     if not workspace_store.path.exists():
         return
     workspace = workspace_store.load()
-    decision = quota_decision(workspace, ledger, kind, requested=quantity)
-    if not decision.allowed:
-        raise HTTPException(status_code=429, detail=decision.reason)
+    try:
+        ledger.reserve(workspace, kind, quantity=quantity)
+    except WorkspacePolicyError as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from exc
 
 
 def record_bound_tenant_usage(

--- a/src/veridra/tenant_project_store.py
+++ b/src/veridra/tenant_project_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from .atomic_fs_lock import AtomicFileLockError, exclusive_directory_lock
 from .identity_tenancy import (
     RequestIdentity,
     TenantCapability,
@@ -11,10 +12,20 @@ from .identity_tenancy import (
     require_tenant_scope,
 )
 from .profile_store import ProfileStore, ProfileStoreError
-from .project_store import ClientProject, ProjectEntry, ProjectStore, ProjectStoreError
+from .project_store import (
+    ClientProject,
+    ProjectEntry,
+    ProjectStore,
+    ProjectStoreError,
+    project_id,
+)
 
 
 class TenantProjectStoreError(RuntimeError):
+    pass
+
+
+class TenantProjectCapacityError(TenantProjectStoreError):
     pass
 
 
@@ -63,6 +74,33 @@ class TenantProjectStore:
         require_tenant_capability(identity, TenantCapability.manage_projects)
         self._require_profile(identity, project)
         return self._store(identity).save(project)
+
+    def save_with_capacity(
+        self,
+        identity: RequestIdentity,
+        project: ClientProject,
+        *,
+        max_projects: int,
+    ) -> str:
+        if max_projects < 1:
+            raise ValueError("Project capacity must be at least one.")
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+        self._require_profile(identity, project)
+        store = self._store(identity)
+        lock_path = self.root / identity.tenant_id / ".project-capacity-lock"
+        try:
+            with exclusive_directory_lock(lock_path):
+                entries = store.list()
+                target_id = project_id(project)
+                if target_id not in {entry.id for entry in entries} and len(entries) >= max_projects:
+                    raise TenantProjectCapacityError(
+                        "The active plan project allowance is exhausted."
+                    )
+                return store.save(project)
+        except AtomicFileLockError as exc:
+            raise TenantProjectStoreError(
+                "Project-capacity lock could not be acquired."
+            ) from exc
 
     def load(self, identity: RequestIdentity, target: TenantObjectRef) -> ClientProject:
         require_tenant_scope(identity, target)

--- a/src/veridra/tenant_project_store.py
+++ b/src/veridra/tenant_project_store.py
@@ -92,7 +92,8 @@ class TenantProjectStore:
             with exclusive_directory_lock(lock_path):
                 entries = store.list()
                 target_id = project_id(project)
-                if target_id not in {entry.id for entry in entries} and len(entries) >= max_projects:
+                target_is_new = target_id not in {entry.id for entry in entries}
+                if target_is_new and len(entries) >= max_projects:
                     raise TenantProjectCapacityError(
                         "The active plan project allowance is exhausted."
                     )

--- a/src/veridra/tenant_signup.py
+++ b/src/veridra/tenant_signup.py
@@ -98,6 +98,16 @@ class SQLiteTenantSignupService:
     def _email_hash(email: str) -> str:
         return hashlib.sha256(email.encode("utf-8")).hexdigest()
 
+    @staticmethod
+    def _table_exists(connection: sqlite3.Connection, table: str) -> bool:
+        return (
+            connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                (table,),
+            ).fetchone()
+            is not None
+        )
+
     def _reserve_attempt(
         self,
         *,
@@ -254,6 +264,7 @@ class SQLiteTenantSignupService:
         *,
         token: str,
         now: datetime | None = None,
+        require_legal_evidence: bool = False,
     ) -> AcceptedTenantSignup:
         accepted_at = (now or datetime.now(UTC)).astimezone(UTC)
         token_hash = self._token_hash(token)
@@ -268,6 +279,22 @@ class SQLiteTenantSignupService:
             ).fetchone()
             if row is None or datetime.fromisoformat(row["expires_at"]) <= accepted_at:
                 raise TenantSignupError("Signup verification token is invalid or expired.")
+            if require_legal_evidence:
+                if not self._table_exists(connection, "signup_legal_acceptances"):
+                    raise TenantSignupError("Signup legal acceptance is unavailable.")
+                legal = connection.execute(
+                    """SELECT expires_at, activated_at FROM signup_legal_acceptances
+                    WHERE token_hash = ?""",
+                    (token_hash,),
+                ).fetchone()
+                if (
+                    legal is None
+                    or legal["activated_at"] is not None
+                    or legal["expires_at"] is None
+                    or datetime.fromisoformat(legal["expires_at"]) <= accepted_at
+                ):
+                    raise TenantSignupError("Signup legal acceptance is unavailable.")
+
             tenant = Tenant.build(
                 slug=row["tenant_slug"],
                 display_name=row["tenant_name"],
@@ -301,7 +328,19 @@ class SQLiteTenantSignupService:
             ).fetchone() is not None:
                 raise TenantSignupError("Signup verification token is no longer available.")
 
-            workspace_store = WorkspaceStore(self.tenant_data_root / tenant.id / "workspace")
+            tenant_directory = self.tenant_data_root / tenant.id
+            if tenant_directory.exists():
+                try:
+                    if any(tenant_directory.iterdir()):
+                        raise TenantSignupError(
+                            "Workspace durable state already exists for this signup slug."
+                        )
+                except OSError as exc:
+                    raise TenantSignupError(
+                        "Workspace durable state could not be validated safely."
+                    ) from exc
+
+            workspace_store = WorkspaceStore(tenant_directory / "workspace")
             workspace_path = workspace_store.path
             workspace_store.save(
                 WorkspaceConfig(display_name=tenant.display_name, plan=PlanName.free)
@@ -345,6 +384,22 @@ class SQLiteTenantSignupService:
                 VALUES (?, ?, ?)""",
                 (user.id, row["password_hash"], accepted_at.isoformat()),
             )
+            if require_legal_evidence:
+                updated = connection.execute(
+                    """UPDATE signup_legal_acceptances
+                    SET activated_at = ?, tenant_id = ?, user_id = ?
+                    WHERE token_hash = ? AND activated_at IS NULL
+                    AND expires_at IS NOT NULL AND expires_at > ?""",
+                    (
+                        accepted_at.isoformat(),
+                        tenant.id,
+                        user.id,
+                        token_hash,
+                        accepted_at.isoformat(),
+                    ),
+                )
+                if updated.rowcount != 1:
+                    raise TenantSignupError("Signup legal acceptance changed concurrently.")
             deleted = connection.execute(
                 "DELETE FROM tenant_signup_requests WHERE token_hash = ?",
                 (token_hash,),

--- a/src/veridra/workspace_policy.py
+++ b/src/veridra/workspace_policy.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import secrets
 from collections import Counter
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from .atomic_fs_lock import AtomicFileLockError, exclusive_directory_lock
 
 
 class WorkspacePolicyError(RuntimeError):
@@ -142,6 +145,15 @@ class UsageEvent(BaseModel):
     note: str = Field(default="", max_length=240)
 
 
+class UsageReservation(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    kind: UsageKind
+    quantity: int = Field(default=1, ge=1, le=2_000_000)
+    reserved_at: datetime
+    expires_at: datetime
+
+
 class UsagePeriod(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -208,8 +220,54 @@ class WorkspaceStore:
 
 class UsageLedger:
     def __init__(self, directory: Path | None = None) -> None:
-        root = directory or default_workspace_directory()
-        self.directory = root / "usage"
+        self.root = directory or default_workspace_directory()
+        self.directory = self.root / "usage"
+        self.reservation_directory = self.root / "usage-reservations"
+        self.lock_path = self.root / ".usage-lock"
+
+    def _reservation_entries(
+        self,
+        *,
+        period: UsagePeriod | None = None,
+        now: datetime | None = None,
+    ) -> list[tuple[str, UsageReservation]]:
+        if not self.reservation_directory.exists():
+            return []
+        checked_at = (now or datetime.now(UTC)).astimezone(UTC)
+        entries: list[tuple[str, UsageReservation]] = []
+        for path in sorted(self.reservation_directory.glob("*.json")):
+            try:
+                reservation = UsageReservation.model_validate_json(
+                    path.read_text(encoding="utf-8")
+                )
+            except (OSError, ValueError):
+                continue
+            reserved_at = reservation.reserved_at.astimezone(UTC)
+            if reservation.expires_at.astimezone(UTC) <= checked_at:
+                continue
+            if period is None or period.starts_at <= reserved_at < period.ends_at:
+                entries.append((path.stem, reservation))
+        return sorted(entries, key=lambda item: (item[1].reserved_at, item[0]))
+
+    def _prune_expired_reservations(self, *, now: datetime) -> None:
+        if not self.reservation_directory.exists():
+            return
+        for path in self.reservation_directory.glob("*.json"):
+            try:
+                reservation = UsageReservation.model_validate_json(
+                    path.read_text(encoding="utf-8")
+                )
+            except (OSError, ValueError):
+                continue
+            if reservation.expires_at.astimezone(UTC) <= now:
+                path.unlink(missing_ok=True)
+
+    def _consume_reservation(self, event: UsageEvent, *, now: datetime) -> None:
+        self._prune_expired_reservations(now=now)
+        for identifier, reservation in self._reservation_entries(now=now):
+            if reservation.kind is event.kind and reservation.quantity == event.quantity:
+                (self.reservation_directory / f"{identifier}.json").unlink(missing_ok=True)
+                return
 
     def record(self, event: UsageEvent) -> str:
         content = json.dumps(
@@ -220,9 +278,66 @@ class UsageLedger:
         ).encode("utf-8")
         identifier = hashlib.sha256(content).hexdigest()[:24]
         destination = self.directory / f"{identifier}.json"
-        if not destination.exists():
-            _atomic_write(destination, content)
+        try:
+            with exclusive_directory_lock(self.lock_path):
+                created = not destination.exists()
+                if created:
+                    _atomic_write(destination, content)
+                    self._consume_reservation(
+                        event,
+                        now=event.occurred_at.astimezone(UTC),
+                    )
+        except AtomicFileLockError as exc:
+            raise WorkspacePolicyError("Usage ledger lock could not be acquired.") from exc
         return identifier
+
+    def reserve(
+        self,
+        workspace: WorkspaceConfig,
+        kind: UsageKind,
+        *,
+        quantity: int = 1,
+        now: datetime | None = None,
+        lifetime: timedelta = timedelta(hours=1),
+    ) -> str:
+        if quantity < 1:
+            raise ValueError("Requested usage must be at least one.")
+        if lifetime <= timedelta(0):
+            raise ValueError("Usage reservation lifetime must be positive.")
+        checked_at = (now or datetime.now(UTC)).astimezone(UTC)
+        try:
+            with exclusive_directory_lock(self.lock_path):
+                self._prune_expired_reservations(now=checked_at)
+                decision = quota_decision(
+                    workspace,
+                    self,
+                    kind,
+                    requested=quantity,
+                    now=checked_at,
+                )
+                if not decision.allowed:
+                    raise WorkspacePolicyError(decision.reason)
+                if decision.limit is None:
+                    return ""
+                identifier = secrets.token_hex(12)
+                reservation = UsageReservation(
+                    kind=kind,
+                    quantity=quantity,
+                    reserved_at=checked_at,
+                    expires_at=checked_at + lifetime,
+                )
+                content = json.dumps(
+                    reservation.model_dump(mode="json"),
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                _atomic_write(
+                    self.reservation_directory / f"{identifier}.json",
+                    content,
+                )
+                return identifier
+        except AtomicFileLockError as exc:
+            raise WorkspacePolicyError("Usage reservation lock could not be acquired.") from exc
 
     def list(self, *, period: UsagePeriod | None = None) -> list[tuple[str, UsageEvent]]:
         if not self.directory.exists():
@@ -242,6 +357,17 @@ class UsageLedger:
         counter = Counter[UsageKind]()
         for _, event in self.list(period=period):
             counter[event.kind] += event.quantity
+        return dict(counter)
+
+    def effective_totals(
+        self,
+        period: UsagePeriod,
+        *,
+        now: datetime | None = None,
+    ) -> dict[UsageKind, int]:
+        counter = Counter[UsageKind](self.totals(period))
+        for _, reservation in self._reservation_entries(period=period, now=now):
+            counter[reservation.kind] += reservation.quantity
         return dict(counter)
 
 
@@ -286,7 +412,7 @@ def quota_decision(
     entitlement = PLAN_CATALOGUE[workspace.plan]
     limit = entitlement.limit_for(kind)
     period = usage_period(workspace, now=now)
-    used = ledger.totals(period).get(kind, 0)
+    used = ledger.effective_totals(period, now=now).get(kind, 0)
     if limit is None:
         return QuotaDecision(
             allowed=True,

--- a/tests/test_lead_delivery.py
+++ b/tests/test_lead_delivery.py
@@ -12,6 +12,7 @@ from veridra.core import Assessment, UnsafeTargetError, demo_assessment
 from veridra.lead_delivery import (
     DeliveryStatus,
     LeadDeliveryStore,
+    _pin_webhook_request,
     build_lead_payload,
     deliver_lead_webhook,
     signature_header,
@@ -73,6 +74,20 @@ def test_destination_requires_https_and_public_resolution(
         validate_webhook_destination("http://hooks.example.test/path")
     with pytest.raises(UnsafeTargetError):
         validate_webhook_destination("https://user:pass@hooks.example.test/path")
+
+
+def test_webhook_request_pins_ip_but_preserves_host_and_tls_name() -> None:
+    request = httpx.Request("POST", "https://hooks.example.test/veridra")
+
+    pinned = _pin_webhook_request(
+        request,
+        hostname="hooks.example.test",
+        ip_address="203.0.113.10",
+    )
+
+    assert pinned.url.host == "203.0.113.10"
+    assert pinned.headers["host"] == "hooks.example.test"
+    assert pinned.extensions["sni_hostname"] == "hooks.example.test"
 
 
 @pytest.mark.asyncio

--- a/tests/test_signup_web.py
+++ b/tests/test_signup_web.py
@@ -17,7 +17,9 @@ from veridra.identity_email_delivery import (
     IdentityEmailKind,
     TenantSignupEmailAdapter,
 )
+from veridra.identity_tenancy import Tenant
 from veridra.runtime_config import RuntimeConfig, RuntimeEnvironment
+from veridra.runtime_legal import LegalLinks
 from veridra.signup_web import router
 from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
 from veridra.workspace_policy import PlanName, WorkspaceStore
@@ -159,6 +161,63 @@ def test_second_agency_can_signup_only_after_email_confirmation(tmp_path: Path) 
     assert workspace.plan is PlanName.free
     assert _count(identity, "tenant_signup_requests") == 0
     assert client.get(f"/verify-signup?token={token}").status_code == 400
+
+
+def test_legal_signup_fails_closed_when_evidence_disappears(tmp_path: Path) -> None:
+    client, identity, _, messages, _ = _client(tmp_path)
+    app = cast(FastAPI, client.app)
+    app.state.veridra_legal_links = LegalLinks(
+        privacy_url="https://legal.example.com/privacy-v1",
+        terms_url="https://legal.example.com/terms-v1",
+    )
+    form = _form()
+    form["terms_accepted"] = "yes"
+
+    requested = client.post("/signup", data=form, headers={"origin": ORIGIN})
+    assert requested.status_code == 202
+    token = _token(messages[-1])
+    with sqlite3.connect(identity) as connection:
+        connection.execute("DELETE FROM signup_legal_acceptances")
+
+    completed = client.post(
+        "/verify-signup",
+        data={"token": token},
+        headers={"origin": ORIGIN},
+        follow_redirects=False,
+    )
+
+    assert completed.status_code == 400
+    assert _count(identity, "tenants") == 1
+    assert _count(identity, "users") == 1
+    assert _count(identity, "tenant_signup_requests") == 1
+
+
+def test_signup_rejects_nonempty_orphan_tenant_state_without_deleting_it(
+    tmp_path: Path,
+) -> None:
+    client, identity, tenants, messages, _ = _client(tmp_path)
+    requested = client.post("/signup", data=_form(), headers={"origin": ORIGIN})
+    assert requested.status_code == 202
+    token = _token(messages[-1])
+    tenant_id = Tenant.build(
+        slug="second-agency",
+        display_name="Second agency",
+    ).id
+    marker = tenants / tenant_id / "projects" / "orphan.json"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("preserve", encoding="utf-8")
+
+    completed = client.post(
+        "/verify-signup",
+        data={"token": token},
+        headers={"origin": ORIGIN},
+        follow_redirects=False,
+    )
+
+    assert completed.status_code == 400
+    assert _count(identity, "tenants") == 1
+    assert marker.read_text(encoding="utf-8") == "preserve"
+    assert not (tenants / tenant_id / "workspace" / "workspace.json").exists()
 
 
 def test_existing_email_is_non_enumerating_and_sends_no_verification(tmp_path: Path) -> None:

--- a/tests/test_stripe_billing.py
+++ b/tests/test_stripe_billing.py
@@ -14,6 +14,7 @@ from veridra.stripe_billing import (
     StripeApiClient,
     StripeBillingConfig,
     StripeBillingError,
+    StripeCheckoutReservationStore,
     StripeSubscriptionAdapter,
     StripeTenantBinding,
     verify_stripe_signature,
@@ -116,13 +117,14 @@ def test_stripe_signature_verifies_raw_body_and_rejects_tampering() -> None:
         )
 
 
-def test_checkout_uses_server_price_and_tenant_subscription_metadata() -> None:
+def test_checkout_uses_server_price_tenant_metadata_and_idempotency() -> None:
     seen: dict[str, str] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/v1/checkout/sessions"
         form = parse_qs(request.content.decode())
         seen.update({key: values[0] for key, values in form.items()})
+        seen["idempotency"] = request.headers["Idempotency-Key"]
         return httpx.Response(
             200,
             json={"id": "cs_test_1", "url": "https://checkout.stripe.com/c/pay/test"},
@@ -133,6 +135,7 @@ def test_checkout_uses_server_price_and_tenant_subscription_metadata() -> None:
         tenant_id=TENANT_ID,
         customer_email="owner@example.com",
         plan=PlanName.professional,
+        idempotency_key="checkout-idempotency-key",
     )
 
     assert session.id == "cs_test_1"
@@ -141,6 +144,18 @@ def test_checkout_uses_server_price_and_tenant_subscription_metadata() -> None:
     assert seen["client_reference_id"] == TENANT_ID
     assert seen["subscription_data[metadata][veridra_tenant_id]"] == TENANT_ID
     assert seen["subscription_data[metadata][veridra_plan]"] == "professional"
+    assert seen["idempotency"] == "checkout-idempotency-key"
+
+
+def test_checkout_reservation_reuses_key_and_blocks_plan_switch(tmp_path: Path) -> None:
+    store = StripeCheckoutReservationStore(tmp_path)
+
+    first = store.reserve(tenant_id=TENANT_ID, plan=PlanName.professional, now=NOW)
+    repeated = store.reserve(tenant_id=TENANT_ID, plan=PlanName.professional, now=NOW)
+
+    assert repeated.idempotency_key == first.idempotency_key
+    with pytest.raises(StripeBillingError, match="different Stripe Checkout"):
+        store.reserve(tenant_id=TENANT_ID, plan=PlanName.agency, now=NOW)
 
 
 def test_adapter_retrieves_current_subscription_and_projects_authoritative_state(
@@ -154,6 +169,11 @@ def test_adapter_retrieves_current_subscription_and_projects_authoritative_state
 
     client = StripeApiClient(_config(), transport=httpx.MockTransport(handler))
     adapter = StripeSubscriptionAdapter(config=_config(), tenant_root=tmp_path, client=client)
+    adapter.checkout_reservations.reserve(
+        tenant_id=TENANT_ID,
+        plan=PlanName.agency,
+        now=NOW,
+    )
     event = adapter.parse_event(
         json.dumps(
             _event(
@@ -175,6 +195,7 @@ def test_adapter_retrieves_current_subscription_and_projects_authoritative_state
     assert binding is not None
     assert binding.customer_id == "cus_current"
     assert binding.subscription_id == "sub_current"
+    assert adapter.checkout_reservations.load(TENANT_ID) is None
 
 
 def test_delayed_webhook_cannot_roll_back_newer_current_stripe_state(tmp_path: Path) -> None:

--- a/tests/test_workspace_policy.py
+++ b/tests/test_workspace_policy.py
@@ -107,6 +107,37 @@ def test_quota_decision_and_exhaustion(tmp_path: Path) -> None:
         raise AssertionError("Expected quota enforcement to reject the fourth free audit.")
 
 
+def test_reservations_prevent_overcommit_and_are_consumed_by_usage(tmp_path: Path) -> None:
+    ledger = UsageLedger(tmp_path)
+    workspace = WorkspaceConfig(plan=PlanName.free)
+    now = datetime(2026, 7, 20, 12, tzinfo=UTC)
+
+    ledger.reserve(workspace, UsageKind.audit, now=now)
+    ledger.reserve(workspace, UsageKind.audit, now=now)
+    ledger.reserve(workspace, UsageKind.audit, now=now)
+
+    blocked = quota_decision(workspace, ledger, UsageKind.audit, now=now)
+    assert blocked.allowed is False
+    assert blocked.used == 3
+    try:
+        ledger.reserve(workspace, UsageKind.audit, now=now)
+    except WorkspacePolicyError as exc:
+        assert "exhausted" in str(exc)
+    else:
+        raise AssertionError("Expected a fourth reservation to be rejected atomically.")
+
+    ledger.record(
+        UsageEvent(
+            kind=UsageKind.audit,
+            occurred_at=now,
+            related_id="a" * 24,
+        )
+    )
+    after_record = quota_decision(workspace, ledger, UsageKind.audit, now=now)
+    assert after_record.used == 3
+    assert len(list((tmp_path / "usage-reservations").glob("*.json"))) == 2
+
+
 def test_unlimited_operational_meter_and_suspended_workspace(tmp_path: Path) -> None:
     ledger = UsageLedger(tmp_path)
     active = WorkspaceConfig(plan=PlanName.agency)

--- a/tools/commercial_acceptance.py
+++ b/tools/commercial_acceptance.py
@@ -33,7 +33,7 @@ def _wait_ready(base_url: str, timeout: float = 20.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            with urlopen(f"{base_url}/health", timeout=1) as response:
+            with urlopen(f"{base_url}/health/live", timeout=1) as response:
                 if response.status == 200:
                     return
         except OSError:


### PR DESCRIPTION
Whole-project bug-hardening pass.

Fixed:
- prevent duplicate Stripe subscription Checkouts with durable per-tenant reservations and Stripe idempotency keys; clear reservations on reconciliation/cancellation;
- make usage quota reservation cross-process atomic and include active reservations in quota decisions;
- make project capacity check + create atomic;
- require and activate configured signup legal evidence inside the same SQLite transaction as tenant creation;
- refuse signup when deterministic tenant durable state already exists and is non-empty;
- pin lead webhook connections to the already-validated public IP while preserving original Host/TLS SNI, closing DNS re-resolution/TOCTOU;
- commercial acceptance now probes the documented /health/live endpoint.

Regression tests cover Checkout idempotency/reservation, quota overcommit prevention, missing signup legal evidence, orphan tenant state preservation, and webhook IP/SNI pinning.

Exact-head CI must be fully green before merge.