### PR TITLE
Reprocess existing Dublin batches with upgraded visual evidence

### DIFF
--- a/VERIDRA_DUBLIN_REPROCESS_VISUAL.bat
+++ b/VERIDRA_DUBLIN_REPROCESS_VISUAL.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal
+set "ROOT=%~dp0"
+set "PYTHON=%ROOT%.venv\Scripts\python.exe"
+if not exist "%PYTHON%" (
+  echo [Veridra] Local environment is missing or outdated. Running setup...
+  call "%ROOT%VERIDRA_SETUP.bat"
+  if errorlevel 1 exit /b %ERRORLEVEL%
+)
+"%PYTHON%" -m veridra.dublin_visual_reprocess_cli %*
+exit /b %ERRORLEVEL%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ veridra-prospect-audit-evidence = "veridra.prospect_audit_evidence_cli:main"
 veridra-prospect-qualification-evidence = "veridra.prospect_qualification_evidence_cli:main"
 veridra-visual-outreach-evidence = "veridra.visual_outreach_regulatory_cli:main"
 veridra-dublin-acquisition-batch = "veridra.dublin_acquisition_batch_regulatory_cli:main"
+veridra-dublin-visual-reprocess = "veridra.dublin_visual_reprocess_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/dublin_visual_reprocess_cli.py
+++ b/src/veridra/dublin_visual_reprocess_cli.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+import zipfile
+from collections.abc import Sequence
+from pathlib import Path
+
+from .visual_outreach_regulatory_cli import run as visual_run
+
+_AUDIT_MEMBER = "02-audits.zip"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="veridra-dublin-visual-reprocess")
+    parser.add_argument("--input", type=Path)
+    parser.add_argument("--downloads", type=Path, default=Path.home() / "Downloads")
+    parser.add_argument("--output-directory", type=Path, default=Path.home() / "Downloads")
+    parser.add_argument("--max-businesses", type=int, default=100)
+    parser.add_argument("--navigation-timeout-ms", type=int, default=20_000)
+    return parser
+
+
+def latest_dublin_batch(downloads: Path) -> Path:
+    values = sorted(
+        downloads.glob("VERIDRA_DUBLIN_BATCH_*.zip"),
+        key=lambda item: item.stat().st_mtime,
+        reverse=True,
+    )
+    if not values:
+        raise FileNotFoundError(f"No VERIDRA_DUBLIN_BATCH_*.zip was found in {downloads}.")
+    return values[0]
+
+
+def extract_audit_zip(batch_path: Path, output_path: Path) -> None:
+    with zipfile.ZipFile(batch_path) as archive:
+        try:
+            payload = archive.read(_AUDIT_MEMBER)
+        except KeyError as exc:
+            raise ValueError(f"Dublin batch does not contain {_AUDIT_MEMBER}.") from exc
+    output_path.write_bytes(payload)
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    batch = args.input or latest_dublin_batch(args.downloads)
+    if not batch.is_file():
+        raise FileNotFoundError(f"Dublin batch was not found: {batch}")
+    args.output_directory.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="veridra-dublin-visual-reprocess-") as temp_name:
+        audit_path = Path(temp_name) / "VERIDRA_PROSPECT_AUDITS_REPROCESS.zip"
+        extract_audit_zip(batch, audit_path)
+        code = visual_run(
+            [
+                "--input",
+                str(audit_path),
+                "--output-directory",
+                str(args.output_directory),
+                "--max-businesses",
+                str(args.max_businesses),
+                "--navigation-timeout-ms",
+                str(args.navigation_timeout_ms),
+                "--country-code",
+                "IE",
+            ]
+        )
+        if code != 0:
+            return code
+
+    outputs = sorted(
+        args.output_directory.glob("VERIDRA_VISUAL_EVIDENCE_STRICT_*.zip"),
+        key=lambda item: item.stat().st_mtime,
+        reverse=True,
+    )
+    if not outputs:
+        raise FileNotFoundError("Regenerated visual evidence ZIP was not created.")
+    print(
+        json.dumps(
+            {
+                "source_batch": str(batch),
+                "output": str(outputs[0]),
+                "country_code": "IE",
+                "rediscovery": "none",
+                "persistence": "none",
+                "outreach": "none",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dublin_visual_reprocess_cli.py
+++ b/tests/test_dublin_visual_reprocess_cli.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from veridra.dublin_visual_reprocess_cli import extract_audit_zip, latest_dublin_batch
+
+
+def test_latest_dublin_batch_prefers_newest(tmp_path: Path) -> None:
+    older = tmp_path / "VERIDRA_DUBLIN_BATCH_20260824_100000.zip"
+    newer = tmp_path / "VERIDRA_DUBLIN_BATCH_20260824_110000.zip"
+    older.write_bytes(b"old")
+    newer.write_bytes(b"new")
+    older.touch()
+    newer.touch()
+    older_mtime = older.stat().st_mtime
+    newer_mtime = newer.stat().st_mtime
+    if newer_mtime <= older_mtime:
+        import os
+
+        os.utime(newer, (older_mtime + 10, older_mtime + 10))
+    assert latest_dublin_batch(tmp_path) == newer
+
+
+def test_extract_audit_zip_reads_nested_stage(tmp_path: Path) -> None:
+    batch = tmp_path / "VERIDRA_DUBLIN_BATCH_20260824_193555.zip"
+    output = tmp_path / "audit.zip"
+    with zipfile.ZipFile(batch, "w") as archive:
+        archive.writestr("02-audits.zip", b"audit payload")
+    extract_audit_zip(batch, output)
+    assert output.read_bytes() == b"audit payload"
+
+
+def test_extract_audit_zip_requires_stage(tmp_path: Path) -> None:
+    batch = tmp_path / "VERIDRA_DUBLIN_BATCH_20260824_193555.zip"
+    with zipfile.ZipFile(batch, "w") as archive:
+        archive.writestr("batch_manifest.json", "{}")
+    with pytest.raises(ValueError, match="02-audits.zip"):
+        extract_audit_zip(batch, tmp_path / "audit.zip")


### PR DESCRIPTION
## Purpose
Regenerate visual/regulatory evidence for an already completed Dublin acquisition batch without rediscovering or re-auditing the cohort.

## Change
- add `VERIDRA_DUBLIN_REPROCESS_VISUAL.bat`, runnable from any current directory;
- auto-select the newest `VERIDRA_DUBLIN_BATCH_*.zip` from Downloads unless `--input` is supplied;
- extract the nested `02-audits.zip` automatically;
- rerun only the upgraded strict + regulatory visual evidence stage with Ireland (`IE`);
- output the regenerated `VERIDRA_VISUAL_EVIDENCE_STRICT_*.zip` to Downloads;
- no rediscovery, persistence, or outreach;
- add tests for batch selection and nested audit extraction.

This lets us regenerate Phoenix Dental's evidence with both the source Privacy Policy screenshot and the failed destination screenshot, plus cautious Ireland/GDPR regulatory context.