### PR TITLE
Handle null Origin for trusted local login

### DIFF
--- a/src/veridra/same_origin.py
+++ b/src/veridra/same_origin.py
@@ -66,6 +66,10 @@ def _request_origin(request: Request) -> str:
     return f"{scheme}://{hostname.lower()}{suffix}"
 
 
+def _loopback_request_matches_trusted_origin(request: Request, trusted_origin: str) -> bool:
+    return _is_loopback_origin(trusted_origin) and _request_origin(request) == trusted_origin
+
+
 @dataclass(frozen=True)
 class TrustedSameOriginPolicy:
     trusted_origin: str
@@ -83,19 +87,25 @@ class TrustedSameOriginPolicy:
         if not self.requires_validation(request):
             return
         supplied_origin = request.headers.get("origin")
-        if supplied_origin:
+        if supplied_origin and supplied_origin.strip().lower() != "null":
             try:
                 candidate = _normalized_origin(supplied_origin)
             except SameOriginConfigurationError as exc:
                 raise SameOriginRequestError(
                     "Authenticated request origin is not permitted."
                 ) from exc
+        elif supplied_origin and supplied_origin.strip().lower() == "null":
+            if not _loopback_request_matches_trusted_origin(request, self.trusted_origin):
+                raise SameOriginRequestError(
+                    "Authenticated request origin is not permitted."
+                )
+            candidate = self.trusted_origin
         else:
             referer = request.headers.get("referer")
             if referer:
                 candidate = _origin_from_referer(referer)
-            elif _is_loopback_origin(self.trusted_origin):
-                candidate = _request_origin(request)
+            elif _loopback_request_matches_trusted_origin(request, self.trusted_origin):
+                candidate = self.trusted_origin
             else:
                 raise SameOriginRequestError(
                     "Authenticated request origin is not permitted."

--- a/tests/test_same_origin.py
+++ b/tests/test_same_origin.py
@@ -78,7 +78,7 @@ def test_authenticated_same_origin_and_referer_fallback_succeed() -> None:
     assert referer_response.status_code == 200
 
 
-def test_authenticated_cross_origin_and_missing_origin_are_rejected() -> None:
+def test_authenticated_cross_origin_missing_and_null_origin_are_rejected_for_production() -> None:
     client = TestClient(_app(StaticAdapter(_identity())))
 
     cross_origin = client.post(
@@ -86,9 +86,14 @@ def test_authenticated_cross_origin_and_missing_origin_are_rejected() -> None:
         headers={"Origin": "https://attacker.example"},
     )
     missing = client.post("/api/tenant/projects")
+    null_origin = client.post(
+        "/api/tenant/projects",
+        headers={"Origin": "null"},
+    )
 
     assert cross_origin.status_code == 403
     assert missing.status_code == 403
+    assert null_origin.status_code == 403
     assert cross_origin.json() == {
         "detail": "Authenticated request origin is not permitted."
     }
@@ -104,6 +109,36 @@ def test_originless_exact_loopback_request_is_allowed() -> None:
     response = client.post("/api/tenant/projects")
 
     assert response.status_code == 200
+
+
+def test_null_origin_exact_loopback_request_is_allowed() -> None:
+    origin = "http://127.0.0.1:8010"
+    client = TestClient(
+        _app(StaticAdapter(_identity()), trusted_origin=origin),
+        base_url=origin,
+    )
+
+    response = client.post(
+        "/api/tenant/projects",
+        headers={"Origin": "null"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_null_origin_loopback_request_with_wrong_host_is_rejected() -> None:
+    trusted = "http://127.0.0.1:8010"
+    client = TestClient(
+        _app(StaticAdapter(_identity()), trusted_origin=trusted),
+        base_url="http://localhost:8010",
+    )
+
+    response = client.post(
+        "/api/tenant/projects",
+        headers={"Origin": "null"},
+    )
+
+    assert response.status_code == 403
 
 
 def test_originless_loopback_request_with_wrong_host_is_rejected() -> None:


### PR DESCRIPTION
## Purpose
Fix the remaining real Chrome login failure on local VERIDRA after PR #204.

## Root cause
Chrome may submit the local HTTP form with `Origin: null`. The previous fix only handled a missing Origin/Referer, so `null` was still parsed as an invalid origin and rejected before password authentication.

## Security boundary
- `Origin: null` is accepted only when `VERIDRA_TRUSTED_ORIGIN` is loopback (`127.0.0.1` / `localhost`) and the actual request URL exactly matches that trusted origin.
- Production/non-loopback origins still reject both missing Origin and `Origin: null`.
- Wrong loopback host remains rejected.

## Tests
Adds regression coverage for production rejection, exact loopback acceptance, and wrong-host rejection.