### PR TITLE
Disable one-time browser onboarding in production

### DIFF
--- a/docs/operations/deployment-acceptance.md
+++ b/docs/operations/deployment-acceptance.md
@@ -11,11 +11,14 @@ The command is intentionally read-only. It validates that the supplied value is 
 - `/health/live` returns HTTP 200 with `{"status":"ok"}`;
 - `/health/ready` returns HTTP 200 with `{"status":"ok"}`;
 - `/signup` exposes the expected public agency-signup surface;
+- `/onboarding` returns HTTP 404, confirming the one-time local bootstrap form is not exposed in production;
 - `/openapi.json` returns HTTP 404, confirming the production API schema and interactive documentation are not publicly exposed;
 - production HSTS, anti-sniffing, anti-framing and CSP headers are present on the public application surface;
 - liveness, readiness and signup responses carry `Cache-Control: no-store`.
 
-The production runtime hides `/openapi.json`, `/docs`, `/docs/...` and `/redoc` at the runtime boundary. Development and test runtimes retain FastAPI's interactive documentation for local engineering use.
+The production runtime hides `/onboarding` even when the identity database is completely empty. Production customer/owner registration must use `/signup`, preserving email verification and configured legal-acceptance evidence. The one-time `/onboarding` browser bootstrap remains available only in development/test-style runtimes for local setup.
+
+The production runtime also hides `/openapi.json`, `/docs`, `/docs/...` and `/redoc` at the runtime boundary. Development and test runtimes retain FastAPI's interactive documentation for local engineering use.
 
 The command does not create accounts, submit forms, mutate tenant state, contact Stripe/SMTP, or print the tested origin/IP in its JSON result. Exit code `0` means the checked deployment contract passed; exit code `2` means at least one critical deployment check failed.
 

--- a/docs/operations/production-onboarding.md
+++ b/docs/operations/production-onboarding.md
@@ -1,0 +1,9 @@
+# Production onboarding boundary
+
+The browser route `/onboarding` is a one-time local bootstrap helper. It is intentionally unavailable in production, including when the production identity database contains no users or tenants.
+
+Production agency registration must use `/signup`. That path preserves the production customer-creation controls: email verification before activation, configured Terms acceptance, Privacy Notice presentation, durable legal-acceptance evidence and the normal signup abuse controls.
+
+Do not expose or re-enable `/onboarding` at the reverse proxy as a production setup shortcut. A fresh production instance may use public `/signup` for its first customer once SMTP, legal URLs and durable storage are configured. Operator recovery/bootstrap workflows that intentionally bypass customer signup should use controlled CLI/restore procedures rather than a public browser route.
+
+`veridra-deployment-check` verifies that a deployed production origin returns HTTP 404 from `/onboarding` while `/signup` remains available.

