### PR TITLE
Add remote production deployment acceptance gate

### DIFF
--- a/docs/operations/deployment-acceptance.md
+++ b/docs/operations/deployment-acceptance.md
@@ -1,0 +1,19 @@
+# Deployment acceptance check
+
+After provisioning a real Veridra host, run the provider-neutral remote deployment gate against its public HTTPS origin:
+
+```text
+veridra-deployment-check --origin https://app.example.com
+```
+
+The command is intentionally read-only. It validates that the supplied value is a bare public HTTPS origin, resolves the hostname to public addresses, pins the connection to the validated address while preserving the original TLS SNI/Host identity, and then checks:
+
+- `/health/live` returns HTTP 200 with `{"status":"ok"}`;
+- `/health/ready` returns HTTP 200 with `{"status":"ok"}`;
+- `/signup` exposes the expected public agency-signup surface;
+- production HSTS, anti-sniffing, anti-framing and CSP headers are present on the public application surface;
+- liveness, readiness and signup responses carry `Cache-Control: no-store`.
+
+The command does not create accounts, submit forms, mutate tenant state, contact Stripe/SMTP, or print the tested origin/IP in its JSON result. Exit code `0` means the checked deployment contract passed; exit code `2` means at least one critical deployment check failed.
+
+This is a deployment smoke/security gate, not a replacement for the full browser commercial acceptance journey or an independent security assessment. After a real environment is connected, use it after `veridra-production-preflight` and before end-to-end signup/billing acceptance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 dev = [
     "mypy>=1.11,<2",
     "pytest>=8,<9",
-    "pytest-asyncio<1,>=0.24",
+    "pytest-asyncio>=0.24,<1",
     "pytest-cov>=5,<7",
     "ruff>=0.6,<1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 dev = [
     "mypy>=1.11,<2",
     "pytest>=8,<9",
-    "pytest-asyncio>=0.24,<1",
+    "pytest-asyncio<1,>=0.24",
     "pytest-cov>=5,<7",
     "ruff>=0.6,<1",
 ]
@@ -38,6 +38,7 @@ veridra-backup = "veridra.backup_restore_cli:main"
 veridra-ops-check = "veridra.ops_check_cli:main"
 veridra-tenant-offboard = "veridra.tenant_offboarding_cli:main"
 veridra-production-preflight = "veridra.production_preflight_cli:main"
