### PR TITLE
Add provider-neutral single-host deployment bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 htmlcov/
 artifacts/
 *.egg-info/
+
+deployment/veridra.env

--- a/deployment/Caddyfile
+++ b/deployment/Caddyfile
@@ -1,0 +1,27 @@
+{$VERIDRA_DOMAIN} {
+    encode zstd gzip
+
+    log {
+        output stdout
+        format filter {
+            request>uri query {
+                replace token REDACTED
+            }
+            request>remote_ip delete
+            request>client_ip delete
+            request>headers>X-Forwarded-For delete
+        }
+    }
+
+    reverse_proxy web:8000 {
+        header_up -Forwarded
+        header_up -X-Forwarded-*
+
+        health_uri /health/ready
+        health_interval 30s
+        health_timeout 5s
+        health_headers {
+            Host {$VERIDRA_DOMAIN}
+        }
+    }
+}

--- a/deployment/compose.yaml
+++ b/deployment/compose.yaml
@@ -1,0 +1,63 @@
+name: veridra
+
+x-veridra-app: &veridra-app
+  build:
+    context: ..
+    dockerfile: Dockerfile
+  image: veridra:${VERIDRA_IMAGE_TAG:-local}
+  env_file:
+    - ./veridra.env
+  volumes:
+    - veridra_data:/var/lib/veridra
+
+services:
+  web:
+    <<: *veridra-app
+    restart: unless-stopped
+    expose:
+      - "8000"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          response=urllib.request.urlopen('http://127.0.0.1:8000/health/live', timeout=3);
+          raise SystemExit(0 if response.status == 200 else 1)
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  worker:
+    <<: *veridra-app
+    profiles:
+      - worker
+    restart: "no"
+    command:
+      - veridra-monitoring-worker
+      - --limit
+      - "10"
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      web:
+        condition: service_healthy
+    environment:
+      VERIDRA_DOMAIN: ${VERIDRA_DOMAIN:?Set VERIDRA_DOMAIN in deployment/veridra.env}
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  veridra_data:
+  caddy_data:
+  caddy_config:

--- a/deployment/veridra.env.example
+++ b/deployment/veridra.env.example
@@ -1,0 +1,31 @@
+# Copy to deployment/veridra.env on the production host. Do not commit the real file.
+VERIDRA_DOMAIN=app.example.com
+VERIDRA_IMAGE_TAG=local
+
+VERIDRA_ENV=production
+VERIDRA_IDENTITY_DB=/var/lib/veridra/identity/identity.sqlite3
+VERIDRA_TENANT_DATA_ROOT=/var/lib/veridra/tenants
+VERIDRA_TRUSTED_ORIGIN=https://app.example.com
+VERIDRA_ALLOWED_HOSTS=app.example.com
+VERIDRA_BIND_HOST=0.0.0.0
+VERIDRA_BIND_PORT=8000
+VERIDRA_MAX_REQUEST_BODY_BYTES=1000000
+
+VERIDRA_PRIVACY_URL=https://example.com/privacy
+VERIDRA_TERMS_URL=https://example.com/terms
+
+VERIDRA_SMTP_HOST=smtp.example.com
+VERIDRA_SMTP_PORT=587
+VERIDRA_SMTP_ENCRYPTION=starttls
+VERIDRA_SMTP_SENDER=security@example.com
+VERIDRA_SMTP_SENDER_NAME=Veridra
+# VERIDRA_SMTP_USERNAME=provider-user
+# VERIDRA_SMTP_PASSWORD=replace-with-runtime-secret
+
+# Optional Stripe billing. Leave every Stripe variable absent for a Free-only launch.
+# VERIDRA_STRIPE_SECRET_KEY=sk_live_replace
+# VERIDRA_STRIPE_WEBHOOK_SECRET=whsec_replace
+# VERIDRA_STRIPE_WEBHOOK_SECRET_PREVIOUS=whsec_previous_during_rotation_only
+# VERIDRA_STRIPE_PRICE_SOLO=price_replace
+# VERIDRA_STRIPE_PRICE_PROFESSIONAL=price_replace
+# VERIDRA_STRIPE_PRICE_AGENCY=price_replace

