### PR TITLE
Hide API schema and interactive docs in production

### DIFF
--- a/docs/operations/deployment-acceptance.md
+++ b/docs/operations/deployment-acceptance.md
@@ -11,8 +11,11 @@ The command is intentionally read-only. It validates that the supplied value is 
 - `/health/live` returns HTTP 200 with `{"status":"ok"}`;
 - `/health/ready` returns HTTP 200 with `{"status":"ok"}`;
 - `/signup` exposes the expected public agency-signup surface;
+- `/openapi.json` returns HTTP 404, confirming the production API schema and interactive documentation are not publicly exposed;
 - production HSTS, anti-sniffing, anti-framing and CSP headers are present on the public application surface;
 - liveness, readiness and signup responses carry `Cache-Control: no-store`.
+
+The production runtime hides `/openapi.json`, `/docs`, `/docs/...` and `/redoc` at the runtime boundary. Development and test runtimes retain FastAPI's interactive documentation for local engineering use.
 
 The command does not create accounts, submit forms, mutate tenant state, contact Stripe/SMTP, or print the tested origin/IP in its JSON result. Exit code `0` means the checked deployment contract passed; exit code `2` means at least one critical deployment check failed.
 

--- a/src/veridra/deployment_acceptance.py
+++ b/src/veridra/deployment_acceptance.py
@@ -201,6 +201,7 @@ def run_deployment_acceptance(
             live = client.get("/health/live")
             ready = client.get("/health/ready")
             signup = client.get("/signup")
+            schema = client.get("/openapi.json")
     except (httpx.HTTPError, DeploymentAcceptanceError):
         checks.append(
             DeploymentCheck(
@@ -237,6 +238,14 @@ def run_deployment_acceptance(
             and "Create your Veridra agency workspace" in signup.text,
             ok="Public signup surface is available.",
             failure="Public signup surface is unavailable or unexpected.",
+        )
+    )
+    checks.append(
+        _check(
+            "schema_exposure",
+            schema.status_code == 404,
+            ok="Production API schema and interactive docs are not publicly exposed.",
+            failure="Production API schema remains publicly exposed.",
         )
     )
     checks.append(

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -42,7 +42,7 @@ from .public_web import ToolDefinition
 from .public_web import router as public_router
 from .runtime_billing import configure_runtime_billing
 from .runtime_boundary import RuntimeBoundaryMiddleware
-from .runtime_config import RuntimeConfig
+from .runtime_config import RuntimeConfig, RuntimeEnvironment
 from .runtime_email import configure_runtime_email
 from .runtime_legal import configure_runtime_legal
 from .security_headers import SecurityHeadersMiddleware
@@ -79,6 +79,7 @@ app.add_middleware(
     RuntimeBoundaryMiddleware,
     max_body_bytes=runtime_config.max_request_body_bytes,
     trusted_proxy_ips=runtime_config.trusted_proxy_ips,
+    hide_schema_routes=(runtime_config.environment is RuntimeEnvironment.production),
 )
 if runtime_config.allowed_hosts:
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(runtime_config.allowed_hosts))

--- a/src/veridra/runtime_boundary.py
+++ b/src/veridra/runtime_boundary.py
@@ -11,6 +11,11 @@ _FORWARDED_HEADERS = {
     b"x-forwarded-port",
     b"x-forwarded-proto",
 }
+_SCHEMA_PATHS = frozenset({"/docs", "/redoc", "/openapi.json"})
+
+
+def _schema_path(path: str) -> bool:
+    return path in _SCHEMA_PATHS or path.startswith("/docs/") or path.startswith("/redoc/")
 
 
 class RuntimeBoundaryMiddleware:
@@ -20,14 +25,20 @@ class RuntimeBoundaryMiddleware:
         *,
         max_body_bytes: int,
         trusted_proxy_ips: tuple[str, ...] = (),
+        hide_schema_routes: bool = False,
     ) -> None:
         self.app = app
         self.max_body_bytes = max_body_bytes
         self.trusted_proxy_ips = frozenset(trusted_proxy_ips)
+        self.hide_schema_routes = hide_schema_routes
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
+            return
+        path = str(scope.get("path", ""))
+        if self.hide_schema_routes and _schema_path(path):
+            await self._reject(scope, receive, send, 404, "Not found.")
             return
         headers = dict(scope.get("headers", []))
         client = scope.get("client")

--- a/tests/test_deployment_acceptance.py
+++ b/tests/test_deployment_acceptance.py
@@ -24,7 +24,12 @@ def _headers() -> dict[str, str]:
     }
 
 
