### PR TITLE
Harden Google Maps discovery metadata quality

### DIFF
--- a/src/veridra/assisted_google_maps.py
+++ b/src/veridra/assisted_google_maps.py
@@ -5,7 +5,7 @@ import re
 import time
 from datetime import UTC, datetime
 from typing import Any
-from urllib.parse import unquote, urlsplit
+from urllib.parse import parse_qs, unquote, urlsplit
 
 from .assisted_discovery import (
     BoundedDiscoveryLimits,
@@ -61,11 +61,24 @@ def _provider_key(source_url: str | None, *, name: str) -> str:
     return f"google-maps:{digest}"
 
 
+def _is_google_hostname(hostname: str) -> bool:
+    host = hostname.casefold().strip(".")
+    return host.startswith("google.") or ".google." in host
+
+
 def _external_website(href: str | None) -> str | None:
     if not isinstance(href, str) or not href.startswith(("http://", "https://")):
         return None
-    hostname = (urlsplit(href).hostname or "").casefold()
-    if hostname == "google.com" or hostname.endswith(".google.com"):
+    parsed = urlsplit(href)
+    hostname = (parsed.hostname or "").casefold()
+    if _is_google_hostname(hostname):
+        query = parse_qs(parsed.query)
+        for key in ("q", "url"):
+            candidate = query.get(key, [""])[0]
+            if candidate.startswith(("http://", "https://")):
+                candidate_host = (urlsplit(candidate).hostname or "").casefold()
+                if candidate_host and not _is_google_hostname(candidate_host):
+                    return candidate
         return None
     return href
 
@@ -79,34 +92,36 @@ def _clean_category(value: str, *, name: str) -> str:
     return clean
 
 
-def _detail_panel_metadata(page: Any, place_link: Any, *, name: str) -> tuple[str | None, str]:
+def _detail_panel_metadata(page: Any, source_url: str, *, name: str) -> tuple[str | None, str]:
+    detail_page: Any | None = None
     try:
-        place_link.click(timeout=2_500)
-        page.wait_for_timeout(450)
-    except Exception:
-        return None, ""
+        detail_page = page.context.new_page()
+        detail_page.goto(source_url, wait_until="domcontentloaded", timeout=5_000)
+        detail_page.wait_for_timeout(500)
 
-    website: str | None = None
-    try:
-        website_locator = page.locator(_DETAIL_WEBSITE_SELECTOR)
+        website: str | None = None
+        website_locator = detail_page.locator(_DETAIL_WEBSITE_SELECTOR)
         if int(website_locator.count()) > 0:
             website = _external_website(website_locator.first.get_attribute("href"))
-    except Exception:
-        website = None
 
-    category = ""
-    for selector in _DETAIL_CATEGORY_SELECTORS:
-        try:
-            locator = page.locator(selector)
+        category = ""
+        for selector in _DETAIL_CATEGORY_SELECTORS:
+            locator = detail_page.locator(selector)
             if int(locator.count()) == 0:
                 continue
             candidate = _clean_category(str(locator.first.inner_text(timeout=1_000)), name=name)
             if candidate:
                 category = candidate
                 break
-        except Exception:
-            continue
-    return website, category
+        return website, category
+    except Exception:
+        return None, ""
+    finally:
+        if detail_page is not None:
+            try:
+                detail_page.close()
+            except Exception:
+                pass
 
 
 def capture_visible_google_maps_businesses(
@@ -149,15 +164,12 @@ def capture_visible_google_maps_businesses(
         links = card.locator("a[href]")
         source_url: str | None = None
         website: str | None = None
-        place_link: Any | None = None
         for link_index in range(int(links.count())):
-            link = links.nth(link_index)
-            href = link.get_attribute("href")
+            href = links.nth(link_index).get_attribute("href")
             if not isinstance(href, str) or not href:
                 continue
             if "/maps/place/" in href and source_url is None:
                 source_url = href
-                place_link = link
                 continue
             external = _external_website(href)
             if external is not None and website is None:
@@ -167,14 +179,13 @@ def capture_visible_google_maps_businesses(
         if len(lines) > 1:
             category = _clean_category(lines[1], name=name)
 
-        if place_link is not None and (website is None or not category):
+        if website is None and source_url is not None:
             detail_website, detail_category = _detail_panel_metadata(
                 page,
-                place_link,
+                source_url,
                 name=name,
             )
-            if website is None:
-                website = detail_website
+            website = detail_website
             if not category:
                 category = detail_category
 

--- a/src/veridra/assisted_google_maps.py
+++ b/src/veridra/assisted_google_maps.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import hashlib
+import re
 import time
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import unquote, urlsplit
 
 from .assisted_discovery import (
     BoundedDiscoveryLimits,
@@ -15,6 +17,12 @@ from .prospect_discovery import ObservedBusiness
 _END_OF_LIST_MARKERS = (
     "you've reached the end of the list",
     "you have reached the end of the list",
+)
+_GOOGLE_PLACE_ID_PATTERN = re.compile(r"!1s([^!/?&]+)")
+_DETAIL_WEBSITE_SELECTOR = 'a[data-item-id="authority"][href]'
+_DETAIL_CATEGORY_SELECTORS = (
+    'button[jsaction*="category"]',
+    '[data-item-id="category"]',
 )
 
 
@@ -34,10 +42,71 @@ def _feed_has_end_marker(feed: Any) -> bool:
     return any(marker in text for marker in _END_OF_LIST_MARKERS)
 
 
-def _provider_key(source_url: str | None, *, name: str, index: int) -> str:
-    identity = source_url or f"{name.casefold()}|{index}"
+def _canonical_maps_identity(source_url: str | None, *, name: str) -> str:
+    if source_url:
+        match = _GOOGLE_PLACE_ID_PATTERN.search(source_url)
+        if match:
+            return f"place-id:{unquote(match.group(1)).casefold()}"
+        parsed = urlsplit(source_url)
+        path = unquote(parsed.path)
+        if "/maps/place/" in path:
+            place_path = path.split("/data=", 1)[0].rstrip("/")
+            return f"place-path:{place_path.casefold()}"
+    return f"name:{' '.join(name.casefold().split())}"
+
+
+def _provider_key(source_url: str | None, *, name: str) -> str:
+    identity = _canonical_maps_identity(source_url, name=name)
     digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()
     return f"google-maps:{digest}"
+
+
+def _external_website(href: str | None) -> str | None:
+    if not isinstance(href, str) or not href.startswith(("http://", "https://")):
+        return None
+    hostname = (urlsplit(href).hostname or "").casefold()
+    if hostname == "google.com" or hostname.endswith(".google.com"):
+        return None
+    return href
+
+
+def _clean_category(value: str, *, name: str) -> str:
+    clean = " ".join(value.split()).strip()
+    if not clean:
+        return ""
+    if clean.casefold() in {name.casefold(), "sponsored", "ad", "advertisement"}:
+        return ""
+    return clean
+
+
+def _detail_panel_metadata(page: Any, place_link: Any, *, name: str) -> tuple[str | None, str]:
+    try:
+        place_link.click(timeout=2_500)
+        page.wait_for_timeout(450)
+    except Exception:
+        return None, ""
+
+    website: str | None = None
+    try:
+        website_locator = page.locator(_DETAIL_WEBSITE_SELECTOR)
+        if int(website_locator.count()) > 0:
+            website = _external_website(website_locator.first.get_attribute("href"))
+    except Exception:
+        website = None
+
+    category = ""
+    for selector in _DETAIL_CATEGORY_SELECTORS:
+        try:
+            locator = page.locator(selector)
+            if int(locator.count()) == 0:
+                continue
+            candidate = _clean_category(str(locator.first.inner_text(timeout=1_000)), name=name)
+            if candidate:
+                category = candidate
+                break
+        except Exception:
+            continue
+    return website, category
 
 
 def capture_visible_google_maps_businesses(
@@ -80,22 +149,42 @@ def capture_visible_google_maps_businesses(
         links = card.locator("a[href]")
         source_url: str | None = None
         website: str | None = None
+        place_link: Any | None = None
         for link_index in range(int(links.count())):
-            href = links.nth(link_index).get_attribute("href")
+            link = links.nth(link_index)
+            href = link.get_attribute("href")
             if not isinstance(href, str) or not href:
                 continue
             if "/maps/place/" in href and source_url is None:
                 source_url = href
-            elif href.startswith("http") and "google." not in href and website is None:
-                website = href
+                place_link = link
+                continue
+            external = _external_website(href)
+            if external is not None and website is None:
+                website = external
+
+        category = ""
+        if len(lines) > 1:
+            category = _clean_category(lines[1], name=name)
+
+        if place_link is not None and (website is None or not category):
+            detail_website, detail_category = _detail_panel_metadata(
+                page,
+                place_link,
+                name=name,
+            )
+            if website is None:
+                website = detail_website
+            if not category:
+                category = detail_category
 
         captured.append(
             ObservedBusiness.model_validate(
                 {
                     "provider": "assisted-google-maps",
-                    "provider_key": _provider_key(source_url, name=name, index=index),
+                    "provider_key": _provider_key(source_url, name=name),
                     "name": name,
-                    "category": lines[1] if len(lines) > 1 else "",
+                    "category": category,
                     "locality": locality,
                     "administrative_area": administrative_area,
                     "country_code": clean_country,

--- a/tests/test_assisted_google_maps_quality.py
+++ b/tests/test_assisted_google_maps_quality.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from veridra.assisted_google_maps import (
+    _canonical_maps_identity,
+    _clean_category,
+    _external_website,
+    _provider_key,
+)
+
+
+def test_same_google_place_identity_survives_url_variants() -> None:
+    sponsored = (
+        "https://www.google.com/maps/place/Slievemore+Dental/"
+        "data=!4m7!3m6!1s0x4867091e23065b7f:0x433908020e736b82!8m2!3d53.2924936!4d-6.2010661"
+        "?authuser=0&hl=en&rclk=1"
+    )
+    organic = (
+        "https://www.google.com/maps/place/Slievemore+Dental/"
+        "data=!4m7!3m6!1s0x4867091e23065b7f:0x433908020e736b82!8m2!3d53.2924936!4d-6.2010661"
+        "?entry=ttu&g_ep=test"
+    )
+
+    assert _canonical_maps_identity(sponsored, name="Slievemore Dental") == _canonical_maps_identity(
+        organic,
+        name="Slievemore Dental",
+    )
+    assert _provider_key(sponsored, name="Slievemore Dental") == _provider_key(
+        organic,
+        name="Slievemore Dental",
+    )
+
+
+def test_google_redirect_can_reveal_real_external_website() -> None:
+    wrapped = "https://www.google.com/url?q=https%3A%2F%2Fslievemoredental.ie%2F&sa=U"
+
+    assert _external_website(wrapped) == "https://slievemoredental.ie/"
+    assert _external_website("https://www.google.ie/maps/place/example") is None
+
+
+def test_category_cleanup_rejects_non_categories() -> None:
+    assert _clean_category("Slievemore Dental", name="Slievemore Dental") == ""
+    assert _clean_category("Sponsored", name="Slievemore Dental") == ""
+    assert _clean_category("  Emergency dental service  ", name="Slievemore Dental") == (
+        "Emergency dental service"
+    )

--- a/tests/test_assisted_google_maps_quality.py
+++ b/tests/test_assisted_google_maps_quality.py
@@ -20,10 +20,9 @@ def test_same_google_place_identity_survives_url_variants() -> None:
         "?entry=ttu&g_ep=test"
     )
 
-    assert _canonical_maps_identity(sponsored, name="Slievemore Dental") == _canonical_maps_identity(
-        organic,
-        name="Slievemore Dental",
-    )
+    sponsored_identity = _canonical_maps_identity(sponsored, name="Slievemore Dental")
+    organic_identity = _canonical_maps_identity(organic, name="Slievemore Dental")
+    assert sponsored_identity == organic_identity
     assert _provider_key(sponsored, name="Slievemore Dental") == _provider_key(
         organic,
         name="Slievemore Dental",


### PR DESCRIPTION
## Purpose
Fix discovery-quality defects exposed by the first real Dublin cohort before any prospects are ingested.

## Confirmed failures
- a business can have a real website in its Google Maps detail panel while the result card exposes no website link (observed with Slievemore Dental);
- category extraction can echo the business name or `Sponsored` instead of a real category;
- sponsored and organic representations of the same Google place can survive as separate observations because raw Maps URLs differ.

## Change
- preserve fast result-card capture;
- when a card has no website, open its Google place URL in a temporary same-context tab and recover authoritative website/category metadata without replacing the results feed;
- unwrap Google redirect URLs around external websites;
- canonicalize Google place identity from the stable Maps place id/path so URL parameter variants dedupe;
- reject business-name / sponsored pseudo-categories rather than persisting misleading sector data;
- add regression tests based on the observed Dublin failure patterns.

## Boundary
No outreach, ingest, scoring, or broader enrichment changes. This is parser/data-quality hardening required before the Dublin commercial experiment continues.