### PR TITLE
Add Webify prospect workbench

### DIFF
--- a/src/veridra/agency_navigation.py
+++ b/src/veridra/agency_navigation.py
@@ -12,7 +12,8 @@ def agency_navigation(identity: RequestIdentity, *, current: str | None = None) 
         ("projects", "/agency/projects", "Client projects"),
     ]
     if TenantCapability.manage_leads in capabilities:
-        destinations.append(("leads", "/agency/leads", "Leads"))
+        destinations.append(("prospects", "/agency/prospects", "Prospects"))
+        destinations.append(("leads", "/agency/leads", "Inbound leads"))
         destinations.append(("lead-forms", "/agency/lead-forms", "Lead forms"))
     if TenantCapability.manage_tenant in capabilities:
         destinations.append(("workspace", "/workspace", "Plan and usage"))

--- a/src/veridra/agency_prospect_web.py
+++ b/src/veridra/agency_prospect_web.py
@@ -1,0 +1,267 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .agency_navigation import agency_navigation
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .prospect import (
+    Prospect,
+    ProspectDecision,
+    ProspectRejectionReason,
+    ProspectStatus,
+    StageAQualification,
+    prospect_identifier,
+)
+from .request_security import require_request_identity
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
+
+router = APIRouter(prefix="/agency/prospects", tags=["agency-prospects"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1180px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.actions{display:flex;gap:8px;flex-wrap:wrap}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:100px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.score-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}@media(max-width:760px){.row,.score-grid{grid-template-columns:1fr}table{display:block;overflow:auto}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _store(request: Request) -> TenantProspectStore:
+    return TenantProspectStore(_root(request))
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Prospect workbench is not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Prospect request is not permitted.") from exc
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _load(request: Request, identity: RequestIdentity, prospect_id: str) -> Prospect:
+    store = _store(request)
+    try:
+        return store.load(identity, store.ref(identity, prospect_id))
+    except TenantProspectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Prospect not found.") from exc
+
+
+def _audit_url(prospect: Prospect) -> str:
+    if prospect.website is None:
+        return ""
+    return f"/agency/quick-audit?{urlencode({'target': str(prospect.website)})}"
+
+
+def _decision(prospect: Prospect) -> str:
+    if prospect.qualification is None:
+        return "Not scored"
+    return f"{prospect.qualification.score}/14 · {prospect.qualification.decision.value.replace('_', ' ')}"
+
+
+@router.get("", response_class=HTMLResponse)
+def prospect_index(request: Request) -> str:
+    identity = _identity(request)
+    entries = _store(request).list(identity)
+    rows: list[str] = []
+    for prospect_id, prospect in entries:
+        website = str(prospect.website) if prospect.website is not None else "—"
+        audit_url = _audit_url(prospect)
+        audit_action = (
+            f"<a class='button secondary' href='{html.escape(audit_url, quote=True)}'>Start audit</a>"
+            if audit_url and prospect.status not in {ProspectStatus.unsuitable, ProspectStatus.duplicate, ProspectStatus.archived}
+            else ""
+        )
+        rows.append(
+            "<tr>"
+            f"<td><strong>{html.escape(prospect.business_name)}</strong><br><span class='muted'>{html.escape(prospect.sector or 'Unclassified')}</span></td>"
+            f"<td>{html.escape(prospect.locality or '—')}<br><span class='muted'>{html.escape(prospect.administrative_area or '')}</span></td>"
+            f"<td>{html.escape(website)}</td>"
+            f"<td><span class='badge'>{html.escape(prospect.status.value)}</span></td>"
+            f"<td>{html.escape(_decision(prospect))}</td>"
+            f"<td><div class='actions'><a class='button' href='/agency/prospects/{html.escape(prospect_id, quote=True)}'>Review</a>{audit_action}</div></td>"
+            "</tr>"
+        )
+    table = (
+        "<table><thead><tr><th>Business</th><th>Territory</th><th>Website</th><th>Status</th><th>Stage A</th><th>Actions</th></tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+        if rows
+        else "<p class='notice'>No outbound prospects yet. Add one manually or import existing LEADS records.</p>"
+    )
+    navigation = agency_navigation(identity, current="prospects")
+    body = f"{navigation}<section><div class='actions'><a class='button' href='/agency/prospects/new'>Add prospect</a></div><h1>Webify prospects</h1><p class='muted'>Businesses discovered for possible website refurbishment. Qualify commercial fit before spending time on a deep audit.</p>{table}</section>"
+    return _page("Webify prospects", body)
+
+
+@router.get("/new", response_class=HTMLResponse)
+def new_prospect_page(request: Request) -> str:
+    identity = _identity(request)
+    navigation = agency_navigation(identity, current="prospects")
+    body = f"{navigation}<section><p><a href='/agency/prospects'>← Prospects</a></p><h1>Add prospect</h1><p class='muted'>Use this for a business you found manually. Discovery adapters will create the same record type.</p><form method='post' action='/agency/prospects/new'><div class='row'><div><label>Business name</label><input name='business_name' maxlength='200' required></div><div><label>Website</label><input name='website' maxlength='2048' placeholder='https://example.com'></div></div><div class='row'><div><label>Sector</label><input name='sector' maxlength='120'></div><div><label>Phone</label><input name='phone' maxlength='80'></div></div><div class='row'><div><label>Locality</label><input name='locality' maxlength='120'></div><div><label>Administrative area</label><input name='administrative_area' maxlength='120'></div></div><div class='row'><div><label>Country code</label><input name='country_code' maxlength='2' value='ES'></div><div><label>Contact email</label><input name='contact_email' type='email' maxlength='254'></div></div><label>Evidence / discovery note</label><textarea name='evidence_summary' maxlength='4000' placeholder='Where the business was found and why it may be worth reviewing.'></textarea><button type='submit'>Create prospect</button></form></section>"
+    return _page("Add prospect", body)
+
+
+@router.post("/new", response_model=None)
+async def create_prospect(request: Request) -> HTMLResponse | RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    values = _values(await request.body())
+    try:
+        prospect = Prospect.model_validate(
+            {
+                "business_name": _one(values, "business_name"),
+                "website": _one(values, "website") or None,
+                "sector": _one(values, "sector"),
+                "locality": _one(values, "locality"),
+                "administrative_area": _one(values, "administrative_area"),
+                "country_code": _one(values, "country_code").upper(),
+                "phone": _one(values, "phone"),
+                "contact_email": _one(values, "contact_email"),
+                "provider": "manual",
+                "provider_key": "",
+                "evidence_summary": _one(values, "evidence_summary"),
+                "status": ProspectStatus.needs_review,
+            }
+        )
+    except ValidationError as exc:
+        return _page("Invalid prospect", f"<section><h1>Prospect could not be saved</h1><p class='muted'>{html.escape(str(exc))}</p><p><a href='/agency/prospects/new'>Return to form</a></p></section>")
+    prospect_id = prospect_identifier(prospect)
+    store = _store(request)
+    try:
+        store.load(identity, store.ref(identity, prospect_id))
+    except TenantProspectStoreError:
+        store.save(identity, prospect)
+    else:
+        return _page("Duplicate prospect", "<section><h1>Prospect already exists</h1><p class='muted'>Review the existing record instead of replacing its qualification or outreach state.</p><p><a href='/agency/prospects'>Return to prospects</a></p></section>")
+    return RedirectResponse(f"/agency/prospects/{prospect_id}", status_code=303)
+
+
+@router.get("/{prospect_id}", response_class=HTMLResponse)
+def prospect_detail(prospect_id: str, request: Request) -> str:
+    identity = _identity(request)
+    prospect = _load(request, identity, prospect_id)
+    navigation = agency_navigation(identity, current="prospects")
+    website = str(prospect.website) if prospect.website is not None else "—"
+    audit_url = _audit_url(prospect)
+    audit_action = f"<a class='button' href='{html.escape(audit_url, quote=True)}'>Start website audit</a>" if audit_url else "<span class='muted'>Add a website before auditing.</span>"
+    qualification = prospect.qualification
+    values = {
+        "active_real_business": qualification.active_real_business if qualification else 0,
+        "website_commercial_importance": qualification.website_commercial_importance if qualification else 0,
+        "business_economic_value": qualification.business_economic_value if qualification else 0,
+        "business_size_fit": qualification.business_size_fit if qualification else 0,
+        "decision_maker_reachability": qualification.decision_maker_reachability if qualification else 0,
+        "website_manageability": qualification.website_manageability if qualification else 0,
+        "no_existing_web_team": qualification.no_existing_web_team if qualification else 0,
+    }
+    score_fields = "".join(
+        f"<div><label>{html.escape(label)}</label><select name='{name}'>"
+        + "".join(f"<option value='{value}'{' selected' if selected == value else ''}>{value}</option>" for value in (0, 1, 2))
+        + "</select></div>"
+        for name, label, selected in (
+            ("active_real_business", "Active real business", values["active_real_business"]),
+            ("website_commercial_importance", "Website commercial importance", values["website_commercial_importance"]),
+            ("business_economic_value", "Business economic value", values["business_economic_value"]),
+            ("business_size_fit", "Business size / Webify fit", values["business_size_fit"]),
+            ("decision_maker_reachability", "Decision-maker reachability", values["decision_maker_reachability"]),
+            ("website_manageability", "Website manageability", values["website_manageability"]),
+            ("no_existing_web_team", "No obvious agency/internal web team", values["no_existing_web_team"]),
+        )
+    )
+    reason = qualification.reason if qualification else ""
+    current_rejection = prospect.rejection_reason.value if prospect.rejection_reason else ""
+    rejection_options = "<option value=''>None</option>" + "".join(
+        f"<option value='{item.value}'{' selected' if current_rejection == item.value else ''}>{item.value.replace('_', ' ').title()}</option>"
+        for item in ProspectRejectionReason
+    )
+    body = f"{navigation}<section><p><a href='/agency/prospects'>← Prospects</a></p><h1>{html.escape(prospect.business_name)}</h1><p><span class='badge'>{html.escape(prospect.status.value)}</span> · Stage A: {html.escape(_decision(prospect))}</p><p><strong>Website:</strong> {html.escape(website)}<br><strong>Sector:</strong> {html.escape(prospect.sector or '—')}<br><strong>Territory:</strong> {html.escape(prospect.locality or '—')}, {html.escape(prospect.administrative_area or '—')}<br><strong>Contact:</strong> {html.escape(prospect.contact_email or prospect.phone or '—')}</p><p class='notice'>{html.escape(prospect.evidence_summary or 'No discovery evidence recorded yet.')}</p><div class='actions'>{audit_action}</div></section><section><h2>Stage A · Commercial fit</h2><p class='muted'>Score each criterion 0–2. 11–14 is ready for audit, 8–10 is hold/secondary, and 0–7 is reject. A rejected prospect needs an explicit reason before it becomes terminally unsuitable.</p><form method='post' action='/agency/prospects/{html.escape(prospect_id, quote=True)}/qualify'><div class='score-grid'>{score_fields}</div><label>Why this score?</label><textarea name='reason' maxlength='1000' required>{html.escape(reason)}</textarea><label>Explicit rejection reason (optional)</label><select name='rejection_reason'>{rejection_options}</select><button type='submit'>Save qualification</button></form></section>"
+    return _page(prospect.business_name, body)
+
+
+@router.post("/{prospect_id}/qualify")
+async def qualify_prospect(prospect_id: str, request: Request) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    prospect = _load(request, identity, prospect_id)
+    values = _values(await request.body())
+    try:
+        rejection_raw = _one(values, "rejection_reason")
+        rejection = ProspectRejectionReason(rejection_raw) if rejection_raw else None
+        qualification = StageAQualification(
+            active_real_business=int(_one(values, "active_real_business")),
+            website_commercial_importance=int(_one(values, "website_commercial_importance")),
+            business_economic_value=int(_one(values, "business_economic_value")),
+            business_size_fit=int(_one(values, "business_size_fit")),
+            decision_maker_reachability=int(_one(values, "decision_maker_reachability")),
+            website_manageability=int(_one(values, "website_manageability")),
+            no_existing_web_team=int(_one(values, "no_existing_web_team")),
+            reason=_one(values, "reason"),
+            rejection_reason=rejection,
+        )
+    except (ValueError, ValidationError) as exc:
+        raise HTTPException(status_code=400, detail="Qualification values are invalid.") from exc
+
+    if qualification.decision is ProspectDecision.send_to_audit:
+        next_status = ProspectStatus.ready_for_audit
+    elif qualification.decision is ProspectDecision.hold:
+        next_status = ProspectStatus.qualified
+    elif rejection is not None:
+        next_status = ProspectStatus.unsuitable
+    else:
+        next_status = ProspectStatus.needs_review
+
+    updated = Prospect.model_validate(
+        {
+            **prospect.model_dump(mode="json"),
+            "qualification": qualification.model_dump(mode="json"),
+            "status": next_status,
+            "human_verified": True,
+            "rejection_reason": rejection.value if rejection is not None else None,
+            "updated_at": datetime.now(UTC),
+        }
+    )
+    store = _store(request)
+    try:
+        store.replace(identity, store.ref(identity, prospect_id), updated)
+    except TenantProspectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Prospect not found.") from exc
+    return RedirectResponse(f"/agency/prospects/{prospect_id}", status_code=303)

--- a/src/veridra/agency_prospect_web.py
+++ b/src/veridra/agency_prospect_web.py
@@ -163,7 +163,13 @@ async def create_prospect(request: Request) -> HTMLResponse | RedirectResponse:
             }
         )
     except ValidationError as exc:
-        return _page("Invalid prospect", f"<section><h1>Prospect could not be saved</h1><p class='muted'>{html.escape(str(exc))}</p><p><a href='/agency/prospects/new'>Return to form</a></p></section>")
+        return HTMLResponse(
+            _page(
+                "Invalid prospect",
+                f"<section><h1>Prospect could not be saved</h1><p class='muted'>{html.escape(str(exc))}</p><p><a href='/agency/prospects/new'>Return to form</a></p></section>",
+            ),
+            status_code=400,
+        )
     prospect_id = prospect_identifier(prospect)
     store = _store(request)
     try:
@@ -171,7 +177,12 @@ async def create_prospect(request: Request) -> HTMLResponse | RedirectResponse:
     except TenantProspectStoreError:
         store.save(identity, prospect)
     else:
-        return _page("Duplicate prospect", "<section><h1>Prospect already exists</h1><p class='muted'>Review the existing record instead of replacing its qualification or outreach state.</p><p><a href='/agency/prospects'>Return to prospects</a></p></section>")
+        return HTMLResponse(
+            _page(
+                "Duplicate prospect",
+                "<section><h1>Prospect already exists</h1><p class='muted'>Review the existing record instead of replacing its qualification or outreach state.</p><p><a href='/agency/prospects'>Return to prospects</a></p></section>",
+            )
+        )
     return RedirectResponse(f"/agency/prospects/{prospect_id}", status_code=303)
 
 

