### PR TITLE
Add validated IP fallback to deployment acceptance

### DIFF
--- a/docs/operations/deployment-acceptance.md
+++ b/docs/operations/deployment-acceptance.md
@@ -6,7 +6,7 @@ After provisioning a real Veridra host, run the provider-neutral remote deployme
 veridra-deployment-check --origin https://app.example.com
 ```
 
-The command is intentionally read-only. It validates that the supplied value is a bare public HTTPS origin, resolves the hostname to public addresses, pins the connection to the validated address while preserving the original TLS SNI/Host identity, and then checks:
+The command is intentionally read-only. It validates that the supplied value is a bare public HTTPS origin, resolves the hostname to public addresses, pins each connection to a validated address while preserving the original TLS SNI/Host identity, and then checks:
 
 - `/health/live` returns HTTP 200 with `{"status":"ok"}`;
 - `/health/ready` returns HTTP 200 with `{"status":"ok"}`;
@@ -16,6 +16,8 @@ The command is intentionally read-only. It validates that the supplied value is 
 - `/openapi.json` returns HTTP 404, confirming the production API schema and interactive documentation are not publicly exposed;
 - production HSTS, anti-sniffing, anti-framing and CSP headers are present on the public application surface;
 - liveness, readiness and signup responses carry `Cache-Control: no-store`.
+
+If DNS returns multiple public addresses, the checker tries them one at a time until one can complete the full read-only deployment probe. Every attempted socket target comes from the already validated public DNS set; the checker never falls back to an unvalidated re-resolution. If all validated addresses fail, the result is one generic network-critical failure and does not disclose the addresses in output.
 
 Production exposes only the canonical health contract: `/health/live` for process liveness and `/health/ready` for dependency readiness. The older `/health` and `/ready` compatibility aliases remain usable only outside production so deployment platforms cannot accidentally bind traffic decisions to their weaker historical semantics.
 

--- a/src/veridra/deployment_acceptance.py
+++ b/src/veridra/deployment_acceptance.py
@@ -62,6 +62,17 @@ class ValidatedDeploymentOrigin:
     public_ips: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class _DeploymentResponses:
+    live: httpx.Response
+    ready: httpx.Response
+    legacy_health: httpx.Response
+    legacy_ready: httpx.Response
+    signup: httpx.Response
+    onboarding: httpx.Response
+    schema: httpx.Response
+
+
 def _validated_origin(origin: str) -> ValidatedDeploymentOrigin:
     value = origin.strip().rstrip("/")
     parsed = urlparse(value)
@@ -124,6 +135,31 @@ class _PinnedDeploymentTransport(httpx.HTTPTransport):
         return super().handle_request(pinned)
 
 
+def _transport_for_ip(hostname: str, ip_address: str) -> httpx.BaseTransport:
+    return _PinnedDeploymentTransport(hostname=hostname, ip_address=ip_address)
+
+
+def _request_deployment(
+    origin: str,
+    transport: httpx.BaseTransport,
+) -> _DeploymentResponses:
+    with httpx.Client(
+        base_url=origin,
+        timeout=_TIMEOUT_SECONDS,
+        follow_redirects=False,
+        transport=transport,
+    ) as client:
+        return _DeploymentResponses(
+            live=client.get("/health/live"),
+            ready=client.get("/health/ready"),
+            legacy_health=client.get("/health"),
+            legacy_ready=client.get("/ready"),
+            signup=client.get("/signup"),
+            onboarding=client.get("/onboarding"),
+            schema=client.get("/openapi.json"),
+        )
+
+
 def _check(
     name: str,
     condition: bool,
@@ -162,6 +198,20 @@ def _json_status(response: httpx.Response) -> str:
     return status if isinstance(status, str) else ""
 
 
+def _network_failure(checks: list[DeploymentCheck]) -> DeploymentAcceptanceResult:
+    checks.append(
+        DeploymentCheck(
+            name="network",
+            status=DeploymentCheckStatus.critical,
+            message="Deployment endpoints could not be reached safely.",
+        )
+    )
+    return DeploymentAcceptanceResult(
+        status=DeploymentCheckStatus.critical,
+        checks=tuple(checks),
+    )
+
+
 def run_deployment_acceptance(
     origin: str,
     *,
@@ -180,10 +230,6 @@ def run_deployment_acceptance(
             checks=(check,),
         )
 
-    active_transport = transport or _PinnedDeploymentTransport(
-        hostname=validated.hostname,
-        ip_address=validated.public_ips[0],
-    )
     checks: list[DeploymentCheck] = [
         DeploymentCheck(
             name="origin",
@@ -191,37 +237,29 @@ def run_deployment_acceptance(
             message="Deployment origin is a validated public HTTPS origin.",
         )
     ]
-    try:
-        with httpx.Client(
-            base_url=validated.origin,
-            timeout=_TIMEOUT_SECONDS,
-            follow_redirects=False,
-            transport=active_transport,
-        ) as client:
-            live = client.get("/health/live")
-            ready = client.get("/health/ready")
-            legacy_health = client.get("/health")
-            legacy_ready = client.get("/ready")
-            signup = client.get("/signup")
-            onboarding = client.get("/onboarding")
-            schema = client.get("/openapi.json")
-    except (httpx.HTTPError, DeploymentAcceptanceError):
-        checks.append(
-            DeploymentCheck(
-                name="network",
-                status=DeploymentCheckStatus.critical,
-                message="Deployment endpoints could not be reached safely.",
-            )
-        )
-        return DeploymentAcceptanceResult(
-            status=DeploymentCheckStatus.critical,
-            checks=tuple(checks),
-        )
+    responses: _DeploymentResponses | None = None
+    if transport is not None:
+        try:
+            responses = _request_deployment(validated.origin, transport)
+        except (httpx.HTTPError, DeploymentAcceptanceError):
+            return _network_failure(checks)
+    else:
+        for ip_address in validated.public_ips:
+            try:
+                responses = _request_deployment(
+                    validated.origin,
+                    _transport_for_ip(validated.hostname, ip_address),
+                )
+            except (httpx.HTTPError, DeploymentAcceptanceError):
+                continue
+            break
+        if responses is None:
+            return _network_failure(checks)
 
     checks.append(
         _check(
             "liveness",
-            live.status_code == 200 and _json_status(live) == "ok",
+            responses.live.status_code == 200 and _json_status(responses.live) == "ok",
             ok="Production liveness endpoint is healthy.",
             failure="Production liveness endpoint is not healthy.",
         )
@@ -229,7 +267,7 @@ def run_deployment_acceptance(
     checks.append(
         _check(
             "readiness",
-            ready.status_code == 200 and _json_status(ready) == "ok",
+            responses.ready.status_code == 200 and _json_status(responses.ready) == "ok",
             ok="Production readiness endpoint is healthy.",
             failure="Production readiness endpoint is not healthy.",
         )
@@ -237,7 +275,8 @@ def run_deployment_acceptance(
     checks.append(
         _check(
             "legacy_health_exposure",
-            legacy_health.status_code == 404 and legacy_ready.status_code == 404,
+            responses.legacy_health.status_code == 404
+            and responses.legacy_ready.status_code == 404,
             ok="Legacy operational health aliases are not publicly exposed.",
             failure="Legacy operational health aliases remain publicly exposed.",
         )
@@ -245,8 +284,8 @@ def run_deployment_acceptance(
     checks.append(
         _check(
             "signup",
-            signup.status_code == 200
-            and "Create your Veridra agency workspace" in signup.text,
+            responses.signup.status_code == 200
+            and "Create your Veridra agency workspace" in responses.signup.text,
             ok="Public signup surface is available.",
             failure="Public signup surface is unavailable or unexpected.",
         )
@@ -254,7 +293,7 @@ def run_deployment_acceptance(
     checks.append(
         _check(
             "onboarding_exposure",
-            onboarding.status_code == 404,
+            responses.onboarding.status_code == 404,
             ok="Production one-time onboarding bootstrap is not publicly exposed.",
             failure="Production one-time onboarding bootstrap remains publicly exposed.",
         )
@@ -262,7 +301,7 @@ def run_deployment_acceptance(
     checks.append(
         _check(
             "schema_exposure",
-            schema.status_code == 404,
+            responses.schema.status_code == 404,
             ok="Production API schema and interactive docs are not publicly exposed.",
             failure="Production API schema remains publicly exposed.",
         )
@@ -270,7 +309,7 @@ def run_deployment_acceptance(
     checks.append(
         _check(
             "security_headers",
-            _security_headers(signup),
+            _security_headers(responses.signup),
             ok="Production security headers are present on the public application surface.",
             failure="Required production security headers are missing or unexpected.",
         )
@@ -278,9 +317,9 @@ def run_deployment_acceptance(
     checks.append(
         _check(
             "cache_control",
-            live.headers.get("cache-control", "") == "no-store"
-            and ready.headers.get("cache-control", "") == "no-store"
-            and signup.headers.get("cache-control", "") == "no-store",
+            responses.live.headers.get("cache-control", "") == "no-store"
+            and responses.ready.headers.get("cache-control", "") == "no-store"
+            and responses.signup.headers.get("cache-control", "") == "no-store",
             ok="Sensitive operational and signup responses are not cacheable.",
             failure="Required no-store cache controls are missing.",
         )

--- a/tests/test_deployment_acceptance.py
+++ b/tests/test_deployment_acceptance.py
@@ -95,6 +95,69 @@ def test_complete_deployment_contract_is_ready(monkeypatch: pytest.MonkeyPatch) 
     assert "203.0.113.10" not in str(payload)
 
 
+def test_deployment_falls_back_to_next_validated_public_ip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    addresses = ["203.0.113.10", "203.0.113.11"]
+    attempted: list[str] = []
+    monkeypatch.setattr(
+        "veridra.deployment_acceptance.resolve_public_ips",
+        lambda hostname: addresses,
+    )
+
+    def transport_for_ip(hostname: str, ip_address: str) -> httpx.BaseTransport:
+        attempted.append(ip_address)
+        if ip_address == addresses[0]:
+            def fail(request: httpx.Request) -> httpx.Response:
+                raise httpx.ConnectError("unreachable", request=request)
+
+            return httpx.MockTransport(fail)
+        return _transport()
+
+    monkeypatch.setattr(
+        "veridra.deployment_acceptance._transport_for_ip",
+        transport_for_ip,
+    )
+
+    result = run_deployment_acceptance(ORIGIN)
+
+    assert result.status is DeploymentCheckStatus.ok
+    assert attempted == addresses
+    assert all(address not in str(result.as_dict()) for address in addresses)
+
+
+def test_deployment_reports_network_failure_after_all_validated_ips_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    addresses = ["203.0.113.10", "203.0.113.11"]
+    attempted: list[str] = []
+    monkeypatch.setattr(
+        "veridra.deployment_acceptance.resolve_public_ips",
+        lambda hostname: addresses,
+    )
+
+    def transport_for_ip(hostname: str, ip_address: str) -> httpx.BaseTransport:
+        attempted.append(ip_address)
+
+        def fail(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("unreachable", request=request)
+
+        return httpx.MockTransport(fail)
+
+    monkeypatch.setattr(
+        "veridra.deployment_acceptance._transport_for_ip",
+        transport_for_ip,
+    )
+
+    result = run_deployment_acceptance(ORIGIN)
+
+    checks = {check.name: check for check in result.checks}
+    assert result.status is DeploymentCheckStatus.critical
+    assert attempted == addresses
+    assert checks["network"].status is DeploymentCheckStatus.critical
+    assert all(address not in str(result.as_dict()) for address in addresses)
+
+
 def test_unready_deployment_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
     _public_dns(monkeypatch)
 


### PR DESCRIPTION
Fix a false-negative risk in `veridra-deployment-check` for multi-address DNS. The checker now tries each already-validated public address until one completes the full read-only probe, while preserving the original Host/TLS SNI and never re-resolving to an unvalidated address. If every validated address fails, output remains one generic network-critical result with no IP disclosure. Includes regression tests for first-address failure/second-address success and all-address failure, plus updated deployment documentation. Do not merge until exact-head full CI succeeds.