-def _transport(*, ready: bool = True, hsts: bool = True) -> httpx.MockTransport:
+def _transport(
+    *,
+    ready: bool = True,
+    hsts: bool = True,
+    schema_hidden: bool = True,
+) -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
         headers = _headers()
         if not hsts:
@@ -42,6 +47,12 @@ def _transport(*, ready: bool = True, hsts: bool = True) -> httpx.MockTransport:
                 200,
                 headers=headers,
                 text="<h1>Create your Veridra agency workspace</h1>",
+            )
+        if request.url.path == "/openapi.json":
+            return httpx.Response(
+                404 if schema_hidden else 200,
+                headers=headers,
+                json={"detail": "Not found."} if schema_hidden else {"openapi": "3.1.0"},
             )
         raise AssertionError(f"Unexpected deployment check request: {request.url}")
 
@@ -95,6 +106,21 @@ def test_missing_production_security_headers_fails(monkeypatch: pytest.MonkeyPat
     checks = {check.name: check for check in result.checks}
     assert result.status is DeploymentCheckStatus.critical
     assert checks["security_headers"].status is DeploymentCheckStatus.critical
+
+
+def test_public_api_schema_fails_deployment_acceptance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _public_dns(monkeypatch)
+
+    result = run_deployment_acceptance(
+        ORIGIN,
+        transport=_transport(schema_hidden=False),
+    )
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is DeploymentCheckStatus.critical
+    assert checks["schema_exposure"].status is DeploymentCheckStatus.critical
 
 
 def test_invalid_or_nonpublic_origin_does_not_attempt_http(

--- a/tests/test_runtime_boundary_schema.py
+++ b/tests/test_runtime_boundary_schema.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.runtime_boundary import RuntimeBoundaryMiddleware
+
+
+def _client(*, hide_schema_routes: bool) -> TestClient:
+    app = FastAPI()
+
+    @app.get("/normal")
+    def normal() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    app.add_middleware(
+        RuntimeBoundaryMiddleware,
+        max_body_bytes=1_000_000,
+        hide_schema_routes=hide_schema_routes,
+    )
+    return TestClient(app)
+
+
+def test_schema_routes_remain_available_when_not_hidden() -> None:
+    client = _client(hide_schema_routes=False)
+
+    assert client.get("/docs").status_code == 200
+    assert client.get("/openapi.json").status_code == 200
+    assert client.get("/normal").json() == {"ok": "yes"}
+
+
+def test_schema_and_interactive_docs_are_hidden_at_boundary() -> None:
+    client = _client(hide_schema_routes=True)
+
+    for path in (
+        "/docs",
+        "/docs/",
+        "/docs/oauth2-redirect",
+        "/redoc",
+        "/redoc/",
+        "/openapi.json",
+    ):
+        response = client.get(path)
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Not found."}
+
+    assert client.get("/normal").status_code == 200


### PR DESCRIPTION
Hide FastAPI schema/documentation routes at the production runtime boundary while retaining them in development/test. Production blocks /openapi.json, /docs and subpaths, and /redoc with generic 404 responses. Extend veridra-deployment-check to require the deployed schema to be hidden. Includes isolated boundary tests, deployment acceptance regression coverage and documentation. Exact-head CI must be fully green before merge.