### PR TITLE
Retry competitive Maps collection and expose diagnostics

### DIFF
--- a/VERIDRA_DUBLIN_COMPETITIVE_CONTEXT.bat
+++ b/VERIDRA_DUBLIN_COMPETITIVE_CONTEXT.bat
@@ -7,9 +7,35 @@ if not exist "%PYTHON%" (
   call "%ROOT%VERIDRA_SETUP.bat"
   if errorlevel 1 exit /b %ERRORLEVEL%
 )
+
 echo [Veridra] Refreshing current Dublin dentist local-profile evidence...
+set "DISCOVERY_OK=0"
+
+echo [Veridra] Maps attempt 1/3...
 "%PYTHON%" -m veridra.automated_discovery_evidence_cli --query "dentist in Dublin, IE" --country-code IE --locality Dublin --administrative-area Dublin --max-results 50 --max-scrolls 25 --max-seconds 120 --startup-wait-seconds 8 --output-directory "%USERPROFILE%\Downloads"
-if errorlevel 1 exit /b %ERRORLEVEL%
+if not errorlevel 1 set "DISCOVERY_OK=1"
+
+if "%DISCOVERY_OK%"=="0" (
+  echo [Veridra] First Maps attempt failed. Waiting before retry...
+  timeout /t 5 /nobreak >nul
+  echo [Veridra] Maps attempt 2/3...
+  "%PYTHON%" -m veridra.automated_discovery_evidence_cli --query "dentist in Dublin, IE" --country-code IE --locality Dublin --administrative-area Dublin --max-results 50 --max-scrolls 25 --max-seconds 120 --startup-wait-seconds 14 --output-directory "%USERPROFILE%\Downloads"
+  if not errorlevel 1 set "DISCOVERY_OK=1"
+)
+
+if "%DISCOVERY_OK%"=="0" (
+  echo [Veridra] Second Maps attempt failed. Waiting before final retry...
+  timeout /t 8 /nobreak >nul
+  echo [Veridra] Maps attempt 3/3...
+  "%PYTHON%" -m veridra.automated_discovery_evidence_cli --query "dentist in Dublin, IE" --country-code IE --locality Dublin --administrative-area Dublin --max-results 50 --max-scrolls 25 --max-seconds 120 --startup-wait-seconds 20 --output-directory "%USERPROFILE%\Downloads"
+  if not errorlevel 1 set "DISCOVERY_OK=1"
+)
+
+if "%DISCOVERY_OK%"=="0" (
+  echo [Veridra] Maps discovery failed after 3 automated attempts.
+  exit /b 2
+)
+
 echo [Veridra] Building read-only local competitive context...
 "%PYTHON%" -m veridra.local_competitive_context_cli --downloads "%USERPROFILE%\Downloads" --output-directory "%USERPROFILE%\Downloads" --label "Dublin-Dentists"
 exit /b %ERRORLEVEL%

--- a/src/veridra/assisted_browser_runner.py
+++ b/src/veridra/assisted_browser_runner.py
@@ -105,6 +105,14 @@ def _handle_collect_bounded(page: object, payload: dict[str, object]) -> dict[st
     }
 
 
+def _safe_browser_error(exc: Exception) -> str:
+    detail = " ".join(str(exc).split())[:300]
+    error_type = type(exc).__name__
+    if detail:
+        return f"The visible browser could not collect the current results ({error_type}: {detail})."
+    return f"The visible browser could not collect the current results ({error_type})."
+
+
 def run(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
@@ -181,13 +189,13 @@ def run(argv: Sequence[str] | None = None) -> int:
                         error_message=str(exc),
                     )
                 )
-            except Exception:
+            except Exception as exc:
                 _respond(
                     ProtocolResponse(
                         request_id=request_id,
                         ok=False,
                         error_code="browser_error",
-                        error_message="The visible browser could not collect the current results.",
+                        error_message=_safe_browser_error(exc),
                     )
                 )
         context.close()

--- a/src/veridra/assisted_browser_runner.py
+++ b/src/veridra/assisted_browser_runner.py
@@ -109,7 +109,10 @@ def _safe_browser_error(exc: Exception) -> str:
     detail = " ".join(str(exc).split())[:300]
     error_type = type(exc).__name__
     if detail:
-        return f"The visible browser could not collect the current results ({error_type}: {detail})."
+        return (
+            "The visible browser could not collect the current results "
+            f"({error_type}: {detail})."
+        )
     return f"The visible browser could not collect the current results ({error_type})."
 
 


### PR DESCRIPTION
## Why
The first live Dublin Local Competitive Context run failed with only a generic visible-browser error, making the failure impossible to diagnose from the console.

## Changes
- retry the Dublin competitive Maps discovery automatically up to three times with increasing startup waits;
- keep the launcher runnable from any path;
- surface a bounded exception type/message from the local browser runner when an unexpected browser error occurs instead of replacing it with a generic message;
- no persistence or outreach changes.

This is aimed specifically at reducing manual reruns and making the next failure actionable if Google Maps is genuinely blocking collection.