### PR TITLE
Reconcile README with production hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The core evidence model is:
 - configurable multi-page crawl profiles with same-origin controls, sitemap discovery and page-level evidence;
 - findings covering technical SEO fundamentals, AI crawler policy, AI technical readiness, trust, accessibility heuristics, domain/email posture and passive public security;
 - authenticated users, tenants, memberships, roles, invitations, browser sign-in, password recovery/reset and server-side sessions;
-- reusable public agency signup with email verification before tenant activation, non-enumerating existing-account handling, bounded signup attempts and Free-plan workspace creation;
+- reusable public agency signup with email verification before tenant activation, non-enumerating existing-account handling, bounded signup attempts, configured Terms/Privacy presentation and durable legal-acceptance evidence;
+- production customer registration restricted to `/signup`; the one-time `/onboarding` browser bootstrap is unavailable in production even when the identity database is empty;
 - transactional identity email through verified TLS SMTP for password recovery, tenant invitations and agency signup verification, with sensitive tokens excluded from durable delivery evidence;
 - complete invitation browser journeys for both new and existing users, including authenticated tenant acceptance;
 - tenant-qualified projects, leads, lead forms, remediation tasks, monitoring configuration, report profiles, assessments and report artifacts;
@@ -33,15 +34,19 @@ The core evidence model is:
 - project-attached remediation task creation and management from saved findings;
 - white-label report-profile creation and in-place editing, plus branded HTML, PDF and evidence-ZIP generation from tenant-qualified project data;
 - durable monitoring jobs with idempotent enqueueing, worker leases, stale-lease recovery, bounded retries and a separate worker CLI;
-- plan feature, usage and user-seat entitlement enforcement, including downgrade behavior;
+- plan feature, usage and user-seat entitlement enforcement, including atomic usage/project-capacity protection and downgrade behavior;
 - a provider-neutral subscription authority with replay, ordering, evidence and rollback protections;
-- an optional Stripe adapter providing authenticated hosted subscription Checkout, Billing Portal management, raw-body webhook-signature verification, server-side Price-to-plan mapping, current-subscription reconciliation, replacement-subscription safety and bounded webhook-secret rotation overlap;
-- health and readiness endpoints, trusted hosts, explicit proxy boundaries, bounded request bodies and fail-closed production runtime validation;
+- an optional Stripe adapter providing authenticated hosted subscription Checkout, durable duplicate-Checkout protection, Billing Portal management, raw-body webhook-signature verification, server-side Price-to-plan mapping, current-subscription reconciliation, replacement-subscription safety and bounded webhook-secret rotation overlap;
+- canonical production health endpoints at `/health/live` and `/health/ready`; older `/health` and `/ready` compatibility aliases are hidden in production;
+- trusted hosts, explicit proxy boundaries, bounded request bodies and fail-closed production runtime validation;
+- production API schema and interactive FastAPI docs hidden while development/test retain them;
 - privacy-minimized structured HTTP access logging with generated request IDs and raw query-string suppression;
 - verified production backup/restore tooling plus aggregate operational health checks for identity, monitoring jobs, identity-email delivery and backup freshness;
 - verified operator tenant offboarding with pre-delete recovery backup, Stripe-binding guard, shared-user preservation and compensating rollback;
 - a provider-neutral non-root production container with Chromium support, durable-storage guidance and secret/state build-context exclusions;
-- global response hardening with content-type, referrer, permissions, anti-framing and production HSTS controls while preserving the intentional public embed surface;
+- a read-only `veridra-production-preflight` command validating production runtime, durable-storage, legal, SMTP and optional/required Stripe configuration without emitting secrets;
+- a read-only `veridra-deployment-check` command validating a real public HTTPS deployment, including liveness/readiness, signup availability, hidden production-only surfaces, security headers and no-store controls, with validated-IP connection pinning and multi-address fallback;
+- global response hardening with HSTS in production, anti-sniffing, referrer/permissions controls and an explicit CSP that disables scripts, constrains resource/form/connection sources and preserves only the intentional `/embed/` framing surface;
 - an agency workflow home that separates temporary quick audits from persistent client projects and exposes only tenant-qualified normal-user operations;
 - deterministic comparisons, history, evidence packages and CI validation.
 
@@ -49,15 +54,17 @@ The core evidence model is:
 
 The repository quality gate includes Ruff, strict mypy, pytest, a deterministic repository audit, a Chromium browser audit and an isolated commercial-acceptance journey.
 
-The commercial acceptance runner exercises onboarding, Agency entitlement, a client project, branded HTML/PDF output, a tenant-bound lead form and public preview, lead qualification/follow-up, remediation-task creation/management and monitoring. It captures browser evidence and fails on false checks or unexpected request failures.
+The commercial acceptance runner uses the isolated non-production bootstrap path, then exercises Agency entitlement, a client project, branded HTML/PDF output, a tenant-bound lead form and public preview, lead qualification/follow-up, remediation-task creation/management and monitoring. It captures browser evidence and fails on false checks or unexpected request failures. Production `/onboarding` is intentionally unavailable and is separately protected by regression and deployment-acceptance checks.
 
 These checks verify repository behavior; they do not replace deployment-specific acceptance testing or an independent security assessment.
 
 ## Production foundation and remaining deployment work
 
