### PR TITLE
Strengthen global Content Security Policy baseline

### DIFF
--- a/docs/operations/security-headers.md
+++ b/docs/operations/security-headers.md
@@ -7,14 +7,16 @@ All HTTP responses receive:
 - `X-Content-Type-Options: nosniff`;
 - `Referrer-Policy: strict-origin-when-cross-origin` unless a route already supplied a stricter policy;
 - `Permissions-Policy: camera=(), microphone=(), geolocation=()`;
-- a narrow Content Security Policy that blocks plugin/object content and constrains document base URLs.
+- a Content Security Policy with `default-src 'none'`, `script-src 'none'`, same-origin connection/form/font boundaries, `frame-src 'none'`, plugin/object blocking and constrained document base URLs;
+- `style-src 'self' 'unsafe-inline'` while the existing server-rendered inline CSS remains in use;
+- `img-src 'self' data:` so local assets and validated embedded PNG/JPEG report logos continue to render.
 
 Non-embed routes also receive:
 
 - `X-Frame-Options: DENY`;
 - `Content-Security-Policy` with `frame-ancestors 'none'`.
 
-Routes under `/embed/` intentionally omit anti-framing directives because those responses are designed to be embedded by customer sites. They still receive the other global hardening headers.
+Routes under `/embed/` intentionally omit anti-framing directives because those responses are designed to be embedded by customer sites. They remain unable to frame child content themselves and still receive the other global source restrictions.
 
 Production responses additionally receive:
 
@@ -24,4 +26,4 @@ HSTS assumes the documented production contract: the public origin and relevant 
 
 The middleware uses add-if-missing behavior. Route-specific responses such as password reset pages may retain stronger headers such as `Referrer-Policy: no-referrer`.
 
-The CSP is intentionally narrow rather than declaring `default-src 'self'` today. Veridra currently renders inline styles in several server-generated pages; adopting a stricter script/style policy requires a separate nonce/hash migration and browser validation rather than silently breaking UI in a security-header change.
+The current CSP deliberately blocks scripts entirely because the composed customer workflow is server-rendered and does not require client-side JavaScript. Inline CSS is the remaining relaxed directive. A future nonce/hash or static-stylesheet migration can remove `'unsafe-inline'` from `style-src`; that migration is not required to establish the current script, connection, framing and resource-source boundaries.

--- a/src/veridra/security_headers.py
+++ b/src/veridra/security_headers.py
@@ -4,6 +4,19 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from .runtime_config import RuntimeEnvironment
 
+_BASE_CSP = (
+    "default-src 'none'; "
+    "script-src 'none'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; "
+    "font-src 'self'; "
+    "connect-src 'self'; "
+    "form-action 'self'; "
+    "frame-src 'none'; "
+    "object-src 'none'; "
+    "base-uri 'self'"
+)
+
 
 class SecurityHeadersMiddleware:
     """Apply response hardening without breaking the intentional embed surface."""
@@ -39,13 +52,13 @@ class SecurityHeadersMiddleware:
                 if embeddable:
                     add_if_missing(
                         b"content-security-policy",
-                        b"object-src 'none'; base-uri 'self'",
+                        _BASE_CSP.encode("ascii"),
                     )
                 else:
                     add_if_missing(b"x-frame-options", b"DENY")
                     add_if_missing(
                         b"content-security-policy",
-                        b"object-src 'none'; base-uri 'self'; frame-ancestors 'none'",
+                        f"{_BASE_CSP}; frame-ancestors 'none'".encode("ascii"),
                     )
                 if self.environment is RuntimeEnvironment.production:
                     add_if_missing(

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -31,6 +31,19 @@ def _client(environment: RuntimeEnvironment) -> TestClient:
     return TestClient(app)
 
 
+def _assert_strict_sources(csp: str) -> None:
+    assert "default-src 'none'" in csp
+    assert "script-src 'none'" in csp
+    assert "style-src 'self' 'unsafe-inline'" in csp
+    assert "img-src 'self' data:" in csp
+    assert "font-src 'self'" in csp
+    assert "connect-src 'self'" in csp
+    assert "form-action 'self'" in csp
+    assert "frame-src 'none'" in csp
+    assert "object-src 'none'" in csp
+    assert "base-uri 'self'" in csp
+
+
 def test_normal_response_gets_safe_global_headers() -> None:
     response = _client(RuntimeEnvironment.development).get("/normal")
 
@@ -38,9 +51,9 @@ def test_normal_response_gets_safe_global_headers() -> None:
     assert response.headers["referrer-policy"] == "strict-origin-when-cross-origin"
     assert response.headers["permissions-policy"] == "camera=(), microphone=(), geolocation=()"
     assert response.headers["x-frame-options"] == "DENY"
-    assert response.headers["content-security-policy"] == (
-        "object-src 'none'; base-uri 'self'; frame-ancestors 'none'"
-    )
+    csp = response.headers["content-security-policy"]
+    _assert_strict_sources(csp)
+    assert "frame-ancestors 'none'" in csp
     assert "strict-transport-security" not in response.headers
 
 
@@ -48,7 +61,9 @@ def test_embed_surface_remains_frameable_but_keeps_safe_headers() -> None:
     response = _client(RuntimeEnvironment.production).get("/embed/example")
 
     assert "x-frame-options" not in response.headers
-    assert response.headers["content-security-policy"] == "object-src 'none'; base-uri 'self'"
+    csp = response.headers["content-security-policy"]
+    _assert_strict_sources(csp)
+    assert "frame-ancestors" not in csp
     assert response.headers["x-content-type-options"] == "nosniff"
     assert response.headers["strict-transport-security"] == (
         "max-age=31536000; includeSubDomains"


### PR DESCRIPTION
Replace the narrow CSP with an explicit source policy: default-src none, scripts disabled, inline/self styles allowed for the current server-rendered UI, images limited to self/data, connections/forms/fonts to self, and child frames disabled. Preserve frameability for /embed/ by continuing to omit frame-ancestors there while keeping the rest of the restrictions. Includes regression tests and updated security-header documentation. Exact-head CI must be fully green before merge.