### PR TITLE
Add safe prospect discovery ingest

### DIFF
--- a/src/veridra/prospect_ingest.py
+++ b/src/veridra/prospect_ingest.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Sequence
+
+from .atomic_fs_lock import AtomicFileLockError, exclusive_directory_lock
+from .identity_tenancy import RequestIdentity
+from .prospect import Prospect, prospect_identifier
+from .tenant_project_store import default_tenant_data_directory
+from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
+
+
+class DiscoveryIngestAction(StrEnum):
+    created = "created"
+    enriched = "enriched"
+    unchanged = "unchanged"
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveryIngestItem:
+    prospect_id: str
+    action: DiscoveryIngestAction
+
+
+class DiscoveryIngestError(RuntimeError):
+    pass
+
+
+def _append_evidence(existing: str, observed: str) -> str:
+    current = existing.strip()
+    incoming = observed.strip()
+    if not incoming or incoming in current:
+        return current
+    combined = f"{current}\n\n{incoming}" if current else incoming
+    return combined[-4000:]
+
+
+def merge_discovery_prospect(existing: Prospect, observed: Prospect) -> Prospect:
+    """Merge machine-observed discovery data without replacing human workflow state."""
+
+    if prospect_identifier(existing) != prospect_identifier(observed):
+        raise ValueError("Discovery observations must resolve to the same prospect identity.")
+
+    updates: dict[str, object] = {
+        "sector": existing.sector or observed.sector,
+        "administrative_area": existing.administrative_area or observed.administrative_area,
+        "phone": existing.phone or observed.phone,
+        "source_url": existing.source_url or observed.source_url,
+        "evidence_summary": _append_evidence(
+            existing.evidence_summary,
+            observed.evidence_summary,
+        ),
+    }
+    changed = any(getattr(existing, field) != value for field, value in updates.items())
+    if not changed:
+        return existing
+
+    updates["updated_at"] = max(existing.updated_at, observed.updated_at)
+    return Prospect.model_validate(
+        {
+            **existing.model_dump(mode="json"),
+            **updates,
+        }
+    )
+
+
+class TenantProspectDiscoveryIngestor:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or default_tenant_data_directory()
+        self.store = TenantProspectStore(self.root)
+
+    def ingest(
+        self,
+        identity: RequestIdentity,
+        prospects: Sequence[Prospect],
+    ) -> tuple[DiscoveryIngestItem, ...]:
+        outcomes: list[DiscoveryIngestItem] = []
+        lock_path = self.root / identity.tenant_id / ".prospect-ingest.lock"
+        try:
+            with exclusive_directory_lock(lock_path):
+                for observed in prospects:
+                    prospect_id = prospect_identifier(observed)
+                    target = self.store.ref(identity, prospect_id)
+                    try:
+                        existing = self.store.load(identity, target)
+                    except TenantProspectStoreError:
+                        self.store.save(identity, observed)
+                        outcomes.append(
+                            DiscoveryIngestItem(prospect_id, DiscoveryIngestAction.created)
+                        )
+                        continue
+
+                    merged = merge_discovery_prospect(existing, observed)
+                    if merged == existing:
+                        outcomes.append(
+                            DiscoveryIngestItem(prospect_id, DiscoveryIngestAction.unchanged)
+                        )
+                        continue
+                    self.store.replace(identity, target, merged)
+                    outcomes.append(
+                        DiscoveryIngestItem(prospect_id, DiscoveryIngestAction.enriched)
+                    )
+        except AtomicFileLockError as exc:
+            raise DiscoveryIngestError("Prospect ingest is already active.") from exc
+        return tuple(outcomes)

--- a/src/veridra/prospect_ingest.py
+++ b/src/veridra/prospect_ingest.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Sequence
 
 from .atomic_fs_lock import AtomicFileLockError, exclusive_directory_lock
 from .identity_tenancy import RequestIdentity

--- a/tests/test_prospect_ingest.py
+++ b/tests/test_prospect_ingest.py
@@ -20,7 +20,7 @@ def _identity() -> RequestIdentity:
         user_id="a" * 24,
         tenant_id="b" * 24,
         membership_role=TenantRole.sales,
-        session_id="prospect-ingest-session",
+        session_id="prospect-ingest-session-01",
         authenticated_at=NOW,
     )
 

