### PR TITLE
Add local headed-browser discovery provider

### DIFF
--- a/src/veridra/assisted_browser_protocol.py
+++ b/src/veridra/assisted_browser_protocol.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import IO, Any
+
+PROTOCOL_VERSION = 1
+MAX_MESSAGE_BYTES = 256_000
+
+
+class BrowserProtocolError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ProtocolRequest:
+    request_id: str
+    command: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ProtocolResponse:
+    request_id: str
+    ok: bool
+    result: dict[str, Any] | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+
+def _decode_message(line: str) -> dict[str, Any]:
+    if len(line.encode("utf-8")) > MAX_MESSAGE_BYTES:
+        raise BrowserProtocolError("Browser protocol message exceeded the size limit.")
+    try:
+        value = json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise BrowserProtocolError("Browser protocol returned malformed JSON.") from exc
+    if not isinstance(value, dict):
+        raise BrowserProtocolError("Browser protocol message must be a JSON object.")
+    if value.get("protocol_version") != PROTOCOL_VERSION:
+        raise BrowserProtocolError("Browser protocol version mismatch.")
+    return value
+
+
+def encode_request(request: ProtocolRequest) -> str:
+    return json.dumps(
+        {
+            "protocol_version": PROTOCOL_VERSION,
+            "request_id": request.request_id,
+            "command": request.command,
+            "payload": request.payload,
+        },
+        separators=(",", ":"),
+    ) + "\n"
+
+
+def decode_request(line: str) -> ProtocolRequest:
+    value = _decode_message(line)
+    request_id = value.get("request_id")
+    command = value.get("command")
+    payload = value.get("payload", {})
+    if not isinstance(request_id, str) or not request_id:
+        raise BrowserProtocolError("Browser protocol request_id is missing.")
+    if not isinstance(command, str) or not command:
+        raise BrowserProtocolError("Browser protocol command is missing.")
+    if not isinstance(payload, dict):
+        raise BrowserProtocolError("Browser protocol payload must be an object.")
+    return ProtocolRequest(request_id=request_id, command=command, payload=payload)
+
+
+def encode_response(response: ProtocolResponse) -> str:
+    value: dict[str, Any] = {
+        "protocol_version": PROTOCOL_VERSION,
+        "request_id": response.request_id,
+        "ok": response.ok,
+    }
+    if response.ok:
+        value["result"] = response.result or {}
+    else:
+        value["error"] = {
+            "code": response.error_code or "browser_error",
+            "message": response.error_message or "The browser command failed.",
+        }
+    return json.dumps(value, separators=(",", ":")) + "\n"
+
+
+def decode_response(line: str, *, expected_request_id: str) -> ProtocolResponse:
+    value = _decode_message(line)
+    request_id = value.get("request_id")
+    if request_id != expected_request_id:
+        raise BrowserProtocolError("Browser protocol response request_id mismatch.")
+    ok = value.get("ok")
+    if not isinstance(ok, bool):
+        raise BrowserProtocolError("Browser protocol response is missing ok state.")
+    if ok:
+        result = value.get("result", {})
+        if not isinstance(result, dict):
+            raise BrowserProtocolError("Browser protocol result must be an object.")
+        return ProtocolResponse(request_id=request_id, ok=True, result=result)
+    error = value.get("error")
+    if not isinstance(error, dict):
+        raise BrowserProtocolError("Browser protocol error envelope is missing.")
+    code = error.get("code")
+    message = error.get("message")
+    if not isinstance(code, str) or not isinstance(message, str):
+        raise BrowserProtocolError("Browser protocol error envelope is invalid.")
+    return ProtocolResponse(
+        request_id=request_id,
+        ok=False,
+        error_code=code,
+        error_message=message,
+    )
+
+
+def write_message(stream: IO[str], message: str) -> None:
+    if len(message.encode("utf-8")) > MAX_MESSAGE_BYTES:
+        raise BrowserProtocolError("Browser protocol message exceeded the size limit.")
+    stream.write(message)
+    stream.flush()