--- a/src/veridra/deployment_acceptance.py
+++ b/src/veridra/deployment_acceptance.py
@@ -201,6 +201,7 @@ def run_deployment_acceptance(
             live = client.get("/health/live")
             ready = client.get("/health/ready")
             signup = client.get("/signup")
+            onboarding = client.get("/onboarding")
             schema = client.get("/openapi.json")
     except (httpx.HTTPError, DeploymentAcceptanceError):
         checks.append(
@@ -238,6 +239,14 @@ def run_deployment_acceptance(
             and "Create your Veridra agency workspace" in signup.text,
             ok="Public signup surface is available.",
             failure="Public signup surface is unavailable or unexpected.",
+        )
+    )
+    checks.append(
+        _check(
+            "onboarding_exposure",
+            onboarding.status_code == 404,
+            ok="Production one-time onboarding bootstrap is not publicly exposed.",
+            failure="Production one-time onboarding bootstrap remains publicly exposed.",
         )
     )
     checks.append(

--- a/src/veridra/onboarding_web.py
+++ b/src/veridra/onboarding_web.py
@@ -16,6 +16,7 @@ from .identity_bootstrap import (
     IdentityBootstrapError,
     SQLiteIdentityBootstrap,
 )
+from .runtime_config import RuntimeConfig, RuntimeEnvironment
 from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
 from .session_api import set_session_cookie
 from .session_lifecycle import SessionLifecycleService
@@ -52,6 +53,14 @@ def _tenant_root(request: Request) -> Path | None:
     return value if isinstance(value, Path) else None
 
 
+def _production(request: Request) -> bool:
+    runtime = getattr(request.app.state, "veridra_runtime_config", None)
+    return (
+        isinstance(runtime, RuntimeConfig)
+        and runtime.environment is RuntimeEnvironment.production
+    )
+
+
 def _is_empty(database: Path) -> bool:
     with sqlite3.connect(database) as connection:
         tenants = int(connection.execute("SELECT COUNT(*) FROM tenants").fetchone()[0])
@@ -60,6 +69,8 @@ def _is_empty(database: Path) -> bool:
 
 
 def _require_available(request: Request) -> Path:
+    if _production(request):
+        raise HTTPException(status_code=404, detail="Onboarding is not available.")
     database = _database(request)
     if not _is_empty(database):
         raise HTTPException(status_code=404, detail="Onboarding is not available.")

--- a/tests/test_deployment_acceptance.py
+++ b/tests/test_deployment_acceptance.py
@@ -29,6 +29,7 @@ def _transport(
     ready: bool = True,
     hsts: bool = True,
     schema_hidden: bool = True,
+    onboarding_hidden: bool = True,
 ) -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
         headers = _headers()
@@ -47,6 +48,12 @@ def _transport(
                 200,
                 headers=headers,
                 text="<h1>Create your Veridra agency workspace</h1>",
+            )
+        if request.url.path == "/onboarding":
+            return httpx.Response(
+                404 if onboarding_hidden else 200,
+                headers=headers,
+                text="Not found" if onboarding_hidden else "Create agency workspace",
             )
         if request.url.path == "/openapi.json":
             return httpx.Response(
@@ -106,6 +113,21 @@ def test_missing_production_security_headers_fails(monkeypatch: pytest.MonkeyPat
     checks = {check.name: check for check in result.checks}
     assert result.status is DeploymentCheckStatus.critical
     assert checks["security_headers"].status is DeploymentCheckStatus.critical
+
+
+def test_public_onboarding_fails_deployment_acceptance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _public_dns(monkeypatch)
+
+    result = run_deployment_acceptance(
+        ORIGIN,
+        transport=_transport(onboarding_hidden=False),
+    )
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is DeploymentCheckStatus.critical
+    assert checks["onboarding_exposure"].status is DeploymentCheckStatus.critical
 
 
 def test_public_api_schema_fails_deployment_acceptance(

--- a/tests/test_onboarding_web.py
+++ b/tests/test_onboarding_web.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 from veridra.identity_tenancy import RequestIdentity
 from veridra.onboarding_web import router
 from veridra.password_auth import SQLitePasswordAuthenticator
+from veridra.runtime_config import RuntimeConfig, RuntimeEnvironment
 from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
 from veridra.tenant_workspace_policy import TenantWorkspacePolicy
 from veridra.workspace_policy import PlanName
@@ -22,6 +23,8 @@ PASSWORD = "correct-horse-battery-staple"
 def _client(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    *,
+    environment: RuntimeEnvironment = RuntimeEnvironment.test,
 ) -> tuple[TestClient, Path, Path]:
     database = tmp_path / "identity.sqlite3"
     tenant_root = tmp_path / "tenants"
@@ -33,6 +36,17 @@ def _client(
     app.state.veridra_identity_database = database
     app.state.veridra_identity_store = store
     app.state.veridra_tenant_data_root = tenant_root
+    app.state.veridra_runtime_config = RuntimeConfig(
+        environment=environment,
+        identity_database=database,
+        tenant_data_root=tenant_root,
+        trusted_origin=ORIGIN,
+        allowed_hosts=("veridra.example",),
+        trusted_proxy_ips=(),
+        max_request_body_bytes=1_000_000,
+        bind_host="127.0.0.1",
+        bind_port=8000,
+    )
     app.include_router(router)
     monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
     return TestClient(app), database, tenant_root
@@ -61,6 +75,31 @@ def test_empty_database_exposes_onboarding_without_mutation(
     assert "Create your Veridra agency workspace" in response.text
     with sqlite3.connect(database) as connection:
         assert connection.execute("SELECT COUNT(*) FROM tenants").fetchone()[0] == 0
+    assert not tenant_root.exists()
+
+
+def test_production_onboarding_is_hidden_even_when_database_is_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, database, tenant_root = _client(
+        tmp_path,
+        monkeypatch,
+        environment=RuntimeEnvironment.production,
+    )
+
+    get_response = client.get("/onboarding")
+    post_response = client.post(
+        "/onboarding",
+        data=_payload(),
+        headers={"Origin": ORIGIN},
+    )
+
+    assert get_response.status_code == 404
+    assert post_response.status_code == 404
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM tenants").fetchone()[0] == 0
+        assert connection.execute("SELECT COUNT(*) FROM users").fetchone()[0] == 0
     assert not tenant_root.exists()
 
 


### PR DESCRIPTION
Close the production first-owner bypass exposed by `/onboarding` on an empty identity database. Production now returns 404 for both GET and POST `/onboarding`, so customer/owner registration must use the verified `/signup` flow with email verification and configured legal-acceptance evidence. Development/test retain the one-time browser bootstrap helper. Extend `veridra-deployment-check` to fail if a real production host exposes `/onboarding`. Includes direct regression coverage and operations documentation. Do not merge until exact-head full CI succeeds.