### PR TITLE
Add assisted discovery lifecycle contract

### DIFF
--- a/src/veridra/assisted_discovery.py
+++ b/src/veridra/assisted_discovery.py
@@ -305,23 +305,15 @@ class AssistedDiscoveryManager:
                 query_sequence=self._session.query_sequence,
                 limits=limits,
             )
-        except Exception as exc:
-            self._session = replace(
-                self._session,
-                state=AssistedDiscoveryState.ready,
-                error=str(exc),
-                progress=TraversalProgress(
-                    query_text=self._session.query_text,
-                    query_sequence=self._session.query_sequence,
-                    scroll_step=0,
-                    unique_results=0,
-                    stagnant_scrolls=0,
-                    elapsed_seconds=0.0,
-                    stop_reason=TraversalStopReason.provider_error,
-                ),
+            self._validate_provider_result(
+                result,
+                limits=limits,
+                expected_query_text=self._session.query_text,
+                expected_query_sequence=self._session.query_sequence,
             )
+        except Exception as exc:
+            self._restore_ready_after_error(exc)
             raise
-        self._validate_provider_result(result, limits=limits)
         self._session = replace(
             self._session,
             state=AssistedDiscoveryState.review,
@@ -353,6 +345,23 @@ class AssistedDiscoveryManager:
             )
         return tuple(item.business for item in self._session.observations)
 
+    def _restore_ready_after_error(self, exc: Exception) -> None:
+        self._session = replace(
+            self._session,
+            state=AssistedDiscoveryState.ready,
+            observations=(),
+            error=str(exc),
+            progress=TraversalProgress(
+                query_text=self._session.query_text,
+                query_sequence=self._session.query_sequence,
+                scroll_step=0,
+                unique_results=0,
+                stagnant_scrolls=0,
+                elapsed_seconds=0.0,
+                stop_reason=TraversalStopReason.provider_error,
+            ),
+        )
+
     def _require_current(self, session_id: str) -> None:
         if not session_id or self._session.session_id != session_id:
             raise AssistedDiscoveryTransitionError(
@@ -364,10 +373,23 @@ class AssistedDiscoveryManager:
         result: TraversalResult,
         *,
         limits: BoundedDiscoveryLimits,
+        expected_query_text: str,
+        expected_query_sequence: int,
     ) -> None:
         if len(result.observations) > limits.max_results:
             raise ValueError("Discovery provider exceeded the configured result limit.")
         if result.progress.unique_results != len(result.observations):
             raise ValueError("Discovery provider returned inconsistent progress evidence.")
-        if result.progress.query_sequence < 1 or not result.progress.query_text.strip():
-            raise ValueError("Discovery provider returned invalid query provenance.")
+        if result.progress.query_text != expected_query_text:
+            raise ValueError("Discovery provider returned mismatched query text provenance.")
+        if result.progress.query_sequence != expected_query_sequence:
+            raise ValueError("Discovery provider returned mismatched query sequence provenance.")
+        for index, observation in enumerate(result.observations, start=1):
+            if observation.query_text != expected_query_text:
+                raise ValueError("Discovery observation returned mismatched query text provenance.")
+            if observation.query_sequence != expected_query_sequence:
+                raise ValueError(
+                    "Discovery observation returned mismatched query sequence provenance."
+                )
+            if observation.result_rank != index:
+                raise ValueError("Discovery observation ranks must be contiguous and ordered.")

--- a/src/veridra/assisted_discovery.py
+++ b/src/veridra/assisted_discovery.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from typing import Protocol
+from uuid import uuid4
+
+from .prospect_discovery import ObservedBusiness
+
+
+class AssistedDiscoveryState(StrEnum):
+    idle = "idle"
+    launching = "launching"
+    awaiting_operator = "awaiting_operator"
+    ready = "ready"
+    collecting = "collecting"
+    review = "review"
+    stopped = "stopped"
+    failed = "failed"
+
+
+_ACTIVE_STATES = {
+    AssistedDiscoveryState.launching,
+    AssistedDiscoveryState.awaiting_operator,
+    AssistedDiscoveryState.ready,
+    AssistedDiscoveryState.collecting,
+    AssistedDiscoveryState.review,
+}
+
+
+class TraversalStopReason(StrEnum):
+    end_of_list = "end_of_list"
+    no_new_results = "no_new_results"
+    max_results = "max_results"
+    max_scrolls = "max_scrolls"
+    timeout = "timeout"
+    operator_stop = "operator_stop"
+    provider_error = "provider_error"
+
+
+@dataclass(frozen=True, slots=True)
+class BoundedDiscoveryLimits:
+    max_results: int = 100
+    max_scrolls: int = 40
+    max_elapsed_seconds: float = 90.0
+    max_stagnant_scrolls: int = 3
+
+    def __post_init__(self) -> None:
+        if self.max_results < 1 or self.max_results > 200:
+            raise ValueError("max_results must be between 1 and 200.")
+        if self.max_scrolls < 0 or self.max_scrolls > 100:
+            raise ValueError("max_scrolls must be between 0 and 100.")
+        if self.max_elapsed_seconds <= 0 or self.max_elapsed_seconds > 300:
+            raise ValueError("max_elapsed_seconds must be between 0 and 300.")
+        if self.max_stagnant_scrolls < 1 or self.max_stagnant_scrolls > 20:
+            raise ValueError("max_stagnant_scrolls must be between 1 and 20.")
+
+
+@dataclass(frozen=True, slots=True)
+class TraversalObservation:
+    business: ObservedBusiness
+    query_text: str
+    query_sequence: int
+    result_rank: int
+    first_seen_scroll_step: int
+
+
+@dataclass(frozen=True, slots=True)
+class TraversalProgress:
+    query_text: str
+    query_sequence: int
+    scroll_step: int
+    unique_results: int
+    stagnant_scrolls: int
+    elapsed_seconds: float
+    stop_reason: TraversalStopReason | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TraversalResult:
+    observations: tuple[TraversalObservation, ...]
+    progress: TraversalProgress
+
+
+class OrderedObservationAccumulator:
+    """Preserve first-seen provider order while enforcing server-owned bounds."""
+
+    def __init__(
+        self,
+        *,
+        query_text: str,
+        query_sequence: int,
+        limits: BoundedDiscoveryLimits,
+    ) -> None:
+        clean_query = query_text.strip()
+        if not clean_query:
+            raise ValueError("query_text cannot be blank.")
+        if query_sequence < 1:
+            raise ValueError("query_sequence must be at least 1.")
+        self._query_text = clean_query
+        self._query_sequence = query_sequence
+        self._limits = limits
+        self._observations: list[TraversalObservation] = []
+        self._seen_provider_keys: set[tuple[str, str]] = set()
+        self._stagnant_scrolls = 0
+
+    @property
+    def observations(self) -> tuple[TraversalObservation, ...]:
+        return tuple(self._observations)
+
+    @property
+    def stagnant_scrolls(self) -> int:
+        return self._stagnant_scrolls
+
+    def add_batch(
+        self,
+        businesses: list[ObservedBusiness],
+        *,
+        scroll_step: int,
+    ) -> int:
+        if scroll_step < 0:
+            raise ValueError("scroll_step cannot be negative.")
+        added = 0
+        for business in businesses:
+            identity = (business.provider.casefold(), business.provider_key.casefold())
+            if identity in self._seen_provider_keys:
+                continue
+            if len(self._observations) >= self._limits.max_results:
+                break
+            self._seen_provider_keys.add(identity)
+            self._observations.append(
+                TraversalObservation(
+                    business=business,
+                    query_text=self._query_text,
+                    query_sequence=self._query_sequence,
+                    result_rank=len(self._observations) + 1,
+                    first_seen_scroll_step=scroll_step,
+                )
+            )
+            added += 1
+        self._stagnant_scrolls = 0 if added else self._stagnant_scrolls + 1
+        return added
+
+    def evaluate_stop(
+        self,
+        *,
+        scroll_step: int,
+        elapsed_seconds: float,
+        end_of_list: bool = False,
+        operator_stop: bool = False,
+        provider_error: bool = False,
+    ) -> TraversalStopReason | None:
+        if operator_stop:
+            return TraversalStopReason.operator_stop
+        if provider_error:
+            return TraversalStopReason.provider_error
+        if end_of_list:
+            return TraversalStopReason.end_of_list
+        if len(self._observations) >= self._limits.max_results:
+            return TraversalStopReason.max_results
+        if elapsed_seconds >= self._limits.max_elapsed_seconds:
+            return TraversalStopReason.timeout
+        if scroll_step >= self._limits.max_scrolls:
+            return TraversalStopReason.max_scrolls
+        if self._stagnant_scrolls >= self._limits.max_stagnant_scrolls:
+            return TraversalStopReason.no_new_results
+        return None
+
+    def result(
+        self,
+        *,
+        scroll_step: int,
+        elapsed_seconds: float,
+        stop_reason: TraversalStopReason,
+    ) -> TraversalResult:
+        return TraversalResult(
+            observations=self.observations,
+            progress=TraversalProgress(
+                query_text=self._query_text,
+                query_sequence=self._query_sequence,
+                scroll_step=scroll_step,
+                unique_results=len(self._observations),
+                stagnant_scrolls=self._stagnant_scrolls,
+                elapsed_seconds=elapsed_seconds,
+                stop_reason=stop_reason,
+            ),
+        )
+
+
+class AssistedDiscoveryProvider(Protocol):
+    def launch(self, *, start_url: str) -> None: ...
+
+    def collect_bounded(
+        self,
+        *,
+        query_text: str,
+        query_sequence: int,
+        limits: BoundedDiscoveryLimits,
+    ) -> TraversalResult: ...
+
+    def stop(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class AssistedDiscoverySession:
+    session_id: str | None
+    state: AssistedDiscoveryState
+    query_text: str = ""
+    query_sequence: int = 0
+    start_url: str = ""
+    observations: tuple[TraversalObservation, ...] = ()
+    progress: TraversalProgress | None = None
+    error: str = ""
+
+
+class AssistedDiscoveryConflict(RuntimeError):
+    pass
+
+
+class AssistedDiscoveryTransitionError(RuntimeError):
+    pass
+
+
+class AssistedDiscoveryManager:
+    """Operator-controlled lifecycle around one bounded discovery provider session."""
+
+    def __init__(self, provider: AssistedDiscoveryProvider) -> None:
+        self._provider = provider
+        self._session = AssistedDiscoverySession(
+            session_id=None,
+            state=AssistedDiscoveryState.idle,
+        )
+
+    def snapshot(self) -> AssistedDiscoverySession:
+        return self._session
+
+    def launch(
+        self,
+        *,
+        query_text: str,
+        query_sequence: int,
+        start_url: str,
+    ) -> AssistedDiscoverySession:
+        if self._session.state in _ACTIVE_STATES:
+            raise AssistedDiscoveryConflict("An assisted discovery session is already active.")
+        clean_query = query_text.strip()
+        clean_url = start_url.strip()
+        if not clean_query:
+            raise ValueError("query_text cannot be blank.")
+        if query_sequence < 1:
+            raise ValueError("query_sequence must be at least 1.")
+        if not clean_url:
+            raise ValueError("start_url cannot be blank.")
+
+        session = AssistedDiscoverySession(
+            session_id=str(uuid4()),
+            state=AssistedDiscoveryState.launching,
+            query_text=clean_query,
+            query_sequence=query_sequence,
+            start_url=clean_url,
+        )
+        self._session = session
+        try:
+            self._provider.launch(start_url=clean_url)
+        except Exception as exc:
+            self._session = replace(
+                session,
+                state=AssistedDiscoveryState.failed,
+                error=str(exc),
+            )
+            raise
+        self._session = replace(session, state=AssistedDiscoveryState.awaiting_operator)
+        return self._session
+
+    def mark_ready(self, session_id: str) -> AssistedDiscoverySession:
+        self._require_current(session_id)
+        if self._session.state is not AssistedDiscoveryState.awaiting_operator:
+            raise AssistedDiscoveryTransitionError(
+                "The session can be marked ready only while awaiting the operator."
+            )
+        self._session = replace(self._session, state=AssistedDiscoveryState.ready)
+        return self._session
+
+    def collect(
+        self,
+        session_id: str,
+        *,
+        limits: BoundedDiscoveryLimits,
+    ) -> AssistedDiscoverySession:
+        self._require_current(session_id)
+        if self._session.state is not AssistedDiscoveryState.ready:
+            raise AssistedDiscoveryTransitionError(
+                "Discovery can run only after the operator marks the browser ready."
+            )
+        self._session = replace(
+            self._session,
+            state=AssistedDiscoveryState.collecting,
+            observations=(),
+            progress=None,
+            error="",
+        )
+        try:
+            result = self._provider.collect_bounded(
+                query_text=self._session.query_text,
+                query_sequence=self._session.query_sequence,
+                limits=limits,
+            )
+        except Exception as exc:
+            self._session = replace(
+                self._session,
+                state=AssistedDiscoveryState.ready,
+                error=str(exc),
+                progress=TraversalProgress(
+                    query_text=self._session.query_text,
+                    query_sequence=self._session.query_sequence,
+                    scroll_step=0,
+                    unique_results=0,
+                    stagnant_scrolls=0,
+                    elapsed_seconds=0.0,
+                    stop_reason=TraversalStopReason.provider_error,
+                ),
+            )
+            raise
+        self._validate_provider_result(result, limits=limits)
+        self._session = replace(
+            self._session,
+            state=AssistedDiscoveryState.review,
+            observations=result.observations,
+            progress=result.progress,
+            error="",
+        )
+        return self._session
+
+    def stop(self, session_id: str | None = None) -> AssistedDiscoverySession:
+        if self._session.session_id is None:
+            return self._session
+        if session_id is not None:
+            self._require_current(session_id)
+        if self._session.state in {
+            AssistedDiscoveryState.stopped,
+            AssistedDiscoveryState.failed,
+        }:
+            return self._session
+        self._provider.stop()
+        self._session = replace(self._session, state=AssistedDiscoveryState.stopped)
+        return self._session
+
+    def included_businesses(self, session_id: str) -> tuple[ObservedBusiness, ...]:
+        self._require_current(session_id)
+        if self._session.state is not AssistedDiscoveryState.review:
+            raise AssistedDiscoveryTransitionError(
+                "Discovery observations are available only during review."
+            )
+        return tuple(item.business for item in self._session.observations)
+
+    def _require_current(self, session_id: str) -> None:
+        if not session_id or self._session.session_id != session_id:
+            raise AssistedDiscoveryTransitionError(
+                "The assisted discovery session does not exist."
+            )
+
+    @staticmethod
+    def _validate_provider_result(
+        result: TraversalResult,
+        *,
+        limits: BoundedDiscoveryLimits,
+    ) -> None:
+        if len(result.observations) > limits.max_results:
+            raise ValueError("Discovery provider exceeded the configured result limit.")
+        if result.progress.unique_results != len(result.observations):
+            raise ValueError("Discovery provider returned inconsistent progress evidence.")
+        if result.progress.query_sequence < 1 or not result.progress.query_text.strip():
+            raise ValueError("Discovery provider returned invalid query provenance.")

--- a/tests/test_assisted_discovery.py
+++ b/tests/test_assisted_discovery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 
 import pytest
@@ -11,6 +12,7 @@ from veridra.assisted_discovery import (
     AssistedDiscoveryTransitionError,
     BoundedDiscoveryLimits,
     OrderedObservationAccumulator,
+    TraversalProgress,
     TraversalResult,
     TraversalStopReason,
 )
@@ -41,6 +43,7 @@ class FakeProvider:
         self.launched_url = ""
         self.stopped = False
         self.fail_collect = False
+        self.mismatched_progress = False
 
     def launch(self, *, start_url: str) -> None:
         self.launched_url = start_url
@@ -60,10 +63,24 @@ class FakeProvider:
             limits=limits,
         )
         accumulator.add_batch([_business("place-1"), _business("place-2")], scroll_step=0)
-        return accumulator.result(
+        result = accumulator.result(
             scroll_step=0,
             elapsed_seconds=0.2,
             stop_reason=TraversalStopReason.end_of_list,
+        )
+        if not self.mismatched_progress:
+            return result
+        return replace(
+            result,
+            progress=TraversalProgress(
+                query_text="wrong query",
+                query_sequence=query_sequence,
+                scroll_step=result.progress.scroll_step,
+                unique_results=result.progress.unique_results,
+                stagnant_scrolls=result.progress.stagnant_scrolls,
+                elapsed_seconds=result.progress.elapsed_seconds,
+                stop_reason=result.progress.stop_reason,
+            ),
         )
 
     def stop(self) -> None:
@@ -167,7 +184,8 @@ def test_complete_assisted_lifecycle_reaches_review_then_stop() -> None:
     assert reviewed.state is AssistedDiscoveryState.review
     assert reviewed.progress is not None
     assert reviewed.progress.stop_reason is TraversalStopReason.end_of_list
-    assert [item.provider_key for item in manager.included_businesses(reviewed.session_id or "")] == [
+    included = manager.included_businesses(reviewed.session_id or "")
+    assert [item.provider_key for item in included] == [
         "place-1",
         "place-2",
     ]
@@ -214,5 +232,29 @@ def test_provider_failure_returns_session_to_ready_without_fake_results() -> Non
     assert snapshot.state is AssistedDiscoveryState.ready
     assert snapshot.observations == ()
     assert snapshot.error == "provider failed"
+    assert snapshot.progress is not None
+    assert snapshot.progress.stop_reason is TraversalStopReason.provider_error
+
+
+def test_invalid_provider_provenance_returns_session_to_ready() -> None:
+    provider = FakeProvider()
+    provider.mismatched_progress = True
+    manager = AssistedDiscoveryManager(provider)
+    launched = manager.launch(
+        query_text="dentist in Vigo, ES",
+        query_sequence=1,
+        start_url="https://maps.example/search",
+    )
+    manager.mark_ready(launched.session_id or "")
+
+    with pytest.raises(ValueError, match="mismatched query text provenance"):
+        manager.collect(
+            launched.session_id or "",
+            limits=BoundedDiscoveryLimits(),
+        )
+
+    snapshot = manager.snapshot()
+    assert snapshot.state is AssistedDiscoveryState.ready
+    assert snapshot.observations == ()
     assert snapshot.progress is not None
     assert snapshot.progress.stop_reason is TraversalStopReason.provider_error

--- a/tests/test_assisted_discovery.py
+++ b/tests/test_assisted_discovery.py
@@ -11,7 +11,6 @@ from veridra.assisted_discovery import (
     AssistedDiscoveryTransitionError,
     BoundedDiscoveryLimits,
     OrderedObservationAccumulator,
-    TraversalProgress,
     TraversalResult,
     TraversalStopReason,
 )
@@ -42,28 +41,6 @@ class FakeProvider:
         self.launched_url = ""
         self.stopped = False
         self.fail_collect = False
-        self.result = TraversalResult(
-            observations=(
-                OrderedObservationAccumulator(
-                    query_text="dentist in Vigo, ES",
-                    query_sequence=1,
-                    limits=BoundedDiscoveryLimits(max_results=10),
-                ).result(
-                    scroll_step=0,
-                    elapsed_seconds=0.1,
-                    stop_reason=TraversalStopReason.end_of_list,
-                ).observations
-            ),
-            progress=TraversalProgress(
-                query_text="dentist in Vigo, ES",
-                query_sequence=1,
-                scroll_step=0,
-                unique_results=0,
-                stagnant_scrolls=0,
-                elapsed_seconds=0.1,
-                stop_reason=TraversalStopReason.end_of_list,
-            ),
-        )
 
     def launch(self, *, start_url: str) -> None:
         self.launched_url = start_url

--- a/tests/test_assisted_discovery.py
+++ b/tests/test_assisted_discovery.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from veridra.assisted_discovery import (
+    AssistedDiscoveryConflict,
+    AssistedDiscoveryManager,
+    AssistedDiscoveryState,
+    AssistedDiscoveryTransitionError,
+    BoundedDiscoveryLimits,
+    OrderedObservationAccumulator,
+    TraversalProgress,
+    TraversalResult,
+    TraversalStopReason,
+)
+from veridra.prospect_discovery import ObservedBusiness
+
+NOW = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
+
+
+def _business(provider_key: str = "place-1") -> ObservedBusiness:
+    return ObservedBusiness.model_validate(
+        {
+            "provider": "assisted-google-maps",
+            "provider_key": provider_key,
+            "name": f"Business {provider_key}",
+            "category": "Dental clinic",
+            "locality": "Vigo",
+            "administrative_area": "Pontevedra",
+            "country_code": "ES",
+            "website": f"https://{provider_key}.example",
+            "source_url": f"https://maps.example/{provider_key}",
+            "observed_at": NOW,
+        }
+    )
+
+
+class FakeProvider:
+    def __init__(self) -> None:
+        self.launched_url = ""
+        self.stopped = False
+        self.fail_collect = False
+        self.result = TraversalResult(
+            observations=(
+                OrderedObservationAccumulator(
+                    query_text="dentist in Vigo, ES",
+                    query_sequence=1,
+                    limits=BoundedDiscoveryLimits(max_results=10),
+                ).result(
+                    scroll_step=0,
+                    elapsed_seconds=0.1,
+                    stop_reason=TraversalStopReason.end_of_list,
+                ).observations
+            ),
+            progress=TraversalProgress(
+                query_text="dentist in Vigo, ES",
+                query_sequence=1,
+                scroll_step=0,
+                unique_results=0,
+                stagnant_scrolls=0,
+                elapsed_seconds=0.1,
+                stop_reason=TraversalStopReason.end_of_list,
+            ),
+        )
+
+    def launch(self, *, start_url: str) -> None:
+        self.launched_url = start_url
+
+    def collect_bounded(
+        self,
+        *,
+        query_text: str,
+        query_sequence: int,
+        limits: BoundedDiscoveryLimits,
+    ) -> TraversalResult:
+        if self.fail_collect:
+            raise RuntimeError("provider failed")
+        accumulator = OrderedObservationAccumulator(
+            query_text=query_text,
+            query_sequence=query_sequence,
+            limits=limits,
+        )
+        accumulator.add_batch([_business("place-1"), _business("place-2")], scroll_step=0)
+        return accumulator.result(
+            scroll_step=0,
+            elapsed_seconds=0.2,
+            stop_reason=TraversalStopReason.end_of_list,
+        )
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def test_bounds_reject_unrestricted_values() -> None:
+    with pytest.raises(ValueError, match="between 1 and 200"):
+        BoundedDiscoveryLimits(max_results=500)
+    with pytest.raises(ValueError, match="between 0 and 100"):
+        BoundedDiscoveryLimits(max_scrolls=101)
+    with pytest.raises(ValueError, match="between 0 and 300"):
+        BoundedDiscoveryLimits(max_elapsed_seconds=301)
+
+
+def test_accumulator_deduplicates_provider_identity_and_preserves_rank() -> None:
+    limits = BoundedDiscoveryLimits(max_results=3, max_stagnant_scrolls=2)
+    accumulator = OrderedObservationAccumulator(
+        query_text="dentist in Vigo, ES",
+        query_sequence=2,
+        limits=limits,
+    )
+
+    added = accumulator.add_batch(
+        [_business("A"), _business("a"), _business("B")],
+        scroll_step=0,
+    )
+
+    assert added == 2
+    assert [item.business.provider_key for item in accumulator.observations] == ["A", "B"]
+    assert [item.result_rank for item in accumulator.observations] == [1, 2]
+    assert all(item.query_sequence == 2 for item in accumulator.observations)
+
+
+def test_accumulator_stops_on_server_owned_result_limit() -> None:
+    limits = BoundedDiscoveryLimits(max_results=2)
+    accumulator = OrderedObservationAccumulator(
+        query_text="dentist in Vigo, ES",
+        query_sequence=1,
+        limits=limits,
+    )
+    accumulator.add_batch(
+        [_business("1"), _business("2"), _business("3")],
+        scroll_step=0,
+    )
+
+    assert len(accumulator.observations) == 2
+    assert (
+        accumulator.evaluate_stop(scroll_step=0, elapsed_seconds=1.0)
+        is TraversalStopReason.max_results
+    )
+
+
+def test_accumulator_stops_after_stagnation() -> None:
+    limits = BoundedDiscoveryLimits(max_stagnant_scrolls=2)
+    accumulator = OrderedObservationAccumulator(
+        query_text="dentist in Vigo, ES",
+        query_sequence=1,
+        limits=limits,
+    )
+    accumulator.add_batch([_business()], scroll_step=0)
+    accumulator.add_batch([_business()], scroll_step=1)
+    accumulator.add_batch([_business()], scroll_step=2)
+
+    assert accumulator.stagnant_scrolls == 2
+    assert (
+        accumulator.evaluate_stop(scroll_step=2, elapsed_seconds=1.0)
+        is TraversalStopReason.no_new_results
+    )
+
+
+def test_operator_must_mark_browser_ready_before_collection() -> None:
+    provider = FakeProvider()
+    manager = AssistedDiscoveryManager(provider)
+    session = manager.launch(
+        query_text="dentist in Vigo, ES",
+        query_sequence=1,
+        start_url="https://maps.example/search",
+    )
+
+    assert session.state is AssistedDiscoveryState.awaiting_operator
+    assert provider.launched_url == "https://maps.example/search"
+    with pytest.raises(AssistedDiscoveryTransitionError, match="marks the browser ready"):
+        manager.collect(session.session_id or "", limits=BoundedDiscoveryLimits())
+
+
+def test_complete_assisted_lifecycle_reaches_review_then_stop() -> None:
+    provider = FakeProvider()
+    manager = AssistedDiscoveryManager(provider)
+    launched = manager.launch(
+        query_text="dentist in Vigo, ES",
+        query_sequence=1,
+        start_url="https://maps.example/search",
+    )
+    ready = manager.mark_ready(launched.session_id or "")
+    reviewed = manager.collect(
+        ready.session_id or "",
+        limits=BoundedDiscoveryLimits(max_results=10),
+    )
+
+    assert reviewed.state is AssistedDiscoveryState.review
+    assert reviewed.progress is not None
+    assert reviewed.progress.stop_reason is TraversalStopReason.end_of_list
+    assert [item.provider_key for item in manager.included_businesses(reviewed.session_id or "")] == [
+        "place-1",
+        "place-2",
+    ]
+
+    stopped = manager.stop(reviewed.session_id)
+    assert stopped.state is AssistedDiscoveryState.stopped
+    assert provider.stopped is True
+
+
+def test_second_active_session_is_rejected() -> None:
+    manager = AssistedDiscoveryManager(FakeProvider())
+    manager.launch(
+        query_text="dentist in Vigo, ES",
+        query_sequence=1,
+        start_url="https://maps.example/search",
+    )
+
+    with pytest.raises(AssistedDiscoveryConflict):
+        manager.launch(
+            query_text="plumber in Vigo, ES",
+            query_sequence=2,
+            start_url="https://maps.example/search2",
+        )
+
+
+def test_provider_failure_returns_session_to_ready_without_fake_results() -> None:
+    provider = FakeProvider()
+    provider.fail_collect = True
+    manager = AssistedDiscoveryManager(provider)
+    launched = manager.launch(
+        query_text="dentist in Vigo, ES",
+        query_sequence=1,
+        start_url="https://maps.example/search",
+    )
+    manager.mark_ready(launched.session_id or "")
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        manager.collect(
+            launched.session_id or "",
+            limits=BoundedDiscoveryLimits(),
+        )
+
+    snapshot = manager.snapshot()
+    assert snapshot.state is AssistedDiscoveryState.ready
+    assert snapshot.observations == ()
+    assert snapshot.error == "provider failed"
+    assert snapshot.progress is not None
+    assert snapshot.progress.stop_reason is TraversalStopReason.provider_error


### PR DESCRIPTION
Migrates the safe operator-controlled discovery contract from the proven LeadMap workflow into Veridra without importing the old application/CRM layers.

This slice adds:
- explicit assisted discovery states: launch → awaiting operator → ready → bounded collection → review → stop;
- server-owned result, scroll, elapsed-time and stagnation bounds;
- deterministic stop reasons;
- provider-identity deduplication with first-seen ordering;
- query sequence, rank and first-seen scroll provenance;
- provider failure recovery back to ready with no fake observations;
- a provider Protocol ready for the later visible Chromium adapter;
- focused lifecycle and bounds regression tests.

It deliberately does not add a fake production discovery button, browser DOM selectors, Chromium subprocess transport, automatic persistence, outreach, CAPTCHA handling, stealth, proxies or unattended discovery. Veridra's existing safe prospect ingest remains the persistence boundary.

The source design is derived from the previously validated LeadMap assisted-browser/traversal implementation, adapted to Veridra's ObservedBusiness model and tighter max bounds.

Do not merge until exact-head full Veridra CI succeeds.