--- a/src/veridra/assisted_browser_provider.py
+++ b/src/veridra/assisted_browser_provider.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import os
+import queue
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from .assisted_browser_protocol import (
+    BrowserProtocolError,
+    ProtocolRequest,
+    decode_response,
+    encode_request,
+    write_message,
+)
+from .assisted_discovery import (
+    AssistedDiscoveryConflict,
+    BoundedDiscoveryLimits,
+    TraversalObservation,
+    TraversalProgress,
+    TraversalResult,
+    TraversalStopReason,
+)
+from .prospect_discovery import ObservedBusiness
+
+
+class VisibleBrowserUnavailable(RuntimeError):
+    pass
+
+
+class SubprocessPlaywrightDiscoveryProvider:
+    """Run visible-browser discovery in a local child process over stdin/stdout only."""
+
+    def __init__(
+        self,
+        *,
+        country_code: str,
+        locality: str = "",
+        administrative_area: str = "",
+        profile_directory: Path | None = None,
+        response_timeout_seconds: float = 120.0,
+    ) -> None:
+        clean_country = country_code.strip().upper()
+        if len(clean_country) != 2:
+            raise ValueError("country_code must contain exactly two characters.")
+        if response_timeout_seconds <= 0 or response_timeout_seconds > 600:
+            raise ValueError("response_timeout_seconds must be between 0 and 600.")
+        configured_profile = os.environ.get("VERIDRA_BROWSER_PROFILE_DIRECTORY", "").strip()
+        default_profile = Path.home() / ".veridra" / "browser-profile"
+        self._profile_directory = profile_directory or (
+            Path(configured_profile) if configured_profile else default_profile
+        )
+        self._country_code = clean_country
+        self._locality = locality.strip()
+        self._administrative_area = administrative_area.strip()
+        self._response_timeout_seconds = response_timeout_seconds
+        self._process: subprocess.Popen[str] | None = None
+
+    def launch(self, *, start_url: str) -> None:
+        if self._process is not None and self._process.poll() is None:
+            raise AssistedDiscoveryConflict("A visible browser process is already active.")
+        self._profile_directory.mkdir(parents=True, exist_ok=True)
+        self._process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "veridra.assisted_browser_runner",
+                "--profile-directory",
+                str(self._profile_directory),
+                "--start-url",
+                start_url,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            bufsize=1,
+        )
+        if self._process.poll() is not None:
+            raise VisibleBrowserUnavailable("The visible browser process exited during launch.")
+
+    def collect_bounded(
+        self,
+        *,
+        query_text: str,
+        query_sequence: int,
+        limits: BoundedDiscoveryLimits,
+    ) -> TraversalResult:
+        result = self._request(
+            command="collect_bounded",
+            payload={
+                "query_text": query_text,
+                "query_sequence": query_sequence,
+                "country_code": self._country_code,
+                "locality": self._locality,
+                "administrative_area": self._administrative_area,
+                "max_results": limits.max_results,
+                "max_scrolls": limits.max_scrolls,
+                "max_elapsed_seconds": limits.max_elapsed_seconds,
+                "max_stagnant_scrolls": limits.max_stagnant_scrolls,
+            },
+        )
+        return self._decode_result(result, limits=limits)
+
+    def stop(self) -> None:
+        process = self._process
+        self._process = None
+        if process is None or process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=8)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+    def _request(self, *, command: str, payload: dict[str, Any]) -> dict[str, Any]:
+        process = self._require_running_process()
+        if process.stdin is None or process.stdout is None:
+            raise VisibleBrowserUnavailable(
+                "The visible browser communication channel is unavailable."
+            )
+        request_id = str(uuid4())
+        write_message(
+            process.stdin,
+            encode_request(
+                ProtocolRequest(
+                    request_id=request_id,
+                    command=command,
+                    payload=payload,
+                )
+            ),
+        )
+        line = self._readline_with_timeout(process.stdout)
+        response = decode_response(line, expected_request_id=request_id)
+        if not response.ok:
+            raise VisibleBrowserUnavailable(
+                response.error_message or "The visible-browser operation failed."
+            )
+        if response.result is None:
+            raise BrowserProtocolError("Browser protocol result is missing.")
+        return response.result
+
+    def _decode_result(
+        self,
+        raw: dict[str, Any],
+        *,
+        limits: BoundedDiscoveryLimits,
+    ) -> TraversalResult:
+        raw_businesses = raw.get("businesses")
+        raw_observations = raw.get("observations")
+        raw_progress = raw.get("progress")
+        if not isinstance(raw_businesses, list) or not isinstance(raw_observations, list):
+            raise BrowserProtocolError("Browser protocol observations are invalid.")
+        if len(raw_businesses) != len(raw_observations):
+            raise BrowserProtocolError("Browser protocol observation counts do not match.")
+        if len(raw_businesses) > limits.max_results:
+            raise BrowserProtocolError("Browser process exceeded the configured result limit.")
+        if not isinstance(raw_progress, dict):
+            raise BrowserProtocolError("Browser protocol progress must be an object.")
+
+        try:
+            businesses = [ObservedBusiness.model_validate(item) for item in raw_businesses]
+            stop_reason = TraversalStopReason(str(raw_progress["stop_reason"]))
+            progress = TraversalProgress(
+                query_text=str(raw_progress["query_text"]),
+                query_sequence=int(raw_progress["query_sequence"]),
+                scroll_step=int(raw_progress["scroll_step"]),
+                unique_results=int(raw_progress["unique_results"]),
+                stagnant_scrolls=int(raw_progress["stagnant_scrolls"]),
+                elapsed_seconds=float(raw_progress["elapsed_seconds"]),
+                stop_reason=stop_reason,
+            )
+            observations = tuple(
+                TraversalObservation(
+                    business=business,
+                    query_text=str(metadata["query_text"]),
+                    query_sequence=int(metadata["query_sequence"]),
+                    result_rank=int(metadata["result_rank"]),
+                    first_seen_scroll_step=int(metadata["first_seen_scroll_step"]),
+                )
+                for business, metadata in zip(
+                    businesses,
+                    raw_observations,
+                    strict=True,
+                )
+                if isinstance(metadata, dict)
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BrowserProtocolError("Browser protocol discovery result is invalid.") from exc
+        if len(observations) != len(businesses):
+            raise BrowserProtocolError("Browser protocol observation metadata is invalid.")
+        return TraversalResult(observations=observations, progress=progress)
+
+    def _require_running_process(self) -> subprocess.Popen[str]:
+        process = self._process
+        if process is None or process.poll() is not None:
+            raise VisibleBrowserUnavailable("The visible browser process is not running.")
+        return process
+
+    def _readline_with_timeout(self, stream: Any) -> str:
+        responses: queue.Queue[str | BaseException] = queue.Queue(maxsize=1)
+
+        def read() -> None:
+            try:
+                responses.put(stream.readline())
+            except BaseException as exc:  # pragma: no cover - defensive pipe boundary
+                responses.put(exc)
+
+        threading.Thread(target=read, daemon=True).start()
+        try:
+            value = responses.get(timeout=self._response_timeout_seconds)
+        except queue.Empty as exc:
+            raise VisibleBrowserUnavailable(
+                "The visible browser did not respond in time."
+            ) from exc
+        if isinstance(value, BaseException):
+            raise VisibleBrowserUnavailable(
+                "The visible browser response could not be read."
+            ) from value
+        if value == "":
+            raise VisibleBrowserUnavailable(
+                "The visible browser process exited before collection completed."
+            )
+        return value

--- a/src/veridra/assisted_browser_runner.py
+++ b/src/veridra/assisted_browser_runner.py
@@ -79,6 +79,7 @@ def _handle_collect_bounded(page: object, payload: dict[str, object]) -> dict[st
         locality=_optional_text(payload, "locality"),
         administrative_area=_optional_text(payload, "administrative_area"),
     )
+    stop_reason = result.progress.stop_reason
     return {
         "businesses": [
             observation.business.model_dump(mode="json") for observation in result.observations
@@ -99,9 +100,7 @@ def _handle_collect_bounded(page: object, payload: dict[str, object]) -> dict[st
             "unique_results": result.progress.unique_results,
             "stagnant_scrolls": result.progress.stagnant_scrolls,
             "elapsed_seconds": result.progress.elapsed_seconds,
-            "stop_reason": (
-                result.progress.stop_reason.value if result.progress.stop_reason is not None else None
-            ),
+            "stop_reason": stop_reason.value if stop_reason is not None else None,
         },
     }
 

--- a/src/veridra/assisted_browser_runner.py
+++ b/src/veridra/assisted_browser_runner.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import argparse
+import signal
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from .assisted_browser_protocol import (
+    BrowserProtocolError,
+    ProtocolResponse,
+    decode_request,
+    encode_response,
+    write_message,
+)
+from .assisted_discovery import BoundedDiscoveryLimits
+from .assisted_google_maps import (
+    VisiblePageSelectorDrift,
+    VisiblePageUnsupported,
+    traverse_google_maps_results,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="veridra-assisted-browser")
+    parser.add_argument("--profile-directory", type=Path, required=True)
+    parser.add_argument("--start-url", required=True)
+    return parser
+
+
+def _respond(response: ProtocolResponse) -> None:
+    write_message(sys.stdout, encode_response(response))
+
+
+def _required_int(payload: dict[str, object], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise BrowserProtocolError(f"{key} must be an integer.")
+    return value
+
+
+def _required_float(payload: dict[str, object], key: str) -> float:
+    value = payload.get(key)
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        raise BrowserProtocolError(f"{key} must be numeric.")
+    return float(value)
+
+
+def _required_text(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise BrowserProtocolError(f"{key} must be a non-empty string.")
+    return value.strip()
+
+
+def _optional_text(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key, "")
+    if not isinstance(value, str):
+        raise BrowserProtocolError(f"{key} must be a string.")
+    return value.strip()
+
+
+def _handle_collect_bounded(page: object, payload: dict[str, object]) -> dict[str, object]:
+    query_text = _required_text(payload, "query_text")
+    query_sequence = _required_int(payload, "query_sequence")
+    country_code = _required_text(payload, "country_code")
+    limits = BoundedDiscoveryLimits(
+        max_results=_required_int(payload, "max_results"),
+        max_scrolls=_required_int(payload, "max_scrolls"),
+        max_elapsed_seconds=_required_float(payload, "max_elapsed_seconds"),
+        max_stagnant_scrolls=_required_int(payload, "max_stagnant_scrolls"),
+    )
+    result = traverse_google_maps_results(
+        page,
+        query_text=query_text,
+        query_sequence=query_sequence,
+        limits=limits,
+        country_code=country_code,
+        locality=_optional_text(payload, "locality"),
+        administrative_area=_optional_text(payload, "administrative_area"),
+    )
+    return {
+        "businesses": [
+            observation.business.model_dump(mode="json") for observation in result.observations
+        ],
+        "observations": [
+            {
+                "query_text": observation.query_text,
+                "query_sequence": observation.query_sequence,
+                "result_rank": observation.result_rank,
+                "first_seen_scroll_step": observation.first_seen_scroll_step,
+            }
+            for observation in result.observations
+        ],
+        "progress": {
+            "query_text": result.progress.query_text,
+            "query_sequence": result.progress.query_sequence,
+            "scroll_step": result.progress.scroll_step,
+            "unique_results": result.progress.unique_results,
+            "stagnant_scrolls": result.progress.stagnant_scrolls,
+            "elapsed_seconds": result.progress.elapsed_seconds,
+            "stop_reason": (
+                result.progress.stop_reason.value if result.progress.stop_reason is not None else None
+            ),
+        },
+    }
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        raise RuntimeError("Playwright is required for assisted discovery.") from exc
+
+    stopping = False
+
+    def request_stop(_signum: int, _frame: object) -> None:
+        nonlocal stopping
+        stopping = True
+
+    signal.signal(signal.SIGTERM, request_stop)
+    signal.signal(signal.SIGINT, request_stop)
+
+    with sync_playwright() as playwright:
+        context = playwright.chromium.launch_persistent_context(
+            str(args.profile_directory),
+            headless=False,
+        )
+        page = context.pages[0] if context.pages else context.new_page()
+        page.goto(str(args.start_url))
+        while not stopping and context.pages:
+            line = sys.stdin.readline()
+            if line == "":
+                break
+            request_id = "unknown"
+            try:
+                request = decode_request(line)
+                request_id = request.request_id
+                if request.command != "collect_bounded":
+                    _respond(
+                        ProtocolResponse(
+                            request_id=request.request_id,
+                            ok=False,
+                            error_code="unsupported_command",
+                            error_message="The browser command is not supported.",
+                        )
+                    )
+                    continue
+                result = _handle_collect_bounded(page, request.payload)
+                _respond(
+                    ProtocolResponse(
+                        request_id=request.request_id,
+                        ok=True,
+                        result=result,
+                    )
+                )
+            except VisiblePageUnsupported as exc:
+                _respond(
+                    ProtocolResponse(
+                        request_id=request_id,
+                        ok=False,
+                        error_code="unsupported_page",
+                        error_message=str(exc),
+                    )
+                )
+            except VisiblePageSelectorDrift as exc:
+                _respond(
+                    ProtocolResponse(
+                        request_id=request_id,
+                        ok=False,
+                        error_code="selector_drift",
+                        error_message=str(exc),
+                    )
+                )
+            except (BrowserProtocolError, ValueError) as exc:
+                _respond(
+                    ProtocolResponse(
+                        request_id=request_id,
+                        ok=False,
+                        error_code="invalid_request",
+                        error_message=str(exc),
+                    )
+                )
+            except Exception:
+                _respond(
+                    ProtocolResponse(
+                        request_id=request_id,
+                        ok=False,
+                        error_code="browser_error",
+                        error_message="The visible browser could not collect the current results.",
+                    )
+                )
+        context.close()
+    return 0
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/veridra/assisted_google_maps.py
+++ b/src/veridra/assisted_google_maps.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import hashlib
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from .assisted_discovery import (
+    BoundedDiscoveryLimits,
+    OrderedObservationAccumulator,
+    TraversalResult,
+)
+from .prospect_discovery import ObservedBusiness
+
+_END_OF_LIST_MARKERS = (
+    "you've reached the end of the list",
+    "you have reached the end of the list",
+)
+
+
+class VisiblePageUnsupported(RuntimeError):
+    pass
+
+
+class VisiblePageSelectorDrift(RuntimeError):
+    pass
+
+
+def _feed_has_end_marker(feed: Any) -> bool:
+    try:
+        text = str(feed.inner_text(timeout=1_000)).casefold()
+    except Exception:
+        return False
+    return any(marker in text for marker in _END_OF_LIST_MARKERS)
+
+
+def _provider_key(source_url: str | None, *, name: str, index: int) -> str:
+    identity = source_url or f"{name.casefold()}|{index}"
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
+    return f"google-maps:{digest}"
+
+
+def capture_visible_google_maps_businesses(
+    page: Any,
+    *,
+    max_results: int,
+    country_code: str,
+    locality: str = "",
+    administrative_area: str = "",
+) -> list[ObservedBusiness]:
+    if max_results < 1:
+        raise ValueError("max_results must be at least 1.")
+    clean_country = country_code.strip().upper()
+    if len(clean_country) != 2:
+        raise ValueError("country_code must contain exactly two characters.")
+    page_url = str(page.url)
+    if "google." not in page_url or "/maps" not in page_url:
+        raise VisiblePageUnsupported(
+            "Open a supported Google Maps results page in the visible browser and retry."
+        )
+
+    cards = page.locator('[role="feed"] [role="article"]')
+    count = min(int(cards.count()), max_results)
+    if count == 0:
+        raise VisiblePageSelectorDrift(
+            "No visible Google Maps result cards were found. Confirm the results panel is open "
+            "and retry; the page structure may have changed."
+        )
+
+    captured: list[ObservedBusiness] = []
+    observed_at = datetime.now(UTC)
+    for index in range(count):
+        card = cards.nth(index)
+        text = str(card.inner_text(timeout=2_000)).strip()
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        name = lines[0] if lines else ""
+        if not name:
+            continue
+
+        links = card.locator("a[href]")
+        source_url: str | None = None
+        website: str | None = None
+        for link_index in range(int(links.count())):
+            href = links.nth(link_index).get_attribute("href")
+            if not isinstance(href, str) or not href:
+                continue
+            if "/maps/place/" in href and source_url is None:
+                source_url = href
+            elif href.startswith("http") and "google." not in href and website is None:
+                website = href
+
+        captured.append(
+            ObservedBusiness.model_validate(
+                {
+                    "provider": "assisted-google-maps",
+                    "provider_key": _provider_key(source_url, name=name, index=index),
+                    "name": name,
+                    "category": lines[1] if len(lines) > 1 else "",
+                    "locality": locality,
+                    "administrative_area": administrative_area,
+                    "country_code": clean_country,
+                    "website": website,
+                    "source_url": source_url,
+                    "observed_at": observed_at,
+                }
+            )
+        )
+    return captured
+
+
+def traverse_google_maps_results(
+    page: Any,
+    *,
+    query_text: str,
+    query_sequence: int,
+    limits: BoundedDiscoveryLimits,
+    country_code: str,
+    locality: str = "",
+    administrative_area: str = "",
+) -> TraversalResult:
+    page_url = str(page.url)
+    if "google." not in page_url or "/maps" not in page_url:
+        raise VisiblePageUnsupported(
+            "Open a supported Google Maps results page in the visible browser and retry."
+        )
+    feed = page.locator('[role="feed"]')
+    if int(feed.count()) == 0:
+        raise VisiblePageSelectorDrift(
+            "No Google Maps result panel was found. Confirm the results panel is open and retry."
+        )
+
+    accumulator = OrderedObservationAccumulator(
+        query_text=query_text,
+        query_sequence=query_sequence,
+        limits=limits,
+    )
+    started = time.monotonic()
+    scroll_step = 0
+
+    while True:
+        elapsed = time.monotonic() - started
+        businesses = capture_visible_google_maps_businesses(
+            page,
+            max_results=limits.max_results,
+            country_code=country_code,
+            locality=locality,
+            administrative_area=administrative_area,
+        )
+        accumulator.add_batch(businesses, scroll_step=scroll_step)
+        stop_reason = accumulator.evaluate_stop(
+            scroll_step=scroll_step,
+            elapsed_seconds=elapsed,
+            end_of_list=_feed_has_end_marker(feed),
+        )
+        if stop_reason is not None:
+            return accumulator.result(
+                scroll_step=scroll_step,
+                elapsed_seconds=elapsed,
+                stop_reason=stop_reason,
+            )
+
+        feed.evaluate(
+            "(element) => element.scrollBy(0, Math.max(element.clientHeight * 0.8, 500))"
+        )
+        page.wait_for_timeout(750)
+        scroll_step += 1

--- a/tests/test_assisted_browser_provider.py
+++ b/tests/test_assisted_browser_provider.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+
+from veridra.assisted_browser_protocol import (
+    BrowserProtocolError,
+    ProtocolRequest,
+    ProtocolResponse,
+    decode_request,
+    decode_response,
+    encode_request,
+    encode_response,
+    write_message,
+)
+from veridra.assisted_browser_provider import SubprocessPlaywrightDiscoveryProvider
+from veridra.assisted_discovery import BoundedDiscoveryLimits, TraversalStopReason
+from veridra.assisted_google_maps import capture_visible_google_maps_businesses
+
+
+class _Link:
+    def __init__(self, href: str) -> None:
+        self.href = href
+
+    def get_attribute(self, name: str) -> str | None:
+        return self.href if name == "href" else None
+
+
+class _Links:
+    def __init__(self, hrefs: list[str]) -> None:
+        self.links = [_Link(item) for item in hrefs]
+
+    def count(self) -> int:
+        return len(self.links)
+
+    def nth(self, index: int) -> _Link:
+        return self.links[index]
+
+
+class _Card:
+    def __init__(self, text: str, hrefs: list[str]) -> None:
+        self.text = text
+        self.hrefs = hrefs
+
+    def inner_text(self, *, timeout: int) -> str:
+        assert timeout == 2_000
+        return self.text
+
+    def locator(self, selector: str) -> _Links:
+        assert selector == "a[href]"
+        return _Links(self.hrefs)
+
+
+class _Cards:
+    def __init__(self, cards: list[_Card]) -> None:
+        self.cards = cards
+
+    def count(self) -> int:
+        return len(self.cards)
+
+    def nth(self, index: int) -> _Card:
+        return self.cards[index]
+
+
+class _Page:
+    url = "https://www.google.es/maps/search/dentist+vigo"
+
+    def __init__(self) -> None:
+        self.cards = _Cards(
+            [
+                _Card(
+                    "Vigo Dental Clinic\nDental clinic\n4.8 stars",
+                    [
+                        "https://www.google.es/maps/place/Vigo+Dental+Clinic/data=abc",
+                        "https://clinic.example/",
+                    ],
+                )
+            ]
+        )
+
+    def locator(self, selector: str) -> _Cards:
+        assert selector == '[role="feed"] [role="article"]'
+        return self.cards
+
+
+def test_protocol_round_trip_and_request_id_validation() -> None:
+    encoded = encode_request(
+        ProtocolRequest(
+            request_id="request-1",
+            command="collect_bounded",
+            payload={"max_results": 10},
+        )
+    )
+    decoded = decode_request(encoded)
+    assert decoded.request_id == "request-1"
+    assert decoded.command == "collect_bounded"
+    assert decoded.payload == {"max_results": 10}
+
+    response = encode_response(
+        ProtocolResponse(
+            request_id="request-1",
+            ok=True,
+            result={"businesses": []},
+        )
+    )
+    assert decode_response(response, expected_request_id="request-1").ok is True
+    with pytest.raises(BrowserProtocolError, match="request_id mismatch"):
+        decode_response(response, expected_request_id="different-request")
+
+
+def test_protocol_write_flushes_bounded_message() -> None:
+    stream = StringIO()
+    write_message(stream, encode_response(ProtocolResponse(request_id="r1", ok=True)))
+    assert '"request_id":"r1"' in stream.getvalue()
+
+
+def test_google_maps_capture_uses_explicit_territory_context() -> None:
+    records = capture_visible_google_maps_businesses(
+        _Page(),
+        max_results=5,
+        country_code="es",
+        locality="Vigo",
+        administrative_area="Pontevedra",
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record.name == "Vigo Dental Clinic"
+    assert record.category == "Dental clinic"
+    assert record.country_code == "ES"
+    assert record.locality == "Vigo"
+    assert record.administrative_area == "Pontevedra"
+    assert record.provider == "assisted-google-maps"
+    assert record.provider_key.startswith("google-maps:")
+    assert len(record.provider_key) < 100
+    assert str(record.website) == "https://clinic.example/"
+    assert "/maps/place/" in str(record.source_url)
+
+
+def test_parent_decodes_bounded_child_result() -> None:
+    provider = SubprocessPlaywrightDiscoveryProvider(country_code="ES", locality="Vigo")
+    raw = {
+        "businesses": [
+            {
+                "provider": "assisted-google-maps",
+                "provider_key": "google-maps:abc",
+                "name": "Vigo Dental Clinic",
+                "category": "Dental clinic",
+                "locality": "Vigo",
+                "administrative_area": "Pontevedra",
+                "country_code": "ES",
+                "postal_area": "",
+                "website": "https://clinic.example/",
+                "phone": "",
+                "source_url": "https://www.google.es/maps/place/Vigo+Dental+Clinic",
+                "observed_at": "2026-08-23T12:00:00Z",
+            }
+        ],
+        "observations": [
+            {
+                "query_text": "dentist in Vigo, ES",
+                "query_sequence": 1,
+                "result_rank": 1,
+                "first_seen_scroll_step": 0,
+            }
+        ],
+        "progress": {
+            "query_text": "dentist in Vigo, ES",
+            "query_sequence": 1,
+            "scroll_step": 0,
+            "unique_results": 1,
+            "stagnant_scrolls": 0,
+            "elapsed_seconds": 0.2,
+            "stop_reason": "end_of_list",
+        },
+    }
+
+    result = provider._decode_result(raw, limits=BoundedDiscoveryLimits(max_results=10))
+
+    assert len(result.observations) == 1
+    assert result.observations[0].business.country_code == "ES"
+    assert result.observations[0].result_rank == 1
+    assert result.progress.stop_reason is TraversalStopReason.end_of_list
+
+
+def test_parent_rejects_child_result_above_server_limit() -> None:
+    provider = SubprocessPlaywrightDiscoveryProvider(country_code="ES")
+    business = {
+        "provider": "assisted-google-maps",
+        "provider_key": "google-maps:abc",
+        "name": "Business",
+        "country_code": "ES",
+    }
+    raw = {
+        "businesses": [business, {**business, "provider_key": "google-maps:def"}],
+        "observations": [{}, {}],
+        "progress": {},
+    }
+
+    with pytest.raises(BrowserProtocolError, match="exceeded the configured result limit"):
+        provider._decode_result(raw, limits=BoundedDiscoveryLimits(max_results=1))


### PR DESCRIPTION
Migrates the proven assisted Google Maps provider boundary from LeadMap into Veridra, adapted to Veridra's bounded discovery contract and ObservedBusiness model.

Included:
- versioned newline-delimited JSON IPC with request IDs and a 256 KB message limit;
- a local visible Chromium child runner launched through Python/Playwright;
- stdin/stdout-only transport with no listening port;
- bounded Google Maps result-panel extraction and scrolling;
- stable hashed Google Maps provider identities;
- explicit operator-selected country/locality/administrative-area context passed into observations rather than inferred from card text;
- parent-side timeout, child-exit handling, structured response validation and server result-limit enforcement;
- deterministic protocol, extraction and decode tests.

Safety boundary:
- visible browser only;
- collection remains gated by the AssistedDiscoveryManager's explicit operator-ready transition;
- no CAPTCHA bypass, stealth, proxies, fingerprint manipulation, automatic persistence, automatic outreach or unattended query sequencing;
- Google DOM selector drift fails closed;
- CI uses deterministic fakes and does not contact Google.

A real headed-browser Windows acceptance remains required separately before exposing this provider in the agency UI.

Do not merge until exact-head full Veridra CI succeeds.