--- a/docs/operations/single-host-deployment.md
+++ b/docs/operations/single-host-deployment.md
@@ -1,0 +1,118 @@
+# Single-host production deployment
+
+The `deployment/` bundle is a provider-neutral Docker Compose baseline for Veridra's current single-writer persistence model. It is intended for one Linux host with a public IPv4/IPv6 address, a DNS name and Docker Engine with the Compose plugin.
+
+It runs:
+
+- `web` — the Veridra API/browser runtime, available only on the private Compose network;
+- `caddy` — the only Internet-facing service, publishing TCP 80/443 and UDP 443 and obtaining/renewing public TLS certificates automatically once DNS points at the host;
+- `worker` — the same Veridra image with the bounded monitoring-worker command, available as an on-demand Compose profile for a host scheduler;
+- one named `veridra_data` volume shared by web and worker, plus Caddy's certificate/config volumes.
+
+This is deliberately one application writer topology. Do not scale `web` horizontally or start overlapping worker invocations without redesigning shared persistence/locking first.
+
+## 1. Prepare the host
+
+Clone the repository onto the host and work from the `deployment/` directory. Copy the example environment file:
+
+```text
+cp veridra.env.example veridra.env
+chmod 600 veridra.env
+```
+
+Edit `veridra.env` with the real domain, trusted origin, allowed host, Terms/Privacy URLs and SMTP settings. If paid launch is required, also configure the real Stripe keys, webhook secret and Price IDs. The real `deployment/veridra.env` is gitignored and must remain host-local or be generated from a secret manager.
+
+The values of `VERIDRA_DOMAIN`, `VERIDRA_TRUSTED_ORIGIN` and `VERIDRA_ALLOWED_HOSTS` must describe the same public hostname. Point DNS A/AAAA records for that hostname at the server and allow inbound TCP 80/443 plus UDP 443. Do not publish container port 8000 on the host firewall or Docker command line.
+
+## 2. Validate configuration before launch
+
+Build the image and validate the Caddy configuration:
+
+```text
+docker compose --env-file ./veridra.env -f compose.yaml build web worker
+docker compose --env-file ./veridra.env -f compose.yaml run --rm caddy caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+```
+
+Run Veridra's read-only production preflight with the same environment and durable volume:
+
+```text
+docker compose --env-file ./veridra.env -f compose.yaml run --rm web veridra-production-preflight
+```
+
+For a paid launch:
+
+```text
+docker compose --env-file ./veridra.env -f compose.yaml run --rm web veridra-production-preflight --require-stripe
+```
+
+Do not start production if preflight returns exit code `2`.
+
+## 3. Start web and TLS proxy
+
+```text
+docker compose --env-file ./veridra.env -f compose.yaml up -d web caddy
+```
+
+Only Caddy publishes host ports. Veridra itself is exposed only as `web:8000` on the private Compose network. Caddy checks `/health/ready` and preserves the public `Host` header while stripping `Forwarded` and `X-Forwarded-*` before proxying, matching Veridra's safest proxy boundary without trusting a dynamic container IP.
+
+Caddy access logs are JSON to stdout. The supplied filter replaces the value of any `token` query parameter with `REDACTED` and removes direct/client IP fields plus `X-Forwarded-For` from the log event. Caddy also redacts credential-style headers by default. Keep this filter if proxy access logging is enabled; do not replace it with raw common-log output.
+
+Check service state:
+
+```text
+docker compose --env-file ./veridra.env -f compose.yaml ps
+docker compose --env-file ./veridra.env -f compose.yaml logs --tail=100 web caddy
+```
+
+## 4. Run the remote deployment gate
+
+From a separate operator machine or CI runner that can reach the public hostname, run:
+
+```text
+veridra-deployment-check --origin https://app.example.com
+```
+
+Use the actual public origin. The checker validates public DNS addresses, pins each connection to the validated address while preserving TLS SNI/Host, and checks the canonical health endpoints, signup surface, hidden production-only routes, security headers and cache controls. A multi-address DNS record is tried safely across its already validated public addresses.
+
+A successful remote deployment check is required before treating the host as ready for customer traffic.
+
+## 5. Schedule the bounded monitoring worker
+
+The `worker` service is intentionally not a daemon. Invoke it from the host scheduler and allow each run to exit before the next run begins. Example cron entry every five minutes when the repository lives at `/opt/veridra`:
+
+```text
+*/5 * * * * cd /opt/veridra/deployment && /usr/bin/docker compose --env-file ./veridra.env -f compose.yaml run --rm worker >> /var/log/veridra-worker.log 2>&1
+```
+
+Adjust cadence based on the monitoring product schedule, but do not create overlapping invocations. Use a systemd timer/locking wrapper instead of cron if the host needs stronger no-overlap guarantees.
+
+## 6. Backup
+
+Veridra backup requires explicit writer quiescence. Stop web traffic and ensure no monitoring-worker or billing writer is active before asserting `--confirm-quiesced`.
+
+Example with a host backup directory mounted outside `/var/lib/veridra`:
+
+```text
+mkdir -p /opt/veridra-backups
+docker compose --env-file ./veridra.env -f compose.yaml stop web
+docker compose --env-file ./veridra.env -f compose.yaml run --rm -v /opt/veridra-backups:/backups worker veridra-backup backup --output /backups/veridra-backup.zip --confirm-quiesced
+docker compose --env-file ./veridra.env -f compose.yaml start web
+```
+
+Copy verified backups off the server. A single VPS plus a local Docker volume is not itself a disaster-recovery strategy.
+
+## 7. Upgrade
+
+Pull the intended repository revision, rebuild, run preflight, then replace the web container:
+
+```text
+docker compose --env-file ./veridra.env -f compose.yaml build web worker
+docker compose --env-file ./veridra.env -f compose.yaml run --rm web veridra-production-preflight
+docker compose --env-file ./veridra.env -f compose.yaml up -d web caddy
+```
+
+After every deployment, run `veridra-deployment-check` from outside the host and then exercise the controlled signup/billing/agency acceptance path appropriate to the release.
+
+## Provider boundary
+
+This bundle does not select or provision a VPS vendor, DNS registrar/provider, SMTP service or Stripe account. It assumes a Linux host already exists. Provider selection should therefore be based on current cost, durable storage/backup options, outbound SMTP policy, support and the operator's desired management burden rather than changing Veridra's application architecture.