-The application provides explicit development, test and production modes; mandatory durable paths and trusted origins in production; trusted-host and proxy boundaries; bounded request bodies; health/readiness endpoints; global security headers; browser authentication/recovery; transactional SMTP identity email; reusable agency signup; invitation acceptance; Stripe billing integration; backup/restore; operational checks; access logging; tenant offboarding; and separate web and monitoring-worker processes.
+The application provides explicit development, test and production modes; mandatory durable paths and trusted origins in production; trusted-host and proxy boundaries; bounded request bodies; canonical health/readiness endpoints; global security headers; browser authentication/recovery; transactional SMTP identity email; verified public agency signup; invitation acceptance; Stripe billing integration; backup/restore; operational checks; access logging; tenant offboarding; and separate web and monitoring-worker processes.
 
-The composed runtime exposes the tenant-native agency and API workflow rather than the old standalone global browser trees. Compatibility router modules remain in the repository for isolated migration or compatibility use.
+Production configuration can be checked before startup with `veridra-production-preflight`. A deployed public HTTPS origin can then be checked read-only with `veridra-deployment-check`. These commands validate application/deployment contracts; they do not provision provider resources.
+
+The composed runtime exposes the tenant-native agency and API workflow rather than the old standalone global browser trees. Compatibility router modules may remain in the repository for isolated migration/test use, but production hides the one-time browser onboarding route, legacy health aliases and FastAPI schema/documentation surfaces.
 
 Stripe integration is implemented in code but remains opt-in. A real deployment still has to create and configure the external Stripe account resources, recurring Prices, Billing Portal settings, webhook endpoint and secrets. A real SMTP provider/account likewise has to be selected and configured.
 
@@ -65,7 +72,7 @@ The repository includes a non-root provider-neutral Docker image and explicit li
 
 The current persistence model combines SQLite with filesystem tenant state and should be treated as single-writer unless shared persistence and concurrency are explicitly redesigned and tested.
 
-Remaining production work is now primarily external and deployment-specific: provision a hosted environment; configure DNS/TLS, durable storage, SMTP and Stripe resources; configure upstream access-log redaction and edge abuse controls; schedule backups/ops checks; and run deployment-specific acceptance/security validation.
+Remaining production work is now primarily external and deployment-specific: provision a hosted environment; configure DNS/TLS, durable storage, SMTP and Stripe resources; configure upstream access-log redaction and edge abuse controls; schedule backups/ops checks; run `veridra-production-preflight`; run `veridra-deployment-check`; and prove the complete signup → billing → agency workflow on the deployed origin.
 
 ## Important AI terminology
 
@@ -99,9 +106,17 @@ For the packaged Windows operational workflow, use the root helper scripts such 
 
 The Windows launcher defaults to `http://127.0.0.1:8010` to avoid common local conflicts. Override it with `VERIDRA_LOCAL_PORT` when needed.
 
-Browser signup is served at `/signup`; signup verification emails point to `/verify-signup?token=...`. Browser sign-in is served at `/login`; password recovery starts at `/forgot-password`, and reset emails point to `/reset-password?token=...` on the configured trusted origin.
+Browser signup is served at `/signup`; signup verification emails point to `/verify-signup?token=...`. Browser sign-in is served at `/login`; password recovery starts at `/forgot-password`, and reset emails point to `/reset-password?token=...` on the configured trusted origin. `/onboarding` is only a local/non-production first-owner bootstrap helper and is hidden in production.
 
-Production configuration is documented under `docs/operations/`, including deployment, Stripe billing, security headers, access logging, backup/restore and tenant offboarding.
+Production validation commands:
+
+```text
+veridra-production-preflight
+veridra-production-preflight --require-stripe
+veridra-deployment-check --origin https://app.example.com
+```
+
+Production configuration is documented under `docs/operations/`, including deployment, deployment acceptance, production preflight, Stripe billing, security headers, access logging, backup/restore and tenant offboarding.
 
 ## Safety boundary
 
@@ -115,6 +130,6 @@ The authenticated agency workflow covers the commercial parity path:
 
 > audit → project → white-label report → lead capture/qualification → remediation → monitoring/proof of improvement.
 
-The code-side commercial and production foundations now also cover customer signup, invitation email/browser acceptance, subscription authority, Stripe customer billing flows, production containerization, health/readiness, response hardening, verified backup/restore, operational checks, structured access logging and tenant offboarding.
+The code-side commercial and production foundations now also cover customer signup/legal evidence, invitation email/browser acceptance, subscription authority, Stripe customer billing flows, production containerization, canonical health/readiness, stronger CSP/response hardening, verified backup/restore, operational checks, structured access logging, tenant offboarding, pre-deployment configuration validation and remote deployment acceptance.
 
-The next coherent priority is deployment validation rather than another broad feature layer: stand up a real hosted environment, connect SMTP and Stripe provider resources, configure DNS/TLS/persistent storage/edge controls, and prove the complete signup → billing → agency workflow on the deployed origin.
+The next coherent priority is real deployment rather than another broad feature layer: stand up a hosted environment, connect SMTP and Stripe provider resources, configure DNS/TLS/persistent storage/edge controls, run the preflight and remote deployment gates, and prove the complete signup → billing → agency workflow on the deployed origin.


### PR DESCRIPTION
Documentation-only reconciliation of README with the production state actually merged: verified signup/legal boundary, production-hidden onboarding/schema/legacy health aliases, atomic quota/project-capacity and Stripe Checkout protections, stronger CSP, production preflight, remote deployment acceptance with validated-IP fallback, and the remaining provider-dependent deployment work. No application behavior changes. Exact-head full CI must still pass before merge.