### PR TITLE
Automate local discovery evidence capture

### DIFF
--- a/VERIDRA_DISCOVERY_EVIDENCE.bat
+++ b/VERIDRA_DISCOVERY_EVIDENCE.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal
+set "ROOT=%~dp0"
+set "RUNNER=%ROOT%.venv\Scripts\veridra-discovery-evidence.exe"
+if not exist "%RUNNER%" (
+  echo [Veridra] Local environment is missing or outdated. Running setup...
+  call "%ROOT%VERIDRA_SETUP.bat"
+  if errorlevel 1 exit /b %ERRORLEVEL%
+)
+"%RUNNER%" %*
+exit /b %ERRORLEVEL%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ veridra-tenant-offboard = "veridra.tenant_offboarding_cli:main"
 veridra-production-preflight = "veridra.production_preflight_cli:main"
 veridra-deployment-check = "veridra.deployment_acceptance_cli:main"
 veridra-assisted-discovery-check = "veridra.assisted_discovery_acceptance_cli:main"
+veridra-discovery-evidence = "veridra.automated_discovery_evidence_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/automated_discovery_evidence_cli.py
+++ b/src/veridra/automated_discovery_evidence_cli.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import time
+import zipfile
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .agency_prospect_discovery_evidence_web import (
+    _csv_bytes,
+    _json_bytes,
+    _safe_filename,
+    _summary_markdown,
+)
+from .agency_prospect_discovery_web import _prospect_for_ingest
+from .assisted_browser_provider import (
+    SubprocessPlaywrightDiscoveryProvider,
+    VisibleBrowserUnavailable,
+)
+from .assisted_discovery import BoundedDiscoveryLimits, TraversalResult
+from .assisted_discovery_acceptance_cli import build_start_url
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="veridra-discovery-evidence")
+    parser.add_argument("--query", default="dentist in Dublin, IE")
+    parser.add_argument("--country-code", default="IE")
+    parser.add_argument("--locality", default="Dublin")
+    parser.add_argument("--administrative-area", default="Dublin")
+    parser.add_argument("--max-results", type=int, default=20)
+    parser.add_argument("--max-scrolls", type=int, default=10)
+    parser.add_argument("--max-seconds", type=float, default=60.0)
+    parser.add_argument("--max-stagnant-scrolls", type=int, default=3)
+    parser.add_argument("--startup-wait-seconds", type=float, default=4.0)
+    parser.add_argument("--output-directory", type=Path, default=Path.home() / "Downloads")
+    return parser
+
+
+def _observations(result: TraversalResult) -> list[dict[str, object]]:
+    return [
+        {
+            "query_text": item.query_text,
+            "query_sequence": item.query_sequence,
+            "result_rank": item.result_rank,
+            "first_seen_scroll_step": item.first_seen_scroll_step,
+            "business": item.business.model_dump(mode="json"),
+        }
+        for item in result.observations
+    ]
+
+
+def _build_archive(*, result: TraversalResult, query_text: str, generated_at: str) -> bytes:
+    observations = _observations(result)
+    ingest_preview = [
+        {
+            "result_rank": item.result_rank,
+            "prospect": _prospect_for_ingest(item).model_dump(mode="json"),
+        }
+        for item in result.observations
+        if item.business.website is not None
+    ]
+    progress = result.progress
+    manifest = {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "query_text": query_text,
+        "query_sequence": progress.query_sequence,
+        "state": "review",
+        "captured_count": len(observations),
+        "website_captured_count": sum(
+            1
+            for row in observations
+            if isinstance(row["business"], dict) and row["business"].get("website")
+        ),
+        "ingest_preview_count": len(ingest_preview),
+        "progress": {
+            "scroll_step": progress.scroll_step,
+            "unique_results": progress.unique_results,
+            "stagnant_scrolls": progress.stagnant_scrolls,
+            "elapsed_seconds": progress.elapsed_seconds,
+            "stop_reason": progress.stop_reason.value if progress.stop_reason else None,
+        },
+        "persistence": "none",
+        "execution": "automated-local-backend",
+    }
+
+    archive_buffer = io.BytesIO()
+    with zipfile.ZipFile(archive_buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", _json_bytes(manifest))
+        archive.writestr("captured_observations.json", _json_bytes(observations))
+        archive.writestr("captured_businesses.csv", _csv_bytes(observations))
+        archive.writestr("ingest_preview.json", _json_bytes(ingest_preview))
+        archive.writestr(
+            "README.md",
+            _summary_markdown(
+                session_id="automated-local-backend",
+                query_text=query_text,
+                observations=observations,
+                generated_at=generated_at,
+            ).encode("utf-8"),
+        )
+    return archive_buffer.getvalue()
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.startup_wait_seconds < 0 or args.startup_wait_seconds > 60:
+        raise ValueError("startup-wait-seconds must be between 0 and 60.")
+
+    limits = BoundedDiscoveryLimits(
+        max_results=args.max_results,
+        max_scrolls=args.max_scrolls,
+        max_elapsed_seconds=args.max_seconds,
+        max_stagnant_scrolls=args.max_stagnant_scrolls,
+    )
+    provider = SubprocessPlaywrightDiscoveryProvider(
+        country_code=args.country_code,
+        locality=args.locality,
+        administrative_area=args.administrative_area,
+    )
+    query = args.query.strip()
+    if not query:
+        raise ValueError("query cannot be blank.")
+
+    print(f"[Veridra] Opening Google Maps for: {query}")
+    provider.launch(start_url=build_start_url(query))
+    try:
+        if args.startup_wait_seconds:
+            time.sleep(args.startup_wait_seconds)
+        print("[Veridra] Collecting bounded discovery evidence automatically...")
+        try:
+            result = provider.collect_bounded(
+                query_text=query,
+                query_sequence=1,
+                limits=limits,
+            )
+        except VisibleBrowserUnavailable as exc:
+            print(f"[Veridra] Collection failed: {exc}")
+            print(
+                "[Veridra] If Google requires consent, sign-in, or CAPTCHA, complete it in the "
+                "persistent browser profile and rerun this command."
+            )
+            return 2
+
+        generated_at = datetime.now(UTC).isoformat()
+        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        args.output_directory.mkdir(parents=True, exist_ok=True)
+        filename = f"VERIDRA_DISCOVERY_{_safe_filename(query)}_{stamp}.zip"
+        output_path = args.output_directory / filename
+        output_path.write_bytes(
+            _build_archive(result=result, query_text=query, generated_at=generated_at)
+        )
+        summary = {
+            "output": str(output_path),
+            "captured": len(result.observations),
+            "websites": sum(1 for item in result.observations if item.business.website is not None),
+            "stop_reason": (
+                result.progress.stop_reason.value if result.progress.stop_reason is not None else None
+            ),
+            "persistence": "none",
+        }
+        print(json.dumps(summary, indent=2, ensure_ascii=False))
+        return 0
+    finally:
+        provider.stop()
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/veridra/automated_discovery_evidence_cli.py
+++ b/src/veridra/automated_discovery_evidence_cli.py
@@ -153,13 +153,12 @@ def run(argv: Sequence[str] | None = None) -> int:
         output_path.write_bytes(
             _build_archive(result=result, query_text=query, generated_at=generated_at)
         )
+        stop_reason = result.progress.stop_reason
         summary = {
             "output": str(output_path),
             "captured": len(result.observations),
             "websites": sum(1 for item in result.observations if item.business.website is not None),
-            "stop_reason": (
-                result.progress.stop_reason.value if result.progress.stop_reason is not None else None
-            ),
+            "stop_reason": stop_reason.value if stop_reason is not None else None,
             "persistence": "none",
         }
         print(json.dumps(summary, indent=2, ensure_ascii=False))

--- a/tests/test_automated_discovery_evidence_cli.py
+++ b/tests/test_automated_discovery_evidence_cli.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import UTC, datetime
+
+from veridra.automated_discovery_evidence_cli import _build_archive
+from veridra.assisted_discovery import (
+    TraversalObservation,
+    TraversalProgress,
+    TraversalResult,
+    TraversalStopReason,
+)
+from veridra.prospect_discovery import ObservedBusiness
+
+
+def _result() -> TraversalResult:
+    business = ObservedBusiness.model_validate(
+        {
+            "provider": "assisted-google-maps",
+            "provider_key": "google-maps:test",
+            "name": "Slievemore Dental",
+            "category": "Emergency dental service",
+            "locality": "Dublin",
+            "administrative_area": "Dublin",
+            "country_code": "IE",
+            "website": "https://www.slievemoredental.ie/",
+            "source_url": "https://www.google.com/maps/place/Slievemore+Dental/",
+            "observed_at": datetime(2026, 8, 24, tzinfo=UTC),
+        }
+    )
+    return TraversalResult(
+        observations=(
+            TraversalObservation(
+                business=business,
+                query_text="dentist in Dublin, IE",
+                query_sequence=1,
+                result_rank=1,
+                first_seen_scroll_step=0,
+            ),
+        ),
+        progress=TraversalProgress(
+            query_text="dentist in Dublin, IE",
+            query_sequence=1,
+            scroll_step=0,
+            unique_results=1,
+            stagnant_scrolls=0,
+            elapsed_seconds=1.2,
+            stop_reason=TraversalStopReason.max_results,
+        ),
+    )
+
+
+def test_build_archive_contains_capture_and_ingest_preview() -> None:
+    payload = _build_archive(
+        result=_result(),
+        query_text="dentist in Dublin, IE",
+        generated_at="2026-08-24T02:00:00+00:00",
+    )
+
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        assert set(archive.namelist()) == {
+            "README.md",
+            "captured_businesses.csv",
+            "captured_observations.json",
+            "ingest_preview.json",
+            "manifest.json",
+        }
+        manifest = json.loads(archive.read("manifest.json"))
+        captured = json.loads(archive.read("captured_observations.json"))
+        preview = json.loads(archive.read("ingest_preview.json"))
+
+    assert manifest["captured_count"] == 1
+    assert manifest["website_captured_count"] == 1
+    assert manifest["persistence"] == "none"
+    assert manifest["execution"] == "automated-local-backend"
+    assert captured[0]["business"]["website"] == "https://www.slievemoredental.ie/"
+    assert preview[0]["prospect"]["website"] == "https://www.slievemoredental.ie/"

--- a/tests/test_automated_discovery_evidence_cli.py
+++ b/tests/test_automated_discovery_evidence_cli.py
@@ -5,13 +5,13 @@ import json
 import zipfile
 from datetime import UTC, datetime
 
-from veridra.automated_discovery_evidence_cli import _build_archive
 from veridra.assisted_discovery import (
     TraversalObservation,
     TraversalProgress,
     TraversalResult,
     TraversalStopReason,
 )
+from veridra.automated_discovery_evidence_cli import _build_archive
 from veridra.prospect_discovery import ObservedBusiness
 
 


### PR DESCRIPTION
## Purpose
Remove manual VERIDRA login/session navigation and manual collection from the local discovery validation workflow.

## Change
- add `veridra-discovery-evidence` CLI that invokes the same production discovery backend directly;
- add `VERIDRA_DISCOVERY_EVIDENCE.bat`, runnable from any path;
- default the command to the Dublin dental cohort;
- launch the persistent Google Maps profile, wait briefly, collect automatically, and write the evidence ZIP to Downloads;
- keep persistence at `none`;
- if Google presents consent/sign-in/CAPTCHA instead of a results feed, fail clearly without bypassing it;
- include regression coverage for the generated ZIP.

## Result
Normal validation becomes one command -> ZIP in Downloads. No local workspace login, no session ID copying, no Collect click, no manual evidence URL.