### PR TITLE
Add unified prospect foundation

### DIFF
--- a/docs/architecture/leads-veridra-fusion.md
+++ b/docs/architecture/leads-veridra-fusion.md
@@ -1,0 +1,96 @@
+# LEADS + Veridra fusion
+
+## Product decision
+
+Veridra is the canonical Webify acquisition workbench.
+
+The former `leadmap-local` / LEADS application remains a source repository during migration, but it is no longer the intended operational boundary. The end-state workflow is one application:
+
+> discover business -> qualify commercial fit -> audit website -> classify refurbishment opportunity -> approve outreach -> track conversation/proposal -> convert to client project -> prove improvement
+
+The primary success metric is Webify customer acquisition and refurbishment revenue, not Veridra subscription MRR.
+
+## Why the applications are being fused
+
+LEADS already modeled the commercial path as `qualified -> shortlisted -> sent_to_veridra -> veridra_reviewed -> approved_for_outreach`. Those handoff states existed only because discovery and website assessment lived in separate applications.
+
+The fused model removes that transport boundary. A Veridra `Prospect` persists discovery evidence and Stage-A business qualification before any deep website audit. The same record then advances through audit, outreach and customer states.
+
+Inbound website-audit form submissions remain `AuditLead` records. They carry consent and delivery semantics and must not be conflated with outbound Webify prospect research.
+
+## Canonical prospect lifecycle
+
+The initial lifecycle is:
+
+- `new`
+- `needs_review`
+- `qualified`
+- `shortlisted`
+- `ready_for_audit`
+- `audited`
+- `approved_for_outreach`
+- `contacted`
+- `responded`
+- `conversation`
+- `proposal`
+- `customer`
+- terminal/support states: `unsuitable`, `duplicate`, `archived`
+
+There is deliberately no `sent_to_veridra` or `veridra_reviewed` state because Veridra now owns both sides of the former handoff.
+
+## Stage A: commercial qualification
+
+The LEADS Webify Qualification v0.1 gate is retained as a seven-criterion, 0-2 scoring model:
+
+1. active real business;
+2. website commercial importance;
+3. business economic value;
+4. business size/fit;
+5. decision-maker reachability;
+6. website/platform manageability;
+7. absence of an obvious existing agency/internal web team.
+
+Maximum score: 14.
+
+- 11-14: `send_to_audit`;
+- 8-10: `hold`;
+- 0-7: `reject`.
+
+An explicit rejection reason overrides the numeric score. Human-readable reasoning is mandatory so the score never becomes opaque automation.
+
+## Rejection evidence
+
+The retained rejection taxonomy is:
+
+- `BUSINESS_INACTIVE`
+- `TOO_SMALL_LOW_VALUE`
+- `TOO_LARGE`
+- `WEBSITE_NOT_IMPORTANT`
+- `INTERNAL_WEB_TEAM`
+- `AGENCY_PRESENT`
+- `NO_CONTACT_ROUTE`
+- `TECH_TOO_COMPLEX`
+- `NO_MEANINGFUL_FINDINGS`
+- `FINDINGS_NOT_FIXABLE`
+- `FIX_TOO_LARGE_FOR_OFFER`
+- `LOW_COMMERCIAL_IMPACT`
+- `EVIDENCE_UNCERTAIN`
+- `DUPLICATE`
+- `OTHER`
+
+These reasons are commercial-learning data. They should later be aggregated to show whether discovery sources, ICP assumptions, audit criteria or the Webify offer are wrong.
+
+## Migration sequence
+
+1. **Prospect foundation** — canonical prospect model, tenant persistence and API in Veridra.
+2. **LEADS import adapter** — deterministic import of existing `leadmap-local` shortlist/handoff data without re-discovery.
+3. **Discovery engine** — migrate provider-neutral territory/query/normalization/deduplication logic into Veridra.
+4. **Local discovery UI** — move the useful territory/business review experience into Veridra; do not copy framework complexity merely for parity.
+5. **Audit conversion** — one action turns a qualified prospect website into the existing Veridra assessment/project pipeline and records the relationship.
+6. **Opportunity qualification** — classify audit findings by Webify commercial usefulness (A/B/C/D), fixability and estimated effort.
+7. **Outreach/pipeline** — manual outreach status, notes, proposal and customer outcome inside the same prospect record/workflow.
+8. **Archive LEADS** — only after the migrated workflow can reproduce the operational discovery-to-audit path and required data from `leadmap-local`.
+
+## Operating boundary
+
+Discovery remains bounded and reviewable. Deep website assessment happens after commercial qualification, and outreach remains a human-reviewed business action. Technical findings must not be turned into sales urgency unless they are reproducible, commercially meaningful and realistically fixable by Webify.