--- a/docs/operations/single-host-deployment.md
+++ b/docs/operations/single-host-deployment.md
@@ -78,24 +78,25 @@ A successful remote deployment check is required before treating the host as rea
 
 ## 5. Schedule the bounded monitoring worker
 
-The `worker` service is intentionally not a daemon. Invoke it from the host scheduler and allow each run to exit before the next run begins. Example cron entry every five minutes when the repository lives at `/opt/veridra`:
+The `worker` service is intentionally not a daemon. Invoke it from the host scheduler and allow each run to exit before the next run begins. Example cron entry every five minutes when the repository lives at `/opt/veridra` uses `flock` so a slow previous run cannot overlap the next invocation:
 
 ```text
-*/5 * * * * cd /opt/veridra/deployment && /usr/bin/docker compose --env-file ./veridra.env -f compose.yaml run --rm worker >> /var/log/veridra-worker.log 2>&1
+*/5 * * * * flock -n /var/lock/veridra-worker.lock sh -c 'cd /opt/veridra/deployment && /usr/bin/docker compose --env-file ./veridra.env -f compose.yaml run --rm worker >> /var/log/veridra-worker.log 2>&1'
 ```
 
-Adjust cadence based on the monitoring product schedule, but do not create overlapping invocations. Use a systemd timer/locking wrapper instead of cron if the host needs stronger no-overlap guarantees.
+Adjust cadence based on the monitoring product schedule. If `flock` is unavailable, use a systemd timer or another scheduler with an explicit no-overlap guarantee rather than plain recurring cron.
 
 ## 6. Backup
 
 Veridra backup requires explicit writer quiescence. Stop web traffic and ensure no monitoring-worker or billing writer is active before asserting `--confirm-quiesced`.
 