--- a/tests/test_prospect_ingest.py
+++ b/tests/test_prospect_ingest.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.prospect import Prospect, ProspectStatus, StageAQualification
+from veridra.prospect_ingest import (
+    DiscoveryIngestAction,
+    TenantProspectDiscoveryIngestor,
+    merge_discovery_prospect,
+)
+from veridra.tenant_prospect_store import TenantProspectStore
+
+NOW = datetime(2026, 8, 22, 18, 0, tzinfo=UTC)
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id="b" * 24,
+        membership_role=TenantRole.sales,
+        session_id="prospect-ingest-session",
+        authenticated_at=NOW,
+    )
+
+
+def _prospect(**updates: object) -> Prospect:
+    payload: dict[str, object] = {
+        "business_name": "Vigo Dental Clinic",
+        "website": "https://example.es",
+        "sector": "",
+        "locality": "Vigo",
+        "administrative_area": "",
+        "country_code": "ES",
+        "phone": "",
+        "provider": "manual",
+        "provider_key": "",
+        "evidence_summary": "Manually identified prospect.",
+        "created_at": NOW,
+        "updated_at": NOW,
+    }
+    payload.update(updates)
+    return Prospect.model_validate(payload)
+
+
+def test_ingest_creates_new_discovered_prospect(tmp_path: Path) -> None:
+    identity = _identity()
+    observed = _prospect(
+        provider="fixture",
+        provider_key="place-1",
+        sector="Dental clinic",
+        administrative_area="Pontevedra",
+        phone="+34986000000",
+        evidence_summary="Observed in local business discovery.",
+    )
+
+    outcomes = TenantProspectDiscoveryIngestor(tmp_path).ingest(identity, [observed])
+
+    assert len(outcomes) == 1
+    assert outcomes[0].action is DiscoveryIngestAction.created
+    saved = TenantProspectStore(tmp_path).load(
+        identity,
+        TenantProspectStore.ref(identity, outcomes[0].prospect_id),
+    )
+    assert saved.provider == "fixture"
+    assert saved.provider_key == "place-1"
+    assert saved.sector == "Dental clinic"
+
+
+def test_rediscovery_enriches_blanks_without_erasing_human_state(tmp_path: Path) -> None:
+    identity = _identity()
+    qualification = StageAQualification(
+        active_real_business=2,
+        website_commercial_importance=2,
+        business_economic_value=2,
+        business_size_fit=2,
+        decision_maker_reachability=1,
+        website_manageability=2,
+        no_existing_web_team=2,
+        reason="Strong commercial fit confirmed by operator.",
+    )
+    existing = _prospect(
+        contact_name="Owner Name",
+        contact_email="owner@example.es",
+        qualification=qualification,
+        status=ProspectStatus.contacted,
+        human_verified=True,
+        best_observation="Homepage is dated and conversion path is weak.",
+        likely_offer="Website refurbishment",
+    )
+    store = TenantProspectStore(tmp_path)
+    prospect_id = store.save(identity, existing)
+    observed = _prospect(
+        provider="fixture",
+        provider_key="place-1",
+        sector="Dental clinic",
+        administrative_area="Pontevedra",
+        phone="+34986000000",
+        source_url="https://directory.example/business/1",
+        evidence_summary="Observed again with current public business details.",
+        updated_at=NOW + timedelta(hours=2),
+    )
+
+    outcomes = TenantProspectDiscoveryIngestor(tmp_path).ingest(identity, [observed])
+    saved = store.load(identity, store.ref(identity, prospect_id))
+
+    assert outcomes[0].action is DiscoveryIngestAction.enriched
+    assert saved.status is ProspectStatus.contacted
+    assert saved.qualification == qualification
+    assert saved.human_verified is True
+    assert saved.contact_name == "Owner Name"
+    assert saved.contact_email == "owner@example.es"
+    assert saved.best_observation == "Homepage is dated and conversion path is weak."
+    assert saved.likely_offer == "Website refurbishment"
+    assert saved.provider == "manual"
+    assert saved.provider_key == ""
+    assert saved.sector == "Dental clinic"
+    assert saved.administrative_area == "Pontevedra"
+    assert saved.phone == "+34986000000"
+    assert str(saved.source_url) == "https://directory.example/business/1"
+    assert "Manually identified prospect." in saved.evidence_summary
+    assert "Observed again with current public business details." in saved.evidence_summary
+    assert saved.updated_at == NOW + timedelta(hours=2)
+
+
+def test_rediscovery_does_not_replace_nonblank_human_discovery_fields() -> None:
+    existing = _prospect(
+        sector="Dentist",
+        administrative_area="Human checked area",
+        phone="+34986111111",
+        source_url="https://human.example/source",
+    )
+    observed = _prospect(
+        sector="Medical clinic",
+        administrative_area="Machine area",
+        phone="+34986222222",
+        source_url="https://machine.example/source",
+        evidence_summary="Fresh machine evidence.",
+        updated_at=NOW + timedelta(hours=1),
+    )
+
+    merged = merge_discovery_prospect(existing, observed)
+
+    assert merged.sector == "Dentist"
+    assert merged.administrative_area == "Human checked area"
+    assert merged.phone == "+34986111111"
+    assert str(merged.source_url) == "https://human.example/source"
+    assert "Fresh machine evidence." in merged.evidence_summary
+
+
+def test_identical_rediscovery_is_unchanged(tmp_path: Path) -> None:
+    identity = _identity()
+    prospect = _prospect(provider="fixture", provider_key="place-1")
+    store = TenantProspectStore(tmp_path)
+    prospect_id = store.save(identity, prospect)
+
+    outcomes = TenantProspectDiscoveryIngestor(tmp_path).ingest(identity, [prospect])
+    saved = store.load(identity, store.ref(identity, prospect_id))
+
+    assert outcomes[0].action is DiscoveryIngestAction.unchanged
+    assert saved == prospect


### PR DESCRIPTION
Adds a tenant-scoped discovery ingest service for the fused prospect workflow. New observations can create prospects or enrich blank machine-observed fields and append new evidence, while existing qualification, rejection, outreach lifecycle, contacts, audit linkage and commercial notes are preserved. Ingest is serialized with the existing filesystem lock and covered by regression tests. Do not merge until exact-head full CI succeeds.