### PR TITLE
Hide legacy operational health aliases in production

### DIFF
--- a/docs/operations/deployment-acceptance.md
+++ b/docs/operations/deployment-acceptance.md
@@ -10,11 +10,14 @@ The command is intentionally read-only. It validates that the supplied value is 
 
 - `/health/live` returns HTTP 200 with `{"status":"ok"}`;
 - `/health/ready` returns HTTP 200 with `{"status":"ok"}`;
+- legacy `/health` and `/ready` aliases return HTTP 404 in production;
 - `/signup` exposes the expected public agency-signup surface;
 - `/onboarding` returns HTTP 404, confirming the one-time local bootstrap form is not exposed in production;
 - `/openapi.json` returns HTTP 404, confirming the production API schema and interactive documentation are not publicly exposed;
 - production HSTS, anti-sniffing, anti-framing and CSP headers are present on the public application surface;
 - liveness, readiness and signup responses carry `Cache-Control: no-store`.
+
+Production exposes only the canonical health contract: `/health/live` for process liveness and `/health/ready` for dependency readiness. The older `/health` and `/ready` compatibility aliases remain usable only outside production so deployment platforms cannot accidentally bind traffic decisions to their weaker historical semantics.
 
 The production runtime hides `/onboarding` even when the identity database is completely empty. Production customer/owner registration must use `/signup`, preserving email verification and configured legal-acceptance evidence. The one-time `/onboarding` browser bootstrap remains available only in development/test-style runtimes for local setup.
 

--- a/src/veridra/deployment_acceptance.py
+++ b/src/veridra/deployment_acceptance.py
@@ -200,6 +200,8 @@ def run_deployment_acceptance(
         ) as client:
             live = client.get("/health/live")
             ready = client.get("/health/ready")
+            legacy_health = client.get("/health")
+            legacy_ready = client.get("/ready")
             signup = client.get("/signup")
             onboarding = client.get("/onboarding")
             schema = client.get("/openapi.json")
@@ -230,6 +232,14 @@ def run_deployment_acceptance(
             ready.status_code == 200 and _json_status(ready) == "ok",
             ok="Production readiness endpoint is healthy.",
             failure="Production readiness endpoint is not healthy.",
+        )
+    )
+    checks.append(
+        _check(
+            "legacy_health_exposure",
+            legacy_health.status_code == 404 and legacy_ready.status_code == 404,
+            ok="Legacy operational health aliases are not publicly exposed.",
+            failure="Legacy operational health aliases remain publicly exposed.",
         )
     )
     checks.append(

--- a/src/veridra/runtime_boundary.py
+++ b/src/veridra/runtime_boundary.py
@@ -12,10 +12,15 @@ _FORWARDED_HEADERS = {
     b"x-forwarded-proto",
 }
 _SCHEMA_PATHS = frozenset({"/docs", "/redoc", "/openapi.json"})
+_LEGACY_OPERATIONAL_PATHS = frozenset({"/health", "/ready"})
 
 
 def _schema_path(path: str) -> bool:
     return path in _SCHEMA_PATHS or path.startswith("/docs/") or path.startswith("/redoc/")
+
+
+def _production_hidden_path(path: str) -> bool:
+    return _schema_path(path) or path in _LEGACY_OPERATIONAL_PATHS
 
 
 class RuntimeBoundaryMiddleware:
@@ -37,7 +42,7 @@ class RuntimeBoundaryMiddleware:
             await self.app(scope, receive, send)
             return
         path = str(scope.get("path", ""))
-        if self.hide_schema_routes and _schema_path(path):
+        if self.hide_schema_routes and _production_hidden_path(path):
             await self._reject(scope, receive, send, 404, "Not found.")
             return
         headers = dict(scope.get("headers", []))

--- a/tests/test_deployment_acceptance.py
+++ b/tests/test_deployment_acceptance.py
@@ -30,6 +30,7 @@ def _transport(
     hsts: bool = True,
     schema_hidden: bool = True,
     onboarding_hidden: bool = True,
+    legacy_health_hidden: bool = True,
 ) -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
         headers = _headers()
@@ -42,6 +43,12 @@ def _transport(
                 200 if ready else 503,
                 headers=headers,
                 json={"status": "ok" if ready else "not_ready"},
+            )
+        if request.url.path in {"/health", "/ready"}:
+            return httpx.Response(
+                404 if legacy_health_hidden else 200,
+                headers=headers,
+                json={"detail": "Not found."} if legacy_health_hidden else {"status": "ok"},
             )
         if request.url.path == "/signup":
             return httpx.Response(
@@ -113,6 +120,21 @@ def test_missing_production_security_headers_fails(monkeypatch: pytest.MonkeyPat
     checks = {check.name: check for check in result.checks}
     assert result.status is DeploymentCheckStatus.critical
     assert checks["security_headers"].status is DeploymentCheckStatus.critical
+
+
+def test_public_legacy_health_aliases_fail_deployment_acceptance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _public_dns(monkeypatch)
+
+    result = run_deployment_acceptance(
+        ORIGIN,
+        transport=_transport(legacy_health_hidden=False),
+    )
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is DeploymentCheckStatus.critical
+    assert checks["legacy_health_exposure"].status is DeploymentCheckStatus.critical
 
 
 def test_public_onboarding_fails_deployment_acceptance(

--- a/tests/test_production_hidden_operational_routes.py
+++ b/tests/test_production_hidden_operational_routes.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from veridra.runtime_boundary import RuntimeBoundaryMiddleware
+
+
+def _client(*, production: bool) -> TestClient:
+    app = FastAPI()
+
+    @app.get("/health")
+    def legacy_health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/ready")
+    def legacy_ready() -> dict[str, str]:
+        return {"status": "ready"}
+
+    @app.get("/health/live")
+    def live() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/health/ready")
+    def ready() -> dict[str, str]:
+        return {"status": "ok"}
+
+    app.add_middleware(
+        RuntimeBoundaryMiddleware,
+        max_body_bytes=1_000_000,
+        hide_schema_routes=production,
+    )
+    return TestClient(app)
+
+
+def test_production_hides_legacy_health_aliases_but_keeps_canonical_routes() -> None:
+    client = _client(production=True)
+
+    assert client.get("/health").status_code == 404
+    assert client.get("/ready").status_code == 404
+    assert client.get("/health/live").status_code == 200
+    assert client.get("/health/ready").status_code == 200
+
+
+def test_nonproduction_keeps_legacy_health_aliases_for_compatibility() -> None:
+    client = _client(production=False)
+
+    assert client.get("/health").status_code == 200
+    assert client.get("/ready").status_code == 200


### PR DESCRIPTION
Restrict production to the canonical health contract: `/health/live` and `/health/ready`. Hide the older `/health` and `/ready` compatibility aliases at the existing production runtime boundary while preserving them in development/test. Extend `veridra-deployment-check` to fail if a deployed production host exposes either legacy alias. Includes direct boundary regression tests and updated deployment documentation. Do not merge until exact-head full CI succeeds.