### PR TITLE
Validate Stripe webhook rotation in production preflight

### DIFF
--- a/docs/operations/production-preflight.md
+++ b/docs/operations/production-preflight.md
@@ -14,6 +14,8 @@ veridra-production-preflight --require-stripe
 
 The storage check keeps production launch aligned with the verified backup/restore contract. The identity SQLite database and tenant-data root must be distinct rather than nested inside one another. Existing storage targets must have the expected file/directory shape and be readable/writable; for storage that has not been created yet, the nearest existing parent must permit creation. This prevents a deployment from passing configuration preflight with a durable layout that backup/restore later rejects.
 
+Stripe validation uses the same webhook-secret overlap rules as production startup. During a controlled signing-secret rotation, `VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS` is accepted only when Stripe billing is otherwise configured, must contain a webhook signing secret, and must differ from the current `VERIDRA_STRIPE_WEBHOOK_SECRET`. A previous secret without active Stripe configuration, a malformed previous secret, or duplicate current/previous values is a critical preflight failure rather than a startup surprise.
+
 Exit codes follow the operational-check convention:
 
 - `0` — required configuration is ready;

--- a/src/veridra/production_preflight.py
+++ b/src/veridra/production_preflight.py
@@ -9,6 +9,7 @@ from .email_delivery import EmailDeliveryError, SmtpConfig
 from .runtime_config import RuntimeConfig, RuntimeConfigurationError, RuntimeEnvironment
 from .runtime_legal import LegalLinks
 from .stripe_billing import StripeBillingConfig, StripeBillingError
+from .stripe_webhook_verification import configured_webhook_secrets
 
 
 class PreflightStatus(StrEnum):
@@ -233,6 +234,9 @@ def run_production_preflight(*, require_stripe: bool = False) -> ProductionPrefl
 
     try:
         stripe = StripeBillingConfig.from_environment()
+        configured_webhook_secrets(
+            stripe.webhook_secret if stripe is not None else None
+        )
     except StripeBillingError:
         checks.append(
             PreflightCheck(
@@ -273,7 +277,7 @@ def run_production_preflight(*, require_stripe: bool = False) -> ProductionPrefl
                 PreflightCheck(
                     name="stripe",
                     status=PreflightStatus.ok,
-                    message="Stripe billing configuration is complete.",
+                    message="Stripe billing and webhook verification configuration are complete.",
                 )
             )
 

--- a/tests/test_production_preflight.py
+++ b/tests/test_production_preflight.py
@@ -23,6 +23,7 @@ def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
         "VERIDRA_SMTP_PASSWORD",
         "VERIDRA_STRIPE_SECRET_KEY",
         "VERIDRA_STRIPE_WEBHOOK_SECRET",
+        "VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS",
         "VERIDRA_STRIPE_PRICE_SOLO",
         "VERIDRA_STRIPE_PRICE_PROFESSIONAL",
         "VERIDRA_STRIPE_PRICE_AGENCY",
@@ -138,6 +139,52 @@ def test_require_stripe_makes_absent_billing_critical(
     assert result.status is PreflightStatus.critical
     assert result.exit_code == 2
     assert not result.ready
+
+
+def test_previous_webhook_secret_without_stripe_is_critical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _valid_required(monkeypatch, tmp_path)
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS", "whsec_previous")
+
+    result = run_production_preflight()
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is PreflightStatus.critical
+    assert checks["stripe"].status is PreflightStatus.critical
+
+
+def test_invalid_webhook_secret_overlap_is_critical(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _valid_required(monkeypatch, tmp_path)
+    _enable_stripe(monkeypatch)
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS", "whsec_preflight")
+
+    result = run_production_preflight(require_stripe=True)
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is PreflightStatus.critical
+    assert checks["stripe"].status is PreflightStatus.critical
+
+
+def test_valid_webhook_secret_overlap_is_paid_launch_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _valid_required(monkeypatch, tmp_path)
+    _enable_stripe(monkeypatch)
+    monkeypatch.setenv("VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS", "whsec_previous")
+
+    result = run_production_preflight(require_stripe=True)
+    payload = json.dumps(result.as_dict(), sort_keys=True)
+
+    assert result.status is PreflightStatus.ok
+    assert result.ready
+    assert "whsec_preflight" not in payload
+    assert "whsec_previous" not in payload
 
 
 def test_complete_paid_launch_configuration_is_ready_and_secret_free(


### PR DESCRIPTION
Make production preflight use the same Stripe webhook signing-secret overlap validator as production startup. This prevents preflight from reporting ready when VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS is configured without Stripe, malformed, or identical to the primary secret. Valid controlled overlap remains accepted and output stays secret-free. Includes regression tests and operations documentation. Exact-head CI must be fully green before merge.