--- a/src/veridra/agency_workflow_web.py
+++ b/src/veridra/agency_workflow_web.py
@@ -34,35 +34,34 @@ def _page(body: str) -> str:
 @router.get("/agency", response_class=HTMLResponse)
 def agency_workflow_home() -> str:
     body = """
-    <div class='top'><div><p class='eyebrow'>Agency workspace</p><h1>Turn website evidence into client work</h1>
-    <p class='muted'>Run an audit, produce a branded report, organise remediation and prove improvement through monitoring.</p></div>
-    <div class='actions'><a class='button secondary' href='/workspace'>Plan and usage</a><a class='button secondary' href='/workspace/members'>Team</a></div></div>
+    <div class='top'><div><p class='eyebrow'>Webify acquisition workspace</p><h1>Find refurbishment opportunities and turn evidence into client work</h1>
+    <p class='muted'>Research prospects, qualify commercial fit, audit the strongest websites, prepare evidence and track work through to improvement.</p></div>
+    <div class='actions'><a class='button' href='/agency/prospects'>Open prospects</a><a class='button secondary' href='/workspace'>Workspace</a></div></div>
     <div class='steps'>
-      <div class='step'><strong>1. Audit</strong><span class='muted'>Collect bounded public evidence.</span></div>
-      <div class='step'><strong>2. Explain</strong><span class='muted'>Review findings and priorities.</span></div>
-      <div class='step'><strong>3. Report</strong><span class='muted'>Create branded client output.</span></div>
-      <div class='step'><strong>4. Remediate</strong><span class='muted'>Convert findings into tasks.</span></div>
-      <div class='step'><strong>5. Prove</strong><span class='muted'>Rescan and compare changes.</span></div>
+      <div class='step'><strong>1. Discover</strong><span class='muted'>Find businesses worth reviewing.</span></div>
+      <div class='step'><strong>2. Qualify</strong><span class='muted'>Prioritise commercial fit.</span></div>
+      <div class='step'><strong>3. Audit</strong><span class='muted'>Collect bounded website evidence.</span></div>
+      <div class='step'><strong>4. Win work</strong><span class='muted'>Use evidence in outreach and proposals.</span></div>
+      <div class='step'><strong>5. Prove</strong><span class='muted'>Re-audit completed refurbishment work.</span></div>
     </div>
     <div class='grid'>
-      <section><p class='eyebrow'>One-off opportunity</p><h2>Quick audit</h2>
-      <p>Use this for a prospect or an initial review. The handoff starts the existing bounded assessment and does not create a project or save data automatically.</p>
+      <section><p class='eyebrow'>Primary workflow</p><h2>Webify prospects</h2>
+      <p>Build and qualify the outbound prospect pipeline before spending time on deep website audits.</p>
+      <div class='actions'><a class='button' href='/agency/prospects'>Open prospect workbench</a><a class='button secondary' href='/agency/prospects/new'>Add prospect</a></div></section>
+      <section><p class='eyebrow'>Direct review</p><h2>Quick audit</h2>
       <form method='get' action='/agency/quick-audit'><label for='target'><strong>Public website</strong></label>
       <input id='target' name='target' maxlength='2048' placeholder='example.com' required>
       <button type='submit'>Start quick audit</button></form></section>
-      <section><p class='eyebrow'>Ongoing client work</p><h2>Client projects</h2>
-      <p>Open persistent tenant projects for saved evidence, branded reports, remediation, monitoring and comparison.</p>
-      <div class='actions'><a class='button' href='/agency/projects'>Open client projects</a></div></section>
     </div>
-    <section><h2>Agency operations</h2><p class='muted'>Normal agency work stays inside tenant-qualified project, lead and workspace routes.</p>
-    <div class='links'>
-      <a href='/agency/projects'><strong>Client projects</strong><br><span class='muted'>Open saved assessments, branded report profiles and outputs, remediation and monitoring.</span></a>
-      <a href='/agency/leads'><strong>Leads</strong><br><span class='muted'>Review captured prospects, qualify follow-up and convert accepted work into client projects.</span></a>
-      <a href='/agency/lead-forms'><strong>Lead forms</strong><br><span class='muted'>Configure tenant-owned embedded capture.</span></a>
-      <a href='/workspace'><strong>Workspace controls</strong><br><span class='muted'>Review plan, usage, permissions and plan-change history.</span></a>
+    <section><h2>Operations</h2><div class='links'>
+      <a href='/agency/prospects'><strong>Prospects</strong><br><span class='muted'>Outbound businesses researched for possible Webify refurbishment work.</span></a>
+      <a href='/agency/projects'><strong>Client projects</strong><br><span class='muted'>Saved assessments, reports, remediation, monitoring and before/after proof.</span></a>
+      <a href='/agency/leads'><strong>Inbound leads</strong><br><span class='muted'>People who submitted tenant-owned audit or lead forms.</span></a>
+      <a href='/agency/lead-forms'><strong>Lead forms</strong><br><span class='muted'>Configure tenant-owned inbound capture.</span></a>
+      <a href='/workspace'><strong>Workspace controls</strong><br><span class='muted'>Review workspace settings and usage.</span></a>
       <a href='/workspace/members'><strong>Team</strong><br><span class='muted'>Manage tenant members and roles.</span></a>
     </div></section>
-    <p class='notice'><strong>Boundary:</strong> A quick audit is temporary until an operator explicitly creates a client project. Veridra does not infer a tenant, client or project from a submitted URL. Persistent work should continue from the tenant-qualified client-project index.</p>
+    <p class='notice'><strong>Boundary:</strong> A prospect is outbound Webify research; an inbound lead is a person who submitted a form. A website audit remains temporary until an operator explicitly creates a client project.</p>
     """
     return _page(body)
 

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -12,6 +12,7 @@ from .agency_lead_form_web import router as agency_lead_form_router
 from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
 from .agency_project_index_web import router as agency_project_index_router