-Example with a host backup directory mounted outside `/var/lib/veridra`:
+Example with a host backup directory mounted outside `/var/lib/veridra`. A UTC timestamp is part of every archive name because verified backup intentionally refuses to overwrite an existing archive:
 
 ```text
 mkdir -p /opt/veridra-backups
+BACKUP_NAME="veridra-$(date -u +%Y%m%dT%H%M%SZ).zip"
 docker compose --env-file ./veridra.env -f compose.yaml stop web
-docker compose --env-file ./veridra.env -f compose.yaml run --rm -v /opt/veridra-backups:/backups worker veridra-backup backup --output /backups/veridra-backup.zip --confirm-quiesced
+docker compose --env-file ./veridra.env -f compose.yaml run --rm -v /opt/veridra-backups:/backups worker veridra-backup backup --output "/backups/${BACKUP_NAME}" --confirm-quiesced
 docker compose --env-file ./veridra.env -f compose.yaml start web
 ```
 

--- a/tests/test_single_host_deployment_bundle.py
+++ b/tests/test_single_host_deployment_bundle.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 DEPLOYMENT = ROOT / "deployment"
 

--- a/tests/test_single_host_deployment_bundle.py
+++ b/tests/test_single_host_deployment_bundle.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOYMENT = ROOT / "deployment"
+
+
+def test_compose_keeps_application_private_and_persists_state() -> None:
+    compose = (DEPLOYMENT / "compose.yaml").read_text(encoding="utf-8")
+
+    assert '"80:80"' in compose
+    assert '"443:443"' in compose
+    assert '"8000:8000"' not in compose
+    assert "expose:\n      - \"8000\"" in compose
+    assert "veridra_data:/var/lib/veridra" in compose
+    assert "condition: service_healthy" in compose
+    assert "veridra-monitoring-worker" in compose
+    assert "profiles:\n      - worker" in compose
+    assert 'restart: "no"' in compose
+
+
+def test_caddy_preserves_runtime_proxy_boundary_and_redacts_tokens() -> None:
+    caddyfile = (DEPLOYMENT / "Caddyfile").read_text(encoding="utf-8")
+
+    assert "reverse_proxy web:8000" in caddyfile
+    assert "header_up -Forwarded" in caddyfile
+    assert "header_up -X-Forwarded-*" in caddyfile
+    assert "replace token REDACTED" in caddyfile
+    assert "request>remote_ip delete" in caddyfile
+    assert "request>client_ip delete" in caddyfile
+    assert "health_uri /health/ready" in caddyfile
+    assert "Host {$VERIDRA_DOMAIN}" in caddyfile
+
+
+def test_environment_template_is_safe_and_real_file_is_ignored() -> None:
+    example = (DEPLOYMENT / "veridra.env.example").read_text(encoding="utf-8")
+    gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8")
+
+    assert "VERIDRA_ENV=production" in example
+    assert "VERIDRA_IDENTITY_DB=/var/lib/veridra/identity/identity.sqlite3" in example
+    assert "VERIDRA_TENANT_DATA_ROOT=/var/lib/veridra/tenants" in example
+    assert "VERIDRA_PRIVACY_URL=" in example
+    assert "VERIDRA_TERMS_URL=" in example
+    assert "VERIDRA_SMTP_HOST=" in example
+    assert "sk_live_replace" in example
+    assert "deployment/veridra.env" in gitignore
+    assert not (DEPLOYMENT / "veridra.env").exists()


### PR DESCRIPTION
Add a production deployment baseline aligned with Veridra's current single-writer architecture: Docker Compose web + bounded worker + durable volume + Caddy TLS reverse proxy. The web port stays private; only Caddy publishes 80/443. Caddy strips Forwarded/X-Forwarded headers before Veridra, redacts token query values and client IP fields from access logs, and health-checks the canonical readiness endpoint. Includes a gitignored production env-file pattern, safe example config, deployment/backup/worker runbook and regression tests for bundle invariants. Provider selection/provisioning remains external. Host deployment must run `caddy validate`, `veridra-production-preflight` and the remote `veridra-deployment-check`. Do not merge until exact-head full CI succeeds.