--- a/src/veridra/leadmap_import.py
+++ b/src/veridra/leadmap_import.py
@@ -82,19 +82,21 @@ def prospect_from_leadmap(record: LeadMapExportRecord) -> Prospect:
         f"first observed {record.first_observed_at.isoformat()}, "
         f"last observed {record.last_observed_at.isoformat()}."
     )
-    return Prospect(
-        business_name=record.business_name,
-        website=record.website or None,
-        locality=record.locality,
-        administrative_area=record.administrative_area,
-        country_code=record.country_code.upper(),
-        phone=record.phone,
-        provider="leadmap-local",
-        provider_key=provider_key,
-        evidence_summary=observed,
-        status=status,
-        created_at=record.first_observed_at,
-        updated_at=record.last_observed_at,
+    return Prospect.model_validate(
+        {
+            "business_name": record.business_name,
+            "website": record.website or None,
+            "locality": record.locality,
+            "administrative_area": record.administrative_area,
+            "country_code": record.country_code.upper(),
+            "phone": record.phone,
+            "provider": "leadmap-local",
+            "provider_key": provider_key,
+            "evidence_summary": observed,
+            "status": status,
+            "created_at": record.first_observed_at,
+            "updated_at": record.last_observed_at,
+        }
     )
 
 

--- a/src/veridra/leadmap_import.py
+++ b/src/veridra/leadmap_import.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .prospect import Prospect, ProspectStatus
+
+LEADMAP_EXPORT_SCHEMA_VERSION = "1.1"
+
+
+class LeadMapImportError(ValueError):
+    pass
+
+
+class LeadMapExportRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    business_id: str = Field(min_length=1, max_length=120)
+    location_id: str = Field(min_length=1, max_length=120)
+    business_name: str = Field(min_length=1, max_length=200)
+    qualification_status: str = Field(default="needs_review", max_length=80)
+    country_code: str = Field(default="", max_length=2)
+    administrative_area: str = Field(default="", max_length=120)
+    locality: str = Field(default="", max_length=120)
+    postal_area: str = Field(default="", max_length=40)
+    phone: str = Field(default="", max_length=80)
+    website: str = Field(default="", max_length=2048)
+    first_observed_at: datetime
+    last_observed_at: datetime
+
+
+class LeadMapExport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str
+    exported_at: datetime
+    records: list[LeadMapExportRecord]
+
+
+_STATUS_MAP: dict[str, ProspectStatus] = {
+    "new": ProspectStatus.new,
+    "needs_review": ProspectStatus.needs_review,
+    "qualified": ProspectStatus.qualified,
+    "shortlisted": ProspectStatus.shortlisted,
+    "sent_to_veridra": ProspectStatus.ready_for_audit,
+    "veridra_reviewed": ProspectStatus.audited,
+    "approved_for_outreach": ProspectStatus.approved_for_outreach,
+    "contacted": ProspectStatus.contacted,
+    "responded": ProspectStatus.responded,
+    "conversation": ProspectStatus.conversation,
+    "proposal": ProspectStatus.proposal,
+    "customer": ProspectStatus.customer,
+    "unsuitable": ProspectStatus.needs_review,
+    "duplicate": ProspectStatus.duplicate,
+    "archived": ProspectStatus.archived,
+}
+
+
+def parse_leadmap_export(payload: str | bytes | dict[str, Any]) -> LeadMapExport:
+    try:
+        export = (
+            LeadMapExport.model_validate(payload)
+            if isinstance(payload, dict)
+            else LeadMapExport.model_validate_json(payload)
+        )
+    except ValueError as exc:
+        raise LeadMapImportError("LEADS export could not be validated.") from exc
+    if export.schema_version != LEADMAP_EXPORT_SCHEMA_VERSION:
+        raise LeadMapImportError(
+            f"Unsupported LEADS export schema version: {export.schema_version}."
+        )
+    return export
+
+
+def prospect_from_leadmap(record: LeadMapExportRecord) -> Prospect:
+    status = _STATUS_MAP.get(record.qualification_status, ProspectStatus.needs_review)
+    provider_key = f"{record.business_id}:{record.location_id}"
+    observed = (
+        f"Imported from LEADS schema {LEADMAP_EXPORT_SCHEMA_VERSION}; "
+        f"first observed {record.first_observed_at.isoformat()}, "
+        f"last observed {record.last_observed_at.isoformat()}."
+    )
+    return Prospect(
+        business_name=record.business_name,
+        website=record.website or None,
+        locality=record.locality,
+        administrative_area=record.administrative_area,
+        country_code=record.country_code.upper(),
+        phone=record.phone,
+        provider="leadmap-local",
+        provider_key=provider_key,
+        evidence_summary=observed,
+        status=status,
+        created_at=record.first_observed_at,
+        updated_at=record.last_observed_at,
+    )
+
+
+def prospects_from_leadmap_export(payload: str | bytes | dict[str, Any]) -> list[Prospect]:
+    export = parse_leadmap_export(payload)
+    return [prospect_from_leadmap(record) for record in export.records]

--- a/src/veridra/prospect.py
+++ b/src/veridra/prospect.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
+
+
+class ProspectStatus(StrEnum):
+    new = "new"
+    needs_review = "needs_review"
+    qualified = "qualified"
+    shortlisted = "shortlisted"
+    ready_for_audit = "ready_for_audit"
+    audited = "audited"
+    approved_for_outreach = "approved_for_outreach"
+    contacted = "contacted"
+    responded = "responded"
+    conversation = "conversation"
+    proposal = "proposal"
+    customer = "customer"
+    unsuitable = "unsuitable"
+    duplicate = "duplicate"
+    archived = "archived"
+
+
+class ProspectDecision(StrEnum):
+    send_to_audit = "send_to_audit"
+    hold = "hold"
+    reject = "reject"
+
+
+class ProspectRejectionReason(StrEnum):
+    business_inactive = "BUSINESS_INACTIVE"
+    too_small_low_value = "TOO_SMALL_LOW_VALUE"
+    too_large = "TOO_LARGE"
+    website_not_important = "WEBSITE_NOT_IMPORTANT"
+    internal_web_team = "INTERNAL_WEB_TEAM"
+    agency_present = "AGENCY_PRESENT"
+    no_contact_route = "NO_CONTACT_ROUTE"
+    tech_too_complex = "TECH_TOO_COMPLEX"
+    no_meaningful_findings = "NO_MEANINGFUL_FINDINGS"
+    findings_not_fixable = "FINDINGS_NOT_FIXABLE"
+    fix_too_large_for_offer = "FIX_TOO_LARGE_FOR_OFFER"
+    low_commercial_impact = "LOW_COMMERCIAL_IMPACT"
+    evidence_uncertain = "EVIDENCE_UNCERTAIN"
+    duplicate = "DUPLICATE"
+    other = "OTHER"
+
+
+class StageAQualification(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    active_real_business: int = Field(ge=0, le=2)
+    website_commercial_importance: int = Field(ge=0, le=2)
+    business_economic_value: int = Field(ge=0, le=2)
+    business_size_fit: int = Field(ge=0, le=2)
+    decision_maker_reachability: int = Field(ge=0, le=2)
+    website_manageability: int = Field(ge=0, le=2)
+    no_existing_web_team: int = Field(ge=0, le=2)
+    reason: str = Field(min_length=1, max_length=1000)
+    rejection_reason: ProspectRejectionReason | None = None
+
+    @property
+    def score(self) -> int:
+        return sum(
+            (
+                self.active_real_business,
+                self.website_commercial_importance,
+                self.business_economic_value,
+                self.business_size_fit,
+                self.decision_maker_reachability,
+                self.website_manageability,
+                self.no_existing_web_team,
+            )
+        )
+
+    @property
+    def decision(self) -> ProspectDecision:
+        if self.rejection_reason is not None:
+            return ProspectDecision.reject
+        if self.score >= 11:
+            return ProspectDecision.send_to_audit
+        if self.score >= 8:
+            return ProspectDecision.hold
+        return ProspectDecision.reject
+
+
+class Prospect(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    business_name: str = Field(min_length=1, max_length=200)
+    website: HttpUrl | None = None
+    sector: str = Field(default="", max_length=120)
+    locality: str = Field(default="", max_length=120)
+    administrative_area: str = Field(default="", max_length=120)
+    country_code: str = Field(default="", max_length=2)
+    phone: str = Field(default="", max_length=80)
+    contact_name: str = Field(default="", max_length=160)
+    contact_email: str = Field(default="", max_length=254)
+    provider: str = Field(default="manual", max_length=80)
+    provider_key: str = Field(default="", max_length=240)
+    source_url: HttpUrl | None = None
+    evidence_summary: str = Field(default="", max_length=4000)
+    qualification: StageAQualification | None = None
+    status: ProspectStatus = ProspectStatus.needs_review
+    audit_project_id: str = Field(default="", max_length=24)
+    best_observation: str = Field(default="", max_length=1000)
+    webify_fixable: bool | None = None
+    estimated_effort_hours: float | None = Field(default=None, ge=0, le=10_000)
+    likely_offer: str = Field(default="", max_length=240)
+    human_verified: bool = False
+    rejection_reason: ProspectRejectionReason | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @model_validator(mode="after")
+    def align_rejection_reason(self) -> Prospect:
+        if self.status is ProspectStatus.unsuitable and self.rejection_reason is None:
+            raise ValueError("Unsuitable prospects require a rejection reason.")
+        return self
+
+
+class ProspectStoreError(RuntimeError):
+    pass
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile(
+        mode="wb",
+        dir=path.parent,
+        prefix=f".{path.stem}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        temporary.write(content)
+        temporary.flush()
+        os.fsync(temporary.fileno())
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(path)
+
+
+def prospect_identifier(prospect: Prospect) -> str:
+    website = str(prospect.website or "").lower().rstrip("/")
+    canonical = "|".join(
+        (
+            prospect.business_name.casefold(),
+            website,
+            prospect.locality.casefold(),
+            prospect.country_code.casefold(),
+        )
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:24]
+
+
+class ProspectStore:
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def save(self, prospect: Prospect) -> str:
+        identifier = prospect_identifier(prospect)
+        content = json.dumps(
+            prospect.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        _atomic_write(self.directory / f"{identifier}.json", content)
+        return identifier
+
+    def load(self, prospect_id: str) -> Prospect:
+        path = self.directory / f"{prospect_id}.json"
+        try:
+            return Prospect.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise ProspectStoreError("Saved prospect was not found or is invalid.") from exc
+
+    def list(self, *, status: ProspectStatus | None = None) -> list[tuple[str, Prospect]]:
+        if not self.directory.exists():
+            return []
+        items: list[tuple[str, Prospect]] = []
+        for path in sorted(self.directory.glob("*.json")):
+            try:
+                prospect = Prospect.model_validate_json(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if status is None or prospect.status is status:
+                items.append((path.stem, prospect))
+        return sorted(items, key=lambda item: (item[1].updated_at, item[0]), reverse=True)
+
+    def replace(self, prospect_id: str, prospect: Prospect) -> None:
+        path = self.directory / f"{prospect_id}.json"
+        if not path.exists():
+            raise ProspectStoreError("Saved prospect was not found.")
+        if prospect_identifier(prospect) != prospect_id:
+            raise ProspectStoreError("Prospect identity fields cannot be changed in place.")
+        content = json.dumps(
+            prospect.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        _atomic_write(path, content)
+
+    def delete(self, prospect_id: str) -> None:
+        path = self.directory / f"{prospect_id}.json"
+        if not path.exists():
+            raise ProspectStoreError("Saved prospect was not found.")
+        path.unlink()

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -57,6 +57,7 @@ from .tenant_lead_form_api import router as tenant_lead_form_router
 from .tenant_monitoring_api import router as tenant_monitoring_router
 from .tenant_profile_api import router as tenant_profile_router
 from .tenant_project_api import router as tenant_project_router
+from .tenant_prospect_api import router as tenant_prospect_router
 from .tenant_report_api import router as tenant_report_router
 from .tenant_task_api import router as tenant_task_router
 from .tenant_team_web import router as tenant_team_router
@@ -132,6 +133,7 @@ app.include_router(assessment_project_conversion_router)
 app.include_router(tenant_history_router)
 app.include_router(tenant_report_router)
 app.include_router(tenant_lead_router)
+app.include_router(tenant_prospect_router)
 app.include_router(lead_project_conversion_router)
 app.include_router(tenant_lead_form_router)
 app.include_router(tenant_task_router)

--- a/src/veridra/tenant_prospect_api.py
+++ b/src/veridra/tenant_prospect_api.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from .identity_tenancy import RequestIdentity, TenantCapability, TenantObjectRef
+from .prospect import Prospect, ProspectStatus
+from .request_security import require_request_capability
+from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
+
+router = APIRouter(prefix="/api/tenant/prospects", tags=["tenant-prospects"])
+ProspectReader = Annotated[
+    RequestIdentity,
+    Depends(require_request_capability(TenantCapability.view_data)),
+]
+ProspectManager = Annotated[
+    RequestIdentity,
+    Depends(require_request_capability(TenantCapability.manage_leads)),
+]
+
+
+def _store(request: Request) -> TenantProspectStore:
+    configured = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return TenantProspectStore(configured)
+
+
+def _target(identity: RequestIdentity, prospect_id: str) -> TenantObjectRef:
+    return TenantObjectRef(
+        tenant_id=identity.tenant_id,
+        object_type="prospect",
+        object_id=prospect_id,
+    )
+
+
+@router.get("")
+def list_prospects(
+    request: Request,
+    identity: ProspectReader,
+    status_filter: ProspectStatus | None = None,
+) -> list[dict[str, object]]:
+    return [
+        {"id": prospect_id, **prospect.model_dump(mode="json")}
+        for prospect_id, prospect in _store(request).list(identity, status=status_filter)
+    ]
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def create_prospect(
+    payload: Prospect,
+    request: Request,
+    identity: ProspectManager,
+) -> dict[str, str]:
+    prospect_id = _store(request).save(identity, payload)
+    return {"id": prospect_id}
+
+
+@router.get("/{prospect_id}", response_model=Prospect)
+def get_prospect(
+    prospect_id: str,
+    request: Request,
+    identity: ProspectReader,
+) -> Prospect:
+    try:
+        return _store(request).load(identity, _target(identity, prospect_id))
+    except TenantProspectStoreError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Prospect not found.",
+        ) from exc
+
+
+@router.put("/{prospect_id}", response_model=Prospect)
+def replace_prospect(
+    prospect_id: str,
+    payload: Prospect,
+    request: Request,
+    identity: ProspectManager,
+) -> Prospect:
+    try:
+        target = _target(identity, prospect_id)
+        _store(request).replace(identity, target, payload)
+        return _store(request).load(identity, target)
+    except TenantProspectStoreError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Prospect not found.",
+        ) from exc
+
+
+@router.delete("/{prospect_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_prospect(
+    prospect_id: str,
+    request: Request,
+    identity: ProspectManager,
+) -> None:
+    try:
+        _store(request).delete(identity, _target(identity, prospect_id))
+    except TenantProspectStoreError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Prospect not found.",
+        ) from exc

--- a/src/veridra/tenant_prospect_store.py
+++ b/src/veridra/tenant_prospect_store.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .identity_tenancy import (
+    RequestIdentity,
+    TenantCapability,
+    TenantObjectRef,
+    require_tenant_capability,
+    require_tenant_scope,
+)
+from .prospect import Prospect, ProspectStatus, ProspectStore, ProspectStoreError
+from .tenant_project_store import default_tenant_data_directory
+
+
+class TenantProspectStoreError(RuntimeError):
+    pass
+
+
+class TenantProspectStore:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or default_tenant_data_directory()
+
+    def _store(self, identity: RequestIdentity) -> ProspectStore:
+        return ProspectStore(self.root / identity.tenant_id / "prospects")
+
+    @staticmethod
+    def ref(identity: RequestIdentity, prospect_id: str) -> TenantObjectRef:
+        return TenantObjectRef(
+            tenant_id=identity.tenant_id,
+            object_type="prospect",
+            object_id=prospect_id,
+        )
+
+    def save(self, identity: RequestIdentity, prospect: Prospect) -> str:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+        return self._store(identity).save(prospect)
+
+    def load(self, identity: RequestIdentity, target: TenantObjectRef) -> Prospect:
+        require_tenant_scope(identity, target)
+        if target.object_type != "prospect":
+            raise TenantProspectStoreError("Tenant object is not a prospect reference.")
+        try:
+            return self._store(identity).load(target.object_id)
+        except ProspectStoreError as exc:
+            raise TenantProspectStoreError("Saved prospect was not found.") from exc
+
+    def list(
+        self,
+        identity: RequestIdentity,
+        *,
+        status: ProspectStatus | None = None,
+    ) -> list[tuple[str, Prospect]]:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        return self._store(identity).list(status=status)
+
+    def replace(
+        self,
+        identity: RequestIdentity,
+        target: TenantObjectRef,
+        prospect: Prospect,
+    ) -> None:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+        require_tenant_scope(identity, target)
+        if target.object_type != "prospect":
+            raise TenantProspectStoreError("Tenant object is not a prospect reference.")
+        try:
+            self._store(identity).replace(target.object_id, prospect)
+        except ProspectStoreError as exc:
+            raise TenantProspectStoreError("Saved prospect was not found.") from exc
+
+    def delete(self, identity: RequestIdentity, target: TenantObjectRef) -> None:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+        require_tenant_scope(identity, target)
+        if target.object_type != "prospect":
+            raise TenantProspectStoreError("Tenant object is not a prospect reference.")
+        try:
+            self._store(identity).delete(target.object_id)
+        except ProspectStoreError as exc:
+            raise TenantProspectStoreError("Saved prospect was not found.") from exc

--- a/tests/test_invitation_web.py
+++ b/tests/test_invitation_web.py
@@ -21,7 +21,7 @@ from veridra.request_security import bind_verified_request_identity
 from veridra.sqlite_identity_store import SQLiteIdentityRecordStore
 from veridra.tenant_invitations import SQLiteTenantInvitationService
 
-NOW = datetime(2026, 8, 20, 15, 0, tzinfo=UTC)
+NOW = datetime.now(UTC).replace(microsecond=0)
 ORIGIN = "http://testserver"
 OWNER_PASSWORD = "owner-correct-horse-battery"
 INVITEE_PASSWORD = "invitee-correct-horse-battery"

--- a/tests/test_leadmap_import.py
+++ b/tests/test_leadmap_import.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from veridra.leadmap_import import LeadMapImportError, prospects_from_leadmap_export
+from veridra.prospect import ProspectStatus
+
+NOW = datetime(2026, 8, 22, 18, 0, tzinfo=UTC)
+
+
+def _payload(*, schema_version: str = "1.1", qualification_status: str = "shortlisted") -> str:
+    return json.dumps(
+        {
+            "schema_version": schema_version,
+            "exported_at": NOW.isoformat(),
+            "records": [
+                {
+                    "business_id": "business-01",
+                    "location_id": "location-01",
+                    "business_name": "Murphy Roofing Ltd",
+                    "qualification_status": qualification_status,
+                    "country_code": "ie",
+                    "administrative_area": "Cork",
+                    "locality": "Cork",
+                    "postal_area": "",
+                    "phone": "+353000000000",
+                    "website": "https://example.ie",
+                    "first_observed_at": NOW.isoformat(),
+                    "last_observed_at": NOW.isoformat(),
+                }
+            ],
+        }
+    )
+
+
+def test_import_preserves_leadmap_identity_and_observation_evidence() -> None:
+    prospects = prospects_from_leadmap_export(_payload())
+
+    assert len(prospects) == 1
+    prospect = prospects[0]
+    assert prospect.business_name == "Murphy Roofing Ltd"
+    assert str(prospect.website) == "https://example.ie/"
+    assert prospect.country_code == "IE"
+    assert prospect.provider == "leadmap-local"
+    assert prospect.provider_key == "business-01:location-01"
+    assert prospect.status is ProspectStatus.shortlisted
+    assert prospect.qualification is None
+    assert "schema 1.1" in prospect.evidence_summary
+
+
+def test_old_handoff_states_collapse_into_single_veridra_lifecycle() -> None:
+    ready = prospects_from_leadmap_export(
+        _payload(qualification_status="sent_to_veridra")
+    )[0]
+    reviewed = prospects_from_leadmap_export(
+        _payload(qualification_status="veridra_reviewed")
+    )[0]
+
+    assert ready.status is ProspectStatus.ready_for_audit
+    assert reviewed.status is ProspectStatus.audited
+
+
+def test_unknown_legacy_status_requires_review_instead_of_guessing() -> None:
+    prospect = prospects_from_leadmap_export(
+        _payload(qualification_status="future_status")
+    )[0]
+
+    assert prospect.status is ProspectStatus.needs_review
+
+
+def test_import_rejects_unknown_export_schema() -> None:
+    with pytest.raises(LeadMapImportError, match="Unsupported LEADS export schema"):
+        prospects_from_leadmap_export(_payload(schema_version="2.0"))

--- a/tests/test_tenant_prospect_store.py
+++ b/tests/test_tenant_prospect_store.py
@@ -48,22 +48,24 @@ def _qualification(*, score_two: bool = True) -> StageAQualification:
 
 
 def _prospect(*, name: str = "Murphy Roofing Ltd") -> Prospect:
-    return Prospect(
-        business_name=name,
-        website="https://example.ie",
-        sector="Roofing",
-        locality="Cork",
-        administrative_area="Cork",
-        country_code="IE",
-        phone="+353000000000",
-        contact_email="owner@example.ie",
-        provider="leadmap-local",
-        provider_key="fixture-business-01",
-        evidence_summary="Business observed in local territory research.",
-        qualification=_qualification(),
-        status=ProspectStatus.shortlisted,
-        created_at=NOW,
-        updated_at=NOW,
+    return Prospect.model_validate(
+        {
+            "business_name": name,
+            "website": "https://example.ie",
+            "sector": "Roofing",
+            "locality": "Cork",
+            "administrative_area": "Cork",
+            "country_code": "IE",
+            "phone": "+353000000000",
+            "contact_email": "owner@example.ie",
+            "provider": "leadmap-local",
+            "provider_key": "fixture-business-01",
+            "evidence_summary": "Business observed in local territory research.",
+            "qualification": _qualification(),
+            "status": ProspectStatus.shortlisted,
+            "created_at": NOW,
+            "updated_at": NOW,
+        }
     )
 
 
@@ -99,9 +101,7 @@ def test_stage_a_hold_range_is_explicit() -> None:
 
 def test_unsuitable_prospect_requires_rejection_reason() -> None:
     with pytest.raises(ValueError, match="rejection reason"):
-        _prospect().model_copy(
-            update={"status": ProspectStatus.unsuitable, "rejection_reason": None}
-        ).model_validate(
+        Prospect.model_validate(
             {
                 **_prospect().model_dump(mode="json"),
                 "status": "unsuitable",

--- a/tests/test_tenant_prospect_store.py
+++ b/tests/test_tenant_prospect_store.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.identity_tenancy import IdentityBoundaryError, RequestIdentity, TenantRole
+from veridra.prospect import (
+    Prospect,
+    ProspectDecision,
+    ProspectRejectionReason,
+    ProspectStatus,
+    StageAQualification,
+)
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_prospect_api import router as tenant_prospect_router
+from veridra.tenant_prospect_store import TenantProspectStore
+
+NOW = datetime(2026, 8, 22, 17, 30, tzinfo=UTC)
+
+
+def _identity(tenant: str, role: TenantRole) -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id=tenant,
+        membership_role=role,
+        session_id=f"session-{tenant}-{role.value}",
+        authenticated_at=NOW,
+    )
+
+
+def _qualification(*, score_two: bool = True) -> StageAQualification:
+    value = 2 if score_two else 1
+    return StageAQualification(
+        active_real_business=value,
+        website_commercial_importance=value,
+        business_economic_value=value,
+        business_size_fit=value,
+        decision_maker_reachability=value,
+        website_manageability=value,
+        no_existing_web_team=value,
+        reason="Active owner-managed business with a commercially important website.",
+    )
+
+
+def _prospect(*, name: str = "Murphy Roofing Ltd") -> Prospect:
+    return Prospect(
+        business_name=name,
+        website="https://example.ie",
+        sector="Roofing",
+        locality="Cork",
+        administrative_area="Cork",
+        country_code="IE",
+        phone="+353000000000",
+        contact_email="owner@example.ie",
+        provider="leadmap-local",
+        provider_key="fixture-business-01",
+        evidence_summary="Business observed in local territory research.",
+        qualification=_qualification(),
+        status=ProspectStatus.shortlisted,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def test_stage_a_qualification_preserves_leads_commercial_gate() -> None:
+    strong = _qualification()
+    secondary = _qualification(score_two=False)
+    rejected = secondary.model_copy(
+        update={"rejection_reason": ProspectRejectionReason.agency_present}
+    )
+
+    assert strong.score == 14
+    assert strong.decision is ProspectDecision.send_to_audit
+    assert secondary.score == 7
+    assert secondary.decision is ProspectDecision.reject
+    assert rejected.decision is ProspectDecision.reject
+
+
+def test_stage_a_hold_range_is_explicit() -> None:
+    qualification = StageAQualification(
+        active_real_business=2,
+        website_commercial_importance=2,
+        business_economic_value=1,
+        business_size_fit=1,
+        decision_maker_reachability=1,
+        website_manageability=1,
+        no_existing_web_team=1,
+        reason="Plausible SMB but more evidence is needed before an audit.",
+    )
+
+    assert qualification.score == 9
+    assert qualification.decision is ProspectDecision.hold
+
+
+def test_unsuitable_prospect_requires_rejection_reason() -> None:
+    with pytest.raises(ValueError, match="rejection reason"):
+        _prospect().model_copy(
+            update={"status": ProspectStatus.unsuitable, "rejection_reason": None}
+        ).model_validate(
+            {
+                **_prospect().model_dump(mode="json"),
+                "status": "unsuitable",
+                "rejection_reason": None,
+            }
+        )
+
+
+def test_tenant_prospect_store_isolates_research_records(tmp_path: Path) -> None:
+    store = TenantProspectStore(tmp_path)
+    tenant_a_sales = _identity("1" * 24, TenantRole.sales)
+    tenant_b_sales = _identity("2" * 24, TenantRole.sales)
+    tenant_a_viewer = _identity("1" * 24, TenantRole.viewer)
+
+    prospect_id_a = store.save(tenant_a_sales, _prospect())
+    prospect_id_b = store.save(tenant_b_sales, _prospect())
+
+    assert prospect_id_a == prospect_id_b
+    assert store.load(
+        tenant_a_viewer,
+        store.ref(tenant_a_viewer, prospect_id_a),
+    ).business_name == "Murphy Roofing Ltd"
+
+    with pytest.raises(IdentityBoundaryError):
+        store.load(
+            tenant_a_viewer,
+            store.ref(tenant_b_sales, prospect_id_b),
+        )
+
+
+def test_tenant_prospect_api_crud_uses_bound_identity(tmp_path: Path) -> None:
+    identity = _identity("3" * 24, TenantRole.sales)
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path
+
+    @app.middleware("http")
+    async def bind_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        bind_verified_request_identity(request, identity)
+        return await call_next(request)
+
+    app.include_router(tenant_prospect_router)
+    client = TestClient(app)
+    payload = _prospect().model_dump(mode="json")
+
+    created = client.post("/api/tenant/prospects", json=payload)
+    assert created.status_code == 201
+    prospect_id = created.json()["id"]
+
+    listed = client.get("/api/tenant/prospects")
+    assert listed.status_code == 200
+    assert [item["id"] for item in listed.json()] == [prospect_id]
+
+    payload["status"] = "ready_for_audit"
+    replaced = client.put(f"/api/tenant/prospects/{prospect_id}", json=payload)
+    assert replaced.status_code == 200
+    assert replaced.json()["status"] == "ready_for_audit"
+
+    fetched = client.get(f"/api/tenant/prospects/{prospect_id}")
+    assert fetched.status_code == 200
+    assert fetched.json()["qualification"]["reason"].startswith("Active")
+
+    deleted = client.delete(f"/api/tenant/prospects/{prospect_id}")
+    assert deleted.status_code == 204


### PR DESCRIPTION
Adds a canonical prospect model, tenant-scoped prospect storage/API, LEADS schema 1.1 import support, lifecycle mapping, migration documentation and regression tests. Existing inbound lead records remain separate. Do not merge until exact-head full CI succeeds.