### PR TITLE
Validate production durable storage topology

### DIFF
--- a/docs/operations/production-preflight.md
+++ b/docs/operations/production-preflight.md
@@ -6,11 +6,13 @@ Run the read-only preflight before starting a production Veridra runtime:
 veridra-production-preflight
 ```
 
-The command validates production runtime, legal-link and SMTP configuration. Stripe is optional by default: if it is absent, the result is a warning because a Free-plan launch can still operate. For a paid launch, require Stripe explicitly:
+The command validates production runtime, durable-storage topology, legal-link and SMTP configuration. Stripe is optional by default: if it is absent, the result is a warning because a Free-plan launch can still operate. For a paid launch, require Stripe explicitly:
 
 ```text
 veridra-production-preflight --require-stripe
 ```
+
+The storage check keeps production launch aligned with the verified backup/restore contract. The identity SQLite database and tenant-data root must be distinct rather than nested inside one another. Existing storage targets must have the expected file/directory shape and be readable/writable; for storage that has not been created yet, the nearest existing parent must permit creation. This prevents a deployment from passing configuration preflight with a durable layout that backup/restore later rejects.
 
 Exit codes follow the operational-check convention:
 
@@ -20,4 +22,4 @@ Exit codes follow the operational-check convention:
 
 Output is compact JSON containing only component names, statuses and generic messages. It does not emit configured paths, origins, legal URLs, SMTP credentials, Stripe keys, webhook secrets or Price IDs. The preflight is read-only: it does not create directories, contact SMTP or Stripe, resolve DNS, obtain TLS certificates or provision infrastructure.
 
-A successful preflight proves configuration shape only. Deployment still requires provider-side resources such as compute, durable storage, DNS/TLS, SMTP account/domain setup, edge controls and—when paid launch is required—Stripe Products/Prices, Portal and webhook configuration. Run deployment-specific acceptance after those resources are connected.
+A successful preflight proves configuration shape and local durable-storage suitability only. Deployment still requires provider-side resources such as compute, durable volumes, DNS/TLS, SMTP account/domain setup, edge controls and—when paid launch is required—Stripe Products/Prices, Portal and webhook configuration. Run deployment-specific acceptance after those resources are connected.

--- a/src/veridra/production_preflight.py
+++ b/src/veridra/production_preflight.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 
 from .email_delivery import EmailDeliveryError, SmtpConfig
 from .runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
@@ -62,6 +64,79 @@ def _overall(checks: list[PreflightCheck]) -> PreflightStatus:
     return PreflightStatus.ok
 
 
+def _nearest_existing_parent(path: Path) -> Path:
+    current = path
+    while not current.exists() and current != current.parent:
+        current = current.parent
+    return current
+
+
+def _writable_directory_or_parent(path: Path) -> bool:
+    candidate = path if path.exists() else _nearest_existing_parent(path.parent)
+    return (
+        candidate.exists()
+        and candidate.is_dir()
+        and os.access(candidate, os.R_OK | os.W_OK | os.X_OK)
+    )
+
+
+def _storage_check(runtime: RuntimeConfig | None) -> PreflightCheck:
+    if runtime is None:
+        return PreflightCheck(
+            name="storage",
+            status=PreflightStatus.critical,
+            message="Production durable-storage configuration could not be validated.",
+        )
+    identity = runtime.identity_database
+    tenant_root = runtime.tenant_data_root
+    if identity is None or tenant_root is None:
+        return PreflightCheck(
+            name="storage",
+            status=PreflightStatus.critical,
+            message="Production durable-storage paths are incomplete.",
+        )
+    if identity.is_relative_to(tenant_root) or tenant_root.is_relative_to(identity):
+        return PreflightCheck(
+            name="storage",
+            status=PreflightStatus.critical,
+            message="Identity and tenant durable-storage paths must be distinct.",
+        )
+    if identity.exists() and (
+        not identity.is_file() or not os.access(identity, os.R_OK | os.W_OK)
+    ):
+        return PreflightCheck(
+            name="storage",
+            status=PreflightStatus.critical,
+            message="Identity durable storage is not a readable and writable file.",
+        )
+    if not identity.exists() and not _writable_directory_or_parent(identity.parent):
+        return PreflightCheck(
+            name="storage",
+            status=PreflightStatus.critical,
+            message="Identity durable-storage parent is not writable.",
+        )
+    if tenant_root.exists() and (
+        not tenant_root.is_dir()
+        or not os.access(tenant_root, os.R_OK | os.W_OK | os.X_OK)
+    ):
+        return PreflightCheck(
+            name="storage",
+            status=PreflightStatus.critical,
+            message="Tenant durable storage is not a readable and writable directory.",
+        )
+    if not tenant_root.exists() and not _writable_directory_or_parent(tenant_root):
+        return PreflightCheck(
+            name="storage",
+            status=PreflightStatus.critical,
+            message="Tenant durable-storage parent is not writable.",
+        )
+    return PreflightCheck(
+        name="storage",
+        status=PreflightStatus.ok,
+        message="Production durable-storage topology is compatible with runtime and backups.",
+    )
+
+
 def run_production_preflight(*, require_stripe: bool = False) -> ProductionPreflightResult:
     checks: list[PreflightCheck] = []
     runtime: RuntimeConfig | None = None
@@ -93,6 +168,7 @@ def run_production_preflight(*, require_stripe: bool = False) -> ProductionPrefl
                     message="Production runtime configuration is valid.",
                 )
             )
+    checks.append(_storage_check(runtime))
 
     try:
         legal = LegalLinks.from_environment()

--- a/tests/test_production_preflight.py
+++ b/tests/test_production_preflight.py
@@ -84,10 +84,47 @@ def test_valid_required_configuration_is_free_launch_ready_with_warning(
     checks = {check.name: check.status for check in result.checks}
     assert checks == {
         "runtime": PreflightStatus.ok,
+        "storage": PreflightStatus.ok,
         "legal": PreflightStatus.ok,
         "smtp": PreflightStatus.ok,
         "stripe": PreflightStatus.warning,
     }
+
+
+def test_overlapping_identity_and_tenant_storage_is_critical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _valid_required(monkeypatch, tmp_path)
+    tenant_root = (tmp_path / "durable").resolve()
+    monkeypatch.setenv("VERIDRA_TENANT_DATA_ROOT", str(tenant_root))
+    monkeypatch.setenv(
+        "VERIDRA_IDENTITY_DB",
+        str((tenant_root / "identity.sqlite3").resolve()),
+    )
+
+    result = run_production_preflight()
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is PreflightStatus.critical
+    assert checks["storage"].status is PreflightStatus.critical
+    assert "distinct" in checks["storage"].message
+
+
+def test_existing_invalid_storage_shapes_are_critical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _valid_required(monkeypatch, tmp_path)
+    identity = tmp_path / "identity" / "veridra.sqlite3"
+    identity.mkdir(parents=True)
+
+    result = run_production_preflight()
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is PreflightStatus.critical
+    assert checks["storage"].status is PreflightStatus.critical
+    assert "file" in checks["storage"].message
 
 
 def test_require_stripe_makes_absent_billing_critical(
@@ -121,3 +158,4 @@ def test_complete_paid_launch_configuration_is_ready_and_secret_free(
     assert "whsec_preflight" not in payload
     assert "price_agency" not in payload
     assert "app.example.com" not in payload
+    assert str(tmp_path) not in payload


### PR DESCRIPTION
Add a read-only production preflight storage check so deployments cannot pass configuration validation with a durable layout that verified backup/restore rejects. The check requires distinct identity/tenant paths, validates existing file/directory shapes and access, and validates creatable parents for not-yet-created storage. Output remains path/secret free. Includes regression tests and operations documentation. Exact-head CI must be fully green before merge.