+veridra-deployment-check = "veridra.deployment_acceptance_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/deployment_acceptance.py
+++ b/src/veridra/deployment_acceptance.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from urllib.parse import urlparse
+
+import httpx
+
+from .core import UnsafeTargetError, resolve_public_ips
+
+_TIMEOUT_SECONDS = 10.0
+
+
+class DeploymentAcceptanceError(RuntimeError):
+    pass
+
+
+class DeploymentCheckStatus(StrEnum):
+    ok = "ok"
+    critical = "critical"
+
+
+@dataclass(frozen=True)
+class DeploymentCheck:
+    name: str
+    status: DeploymentCheckStatus
+    message: str
+
+
+@dataclass(frozen=True)
+class DeploymentAcceptanceResult:
+    status: DeploymentCheckStatus
+    checks: tuple[DeploymentCheck, ...]
+
+    @property
+    def ready(self) -> bool:
+        return self.status is DeploymentCheckStatus.ok
+
+    @property
+    def exit_code(self) -> int:
+        return 0 if self.ready else 2
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "ready": self.ready,
+            "status": self.status.value,
+            "checks": [
+                {
+                    "name": check.name,
+                    "status": check.status.value,
+                    "message": check.message,
+                }
+                for check in self.checks
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class ValidatedDeploymentOrigin:
+    origin: str
+    hostname: str
+    public_ips: tuple[str, ...]
+
+
+def _validated_origin(origin: str) -> ValidatedDeploymentOrigin:
+    value = origin.strip().rstrip("/")
+    parsed = urlparse(value)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise DeploymentAcceptanceError(
+            "Deployment origin must be a bare HTTPS origin without credentials, path or query."
+        )
+    try:
+        public_ips = tuple(resolve_public_ips(parsed.hostname))
+    except UnsafeTargetError as exc:
+        raise DeploymentAcceptanceError(
+            "Deployment origin must resolve only to public network addresses."
+        ) from exc
+    if not public_ips:
+        raise DeploymentAcceptanceError(
+            "Deployment origin did not resolve to a public network address."
+        )
+    return ValidatedDeploymentOrigin(
+        origin=value,
+        hostname=parsed.hostname,
+        public_ips=public_ips,
+    )
+
+
+def _pin_deployment_request(
+    request: httpx.Request,
+    *,
+    hostname: str,
+    ip_address: str,
+) -> httpx.Request:
+    if request.url.host != hostname:
+        raise DeploymentAcceptanceError(
+            "Deployment request hostname changed before connection."
+        )
+    request.extensions["sni_hostname"] = hostname
+    request.url = request.url.copy_with(host=ip_address)
+    return request
+
+
+class _PinnedDeploymentTransport(httpx.HTTPTransport):
+    def __init__(self, *, hostname: str, ip_address: str) -> None:
+        super().__init__()
+        self.hostname = hostname
+        self.ip_address = ip_address
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        pinned = _pin_deployment_request(
+            request,
+            hostname=self.hostname,
+            ip_address=self.ip_address,
+        )
+        return super().handle_request(pinned)
+
+
+def _check(
+    name: str,
+    condition: bool,
+    *,
+    ok: str,
+    failure: str,
+) -> DeploymentCheck:
+    return DeploymentCheck(
+        name=name,
+        status=(DeploymentCheckStatus.ok if condition else DeploymentCheckStatus.critical),
+        message=ok if condition else failure,
+    )
+
+
+def _security_headers(response: httpx.Response) -> bool:
+    csp = response.headers.get("content-security-policy", "")
+    return (
+        response.headers.get("strict-transport-security", "")
+        == "max-age=31536000; includeSubDomains"
+        and response.headers.get("x-content-type-options", "") == "nosniff"
+        and response.headers.get("x-frame-options", "") == "DENY"
+        and "object-src 'none'" in csp
+        and "base-uri 'self'" in csp
+        and "frame-ancestors 'none'" in csp
+    )
+
+
+def _json_status(response: httpx.Response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    status = payload.get("status")
+    return status if isinstance(status, str) else ""
+
+
+def run_deployment_acceptance(
+    origin: str,
+    *,
+    transport: httpx.BaseTransport | None = None,
+) -> DeploymentAcceptanceResult:
+    try:
+        validated = _validated_origin(origin)
+    except DeploymentAcceptanceError:
+        check = DeploymentCheck(
+            name="origin",
+            status=DeploymentCheckStatus.critical,
+            message="Deployment origin is invalid or not publicly routable.",
+        )
+        return DeploymentAcceptanceResult(
+            status=DeploymentCheckStatus.critical,
+            checks=(check,),
+        )
+
+    active_transport = transport or _PinnedDeploymentTransport(
+        hostname=validated.hostname,
+        ip_address=validated.public_ips[0],
+    )
+    checks: list[DeploymentCheck] = [
+        DeploymentCheck(
+            name="origin",
+            status=DeploymentCheckStatus.ok,
+            message="Deployment origin is a validated public HTTPS origin.",
+        )
+    ]
+    try:
+        with httpx.Client(
+            base_url=validated.origin,
+            timeout=_TIMEOUT_SECONDS,
+            follow_redirects=False,
+            transport=active_transport,
+        ) as client:
+            live = client.get("/health/live")
+            ready = client.get("/health/ready")
+            signup = client.get("/signup")
+    except (httpx.HTTPError, DeploymentAcceptanceError):
+        checks.append(
+            DeploymentCheck(
+                name="network",
+                status=DeploymentCheckStatus.critical,
+                message="Deployment endpoints could not be reached safely.",
+            )
+        )
+        return DeploymentAcceptanceResult(
+            status=DeploymentCheckStatus.critical,
+            checks=tuple(checks),
+        )
+
+    checks.append(
+        _check(
+            "liveness",
+            live.status_code == 200 and _json_status(live) == "ok",
+            ok="Production liveness endpoint is healthy.",
+            failure="Production liveness endpoint is not healthy.",
+        )
+    )
+    checks.append(
+        _check(
+            "readiness",
+            ready.status_code == 200 and _json_status(ready) == "ok",
+            ok="Production readiness endpoint is healthy.",
+            failure="Production readiness endpoint is not healthy.",
+        )
+    )
+    checks.append(
+        _check(
+            "signup",
+            signup.status_code == 200
+            and "Create your Veridra agency workspace" in signup.text,
+            ok="Public signup surface is available.",
+            failure="Public signup surface is unavailable or unexpected.",
+        )
+    )
+    checks.append(
+        _check(
+            "security_headers",
+            _security_headers(signup),
+            ok="Production security headers are present on the public application surface.",
+            failure="Required production security headers are missing or unexpected.",
+        )
+    )
+    checks.append(
+        _check(
+            "cache_control",
+            live.headers.get("cache-control", "") == "no-store"
+            and ready.headers.get("cache-control", "") == "no-store"
+            and signup.headers.get("cache-control", "") == "no-store",
+            ok="Sensitive operational and signup responses are not cacheable.",
+            failure="Required no-store cache controls are missing.",
+        )
+    )
+    status = (
+        DeploymentCheckStatus.ok
+        if all(check.status is DeploymentCheckStatus.ok for check in checks)
+        else DeploymentCheckStatus.critical
+    )
+    return DeploymentAcceptanceResult(status=status, checks=tuple(checks))

--- a/src/veridra/deployment_acceptance_cli.py
+++ b/src/veridra/deployment_acceptance_cli.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from .deployment_acceptance import run_deployment_acceptance
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate a deployed Veridra HTTPS origin after infrastructure provisioning."
+    )
+    parser.add_argument(
+        "--origin",
+        required=True,
+        help="Bare public HTTPS origin, for example https://app.example.com",
+    )
+    args = parser.parse_args()
+    result = run_deployment_acceptance(args.origin)
+    print(json.dumps(result.as_dict(), sort_keys=True, separators=(",", ":")))
+    raise SystemExit(result.exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deployment_acceptance.py
+++ b/tests/test_deployment_acceptance.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from veridra.deployment_acceptance import (
+    DeploymentCheckStatus,
+    _pin_deployment_request,
+    run_deployment_acceptance,
+)
+
+ORIGIN = "https://app.example.test"
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "Content-Security-Policy": (
+            "object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
+        ),
+        "Cache-Control": "no-store",
+    }
+
+
+def _transport(*, ready: bool = True, hsts: bool = True) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        headers = _headers()
+        if not hsts:
+            headers.pop("Strict-Transport-Security")
+        if request.url.path == "/health/live":
+            return httpx.Response(200, headers=headers, json={"status": "ok"})
+        if request.url.path == "/health/ready":
+            return httpx.Response(
+                200 if ready else 503,
+                headers=headers,
+                json={"status": "ok" if ready else "not_ready"},
+            )
+        if request.url.path == "/signup":
+            return httpx.Response(
+                200,
+                headers=headers,
+                text="<h1>Create your Veridra agency workspace</h1>",
+            )
+        raise AssertionError(f"Unexpected deployment check request: {request.url}")
+
+    return httpx.MockTransport(handler)
+
+
+def _public_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "veridra.deployment_acceptance.resolve_public_ips",
+        lambda hostname: ["203.0.113.10"],
+    )
+
+
+def test_complete_deployment_contract_is_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    _public_dns(monkeypatch)
+
+    result = run_deployment_acceptance(ORIGIN, transport=_transport())
+
+    assert result.status is DeploymentCheckStatus.ok
+    assert result.ready is True
+    assert result.exit_code == 0
+    assert all(check.status is DeploymentCheckStatus.ok for check in result.checks)
+    payload = result.as_dict()
+    assert payload["ready"] is True
+    assert ORIGIN not in str(payload)
+    assert "203.0.113.10" not in str(payload)
+
+
+def test_unready_deployment_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _public_dns(monkeypatch)
+
+    result = run_deployment_acceptance(
+        ORIGIN,
+        transport=_transport(ready=False),
+    )
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is DeploymentCheckStatus.critical
+    assert result.exit_code == 2
+    assert checks["readiness"].status is DeploymentCheckStatus.critical
+
+
+def test_missing_production_security_headers_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    _public_dns(monkeypatch)
+
+    result = run_deployment_acceptance(
+        ORIGIN,
+        transport=_transport(hsts=False),
+    )
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is DeploymentCheckStatus.critical
+    assert checks["security_headers"].status is DeploymentCheckStatus.critical
+
+
+def test_invalid_or_nonpublic_origin_does_not_attempt_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "veridra.deployment_acceptance.resolve_public_ips",
+        lambda hostname: (_ for _ in ()).throw(AssertionError("DNS should not run")),
+    )
+    result = run_deployment_acceptance("http://127.0.0.1:8000")
+
+    assert result.status is DeploymentCheckStatus.critical
+    assert [check.name for check in result.checks] == ["origin"]
+
+
+def test_pinned_transport_preserves_tls_hostname_and_changes_socket_target() -> None:
+    request = httpx.Request("GET", f"{ORIGIN}/health/live")
+
+    pinned = _pin_deployment_request(
+        request,
+        hostname="app.example.test",
+        ip_address="203.0.113.10",
+    )
+
+    assert pinned.url.host == "203.0.113.10"
+    assert pinned.headers["host"] == "app.example.test"
+    assert pinned.extensions["sni_hostname"] == "app.example.test"


### PR DESCRIPTION
Add a provider-neutral read-only deployment checker for a real Veridra HTTPS origin. It validates a public HTTPS target, pins the connection to the validated IP while preserving Host/TLS SNI, and checks liveness, readiness, public signup availability, production security headers and no-store cache controls. Adds `veridra-deployment-check`, regression tests and operations documentation. Exact-head CI must be fully green before merge.