+from .agency_prospect_web import router as agency_prospect_router
 from .agency_report_profile_edit_web import router as agency_report_profile_edit_router
 from .agency_report_profile_web import router as agency_report_profile_router
 from .agency_report_web import router as agency_report_router
@@ -153,6 +154,7 @@ app.include_router(agency_workflow_router)
 app.include_router(agency_project_index_router)
 app.include_router(agency_conversion_router)
 app.include_router(agency_crawl_profile_router)
+app.include_router(agency_prospect_router)
 app.include_router(agency_lead_router)
 app.include_router(agency_lead_form_router)
 app.include_router(agency_task_router)

--- a/tests/test_agency_prospect_web.py
+++ b/tests/test_agency_prospect_web.py
@@ -129,7 +129,9 @@ def test_strong_stage_a_score_moves_prospect_to_ready_for_audit(
             "decision_maker_reachability": "1",
             "website_manageability": "2",
             "no_existing_web_team": "2",
-            "reason": "Active clinic, reachable owner and a commercially important manageable site.",
+            "reason": (
+                "Active clinic, reachable owner and a commercially important manageable site."
+            ),
             "rejection_reason": "",
         },
         follow_redirects=False,

--- a/tests/test_agency_prospect_web.py
+++ b/tests/test_agency_prospect_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 from fastapi import FastAPI, Request
@@ -49,21 +50,24 @@ def _client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient
 
 
 def _create(client: TestClient) -> Response:
-    return client.post(
-        "/agency/prospects/new",
-        headers={"Origin": ORIGIN},
-        data={
-            "business_name": "Vigo Dental Clinic",
-            "website": "https://example.es",
-            "sector": "Dental clinic",
-            "locality": "Vigo",
-            "administrative_area": "Pontevedra",
-            "country_code": "ES",
-            "phone": "+34986000000",
-            "contact_email": "hello@example.es",
-            "evidence_summary": "Active local clinic with an older public website.",
-        },
-        follow_redirects=False,
+    return cast(
+        Response,
+        client.post(
+            "/agency/prospects/new",
+            headers={"Origin": ORIGIN},
+            data={
+                "business_name": "Vigo Dental Clinic",
+                "website": "https://example.es",
+                "sector": "Dental clinic",
+                "locality": "Vigo",
+                "administrative_area": "Pontevedra",
+                "country_code": "ES",
+                "phone": "+34986000000",
+                "contact_email": "hello@example.es",
+                "evidence_summary": "Active local clinic with an older public website.",
+            },
+            follow_redirects=False,
+        ),
     )
 
 

--- a/tests/test_agency_prospect_web.py
+++ b/tests/test_agency_prospect_web.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_prospect_web import router as agency_prospect_router
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.prospect import ProspectStatus
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_prospect_store import TenantProspectStore
+
+ORIGIN = "http://testserver"
+NOW = datetime(2026, 8, 22, 18, 30, tzinfo=UTC)
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id="b" * 24,
+        membership_role=TenantRole.sales,
+        session_id="prospect-workbench-session",
+        authenticated_at=NOW,
+    )
+
+
+def _client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient, RequestIdentity]:
+    identity = _identity()
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path
+
+    @app.middleware("http")
+    async def bind_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        bind_verified_request_identity(request, identity)
+        return await call_next(request)
+
+    app.include_router(agency_prospect_router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    return TestClient(app), identity
+
+
+def _create(client: TestClient) -> Response:
+    return client.post(
+        "/agency/prospects/new",
+        headers={"Origin": ORIGIN},
+        data={
+            "business_name": "Vigo Dental Clinic",
+            "website": "https://example.es",
+            "sector": "Dental clinic",
+            "locality": "Vigo",
+            "administrative_area": "Pontevedra",
+            "country_code": "ES",
+            "phone": "+34986000000",
+            "contact_email": "hello@example.es",
+            "evidence_summary": "Active local clinic with an older public website.",
+        },
+        follow_redirects=False,
+    )
+
+
+def test_operator_can_create_review_and_start_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _client(tmp_path, monkeypatch)
+
+    created = _create(client)
+    assert created.status_code == 303
+    detail_url = created.headers["location"]
+
+    index = client.get("/agency/prospects")
+    detail = client.get(detail_url)
+
+    assert index.status_code == 200
+    assert "Webify prospects" in index.text
+    assert "Vigo Dental Clinic" in index.text
+    assert "Inbound leads" in index.text
+    assert detail.status_code == 200
+    assert "Stage A · Commercial fit" in detail.text
+    assert "/agency/quick-audit?target=https%3A%2F%2Fexample.es%2F" in detail.text
+
+
+def test_duplicate_manual_creation_does_not_overwrite_existing_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity = _client(tmp_path, monkeypatch)
+    first = _create(client)
+    prospect_id = first.headers["location"].rsplit("/", 1)[-1]
+    store = TenantProspectStore(tmp_path)
+    original = store.load(identity, store.ref(identity, prospect_id))
+    qualified = original.model_copy(
+        update={"status": ProspectStatus.contacted, "human_verified": True}
+    )
+    store.replace(identity, store.ref(identity, prospect_id), qualified)
+
+    duplicate = _create(client)
+    saved = store.load(identity, store.ref(identity, prospect_id))
+
+    assert duplicate.status_code == 200
+    assert "Prospect already exists" in duplicate.text
+    assert saved.status is ProspectStatus.contacted
+    assert saved.human_verified is True
+
+
+def test_strong_stage_a_score_moves_prospect_to_ready_for_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity = _client(tmp_path, monkeypatch)
+    created = _create(client)
+    prospect_id = created.headers["location"].rsplit("/", 1)[-1]
+
+    response = client.post(
+        f"/agency/prospects/{prospect_id}/qualify",
+        headers={"Origin": ORIGIN},
+        data={
+            "active_real_business": "2",
+            "website_commercial_importance": "2",
+            "business_economic_value": "2",
+            "business_size_fit": "2",
+            "decision_maker_reachability": "1",
+            "website_manageability": "2",
+            "no_existing_web_team": "2",
+            "reason": "Active clinic, reachable owner and a commercially important manageable site.",
+            "rejection_reason": "",
+        },
+        follow_redirects=False,
+    )
+
+    saved = TenantProspectStore(tmp_path).load(
+        identity,
+        TenantProspectStore.ref(identity, prospect_id),
+    )
+    assert response.status_code == 303
+    assert saved.status is ProspectStatus.ready_for_audit
+    assert saved.qualification is not None
+    assert saved.qualification.score == 13
+    assert saved.human_verified is True
+
+
+def test_explicit_rejection_records_reason_and_marks_unsuitable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity = _client(tmp_path, monkeypatch)
+    created = _create(client)
+    prospect_id = created.headers["location"].rsplit("/", 1)[-1]
+
+    response = client.post(
+        f"/agency/prospects/{prospect_id}/qualify",
+        headers={"Origin": ORIGIN},
+        data={
+            "active_real_business": "2",
+            "website_commercial_importance": "1",
+            "business_economic_value": "1",
+            "business_size_fit": "1",
+            "decision_maker_reachability": "0",
+            "website_manageability": "1",
+            "no_existing_web_team": "0",
+            "reason": "The business appears active but there is no realistic direct contact route.",
+            "rejection_reason": "NO_CONTACT_ROUTE",
+        },
+        follow_redirects=False,
+    )
+
+    store = TenantProspectStore(tmp_path)
+    saved = store.load(identity, store.ref(identity, prospect_id))
+    assert response.status_code == 303
+    assert saved.status is ProspectStatus.unsuitable
+    assert saved.rejection_reason is not None
+    assert saved.rejection_reason.value == "NO_CONTACT_ROUTE"
+
+
+def test_prospect_mutations_reject_missing_origin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/agency/prospects/new",
+        data={"business_name": "No Origin Ltd", "country_code": "ES"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 403

--- a/tests/test_agency_prospect_web.py
+++ b/tests/test_agency_prospect_web.py
@@ -5,7 +5,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
-from fastapi import FastAPI, Request, Response as FastAPIResponse
+from fastapi import FastAPI, Request
+from fastapi import Response as FastAPIResponse
 from fastapi.testclient import TestClient
 from httpx import Response
 

--- a/tests/test_agency_prospect_web.py
+++ b/tests/test_agency_prospect_web.py
@@ -5,8 +5,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, Request, Response as FastAPIResponse
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from veridra.agency_prospect_web import router as agency_prospect_router
 from veridra.identity_tenancy import RequestIdentity, TenantRole
@@ -36,8 +37,8 @@ def _client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient
     @app.middleware("http")
     async def bind_identity(
         request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
+        call_next: Callable[[Request], Awaitable[FastAPIResponse]],
+    ) -> FastAPIResponse:
         bind_verified_request_identity(request, identity)
         return await call_next(request)
 

--- a/tests/test_agency_workflow_web.py
+++ b/tests/test_agency_workflow_web.py
@@ -12,16 +12,22 @@ def _client() -> TestClient:
     return TestClient(app)
 
 
-def test_agency_home_explains_quick_and_persistent_workflows() -> None:
+def test_agency_home_explains_acquisition_and_persistent_workflows() -> None:
     response = _client().get("/agency")
 
     assert response.status_code == 200
-    assert "Turn website evidence into client work" in response.text
+    assert "Find refurbishment opportunities and turn evidence into client work" in response.text
+    assert "1. Discover" in response.text
+    assert "2. Qualify" in response.text
+    assert "3. Audit" in response.text
+    assert "4. Win work" in response.text
+    assert "5. Prove" in response.text
+    assert "Webify prospects" in response.text
     assert "Quick audit" in response.text
     assert "Client projects" in response.text
-    assert "does not create a project or save data automatically" in response.text
-    assert "Veridra does not infer a tenant, client or project" in response.text
-    assert "tenant-qualified project, lead and workspace routes" in response.text
+    assert "A prospect is outbound Webify research" in response.text
+    assert "website audit remains temporary until an operator explicitly creates" in response.text
+    assert "href='/agency/prospects'" in response.text
     assert "href='/agency/projects'" in response.text
     assert "href='/agency/leads'" in response.text
     assert "href='/agency/lead-forms'" in response.text


### PR DESCRIPTION
Adds the operator-facing fused workflow inside Veridra: outbound Prospects navigation, manual prospect creation with duplicate preservation, Stage-A commercial qualification, explicit rejection evidence and one-click handoff to the existing quick-audit workflow. Reframes the agency home around Discover → Qualify → Audit → Win work → Prove and distinguishes outbound prospects from inbound consented leads. Includes same-origin protection and regression tests. Do not merge until exact-head full CI succeeds.