### PR TITLE
Make review statistics sampling-strategy safe

### DIFF
--- a/VERIDRA_REVIEW_INTELLIGENCE.bat
+++ b/VERIDRA_REVIEW_INTELLIGENCE.bat
@@ -8,6 +8,6 @@ if not exist "%PYTHON%" (
   if errorlevel 1 exit /b %ERRORLEVEL%
 )
 
-echo [Veridra] Building hardened bounded read-only review intelligence...
-"%PYTHON%" -m veridra.review_intelligence_hardened_cli --downloads "%USERPROFILE%\Downloads" --output-directory "%USERPROFILE%\Downloads" %*
+echo [Veridra] Building sampling-safe bounded read-only review intelligence...
+"%PYTHON%" -m veridra.review_intelligence_sampling_safe_cli --downloads "%USERPROFILE%\Downloads" --output-directory "%USERPROFILE%\Downloads" %*
 exit /b %ERRORLEVEL%

--- a/docs/issue-232-validation.md
+++ b/docs/issue-232-validation.md
@@ -1,0 +1,7 @@
+# Issue #232 validation basis
+
+The second Dublin live run, `VERIDRA_REVIEW_INTELLIGENCE_20260826_123018.zip`, captured 472 deduplicated review evidence items across 10 businesses with working newest, lowest-rating and highest-rating sorting.
+
+The collector is considered live-selector validated. The remaining issue is statistical interpretation: merged stratified samples must not be presented as representative of the full review population.
+
+This change therefore reuses the already-captured evidence and changes only how future deterministic statistics are scoped. No additional Google Maps rerun is required for this semantic hardening.

--- a/docs/review-intelligence-sampling-safety.md
+++ b/docs/review-intelligence-sampling-safety.md
@@ -1,0 +1,14 @@
+# Review Intelligence sampling safety
+
+VERIDRA deliberately captures stratified Google review evidence using newest, lowest-rating and highest-rating samples. The merged review rows are useful for evidence inspection and AI theme analysis, but they are not a random or complete sample of a business's review population.
+
+The safe statistics contract is therefore:
+
+- recency counts are calculated only from rows captured after explicitly selecting `newest`;
+- owner-response rate associated with recency is scoped to the `newest` sample;
+- negative-review response rate is calculated only from negative rows in the `lowest` sample;
+- highest-rating rows are retained for positive-theme evidence only;
+- review velocity, overall owner-response rate and overall rating distribution are suppressed because the stratified sample cannot support population-level claims;
+- if the newest sort was unavailable and the visible default ordering was used, newest/recency statistics are unavailable rather than inferred.
+
+Raw review evidence remains read-only. This layer performs no persistence, outreach, sentiment classification or AI interpretation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ veridra-dublin-acquisition-batch = "veridra.dublin_acquisition_batch_regulatory_
 veridra-dublin-visual-reprocess = "veridra.dublin_visual_reprocess_cli:main"
 veridra-local-competitive-context = "veridra.local_competitive_context_cli:main"
 veridra-ai-evidence-exchange = "veridra.ai_evidence_exchange_cli:main"
-veridra-review-intelligence = "veridra.review_intelligence_hardened_cli:main"
+veridra-review-intelligence = "veridra.review_intelligence_sampling_safe_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ disable_error_code = ["attr-defined", "assignment"]
 module = "veridra.review_intelligence_hardened_cli"
 disable_error_code = ["call-overload", "assignment"]
 
+[[tool.mypy.overrides]]
+module = "veridra.review_intelligence_sampling_safe_cli"
+disable_error_code = ["attr-defined"]
+
 [tool.ruff.lint.per-file-ignores]
 "src/veridra/app.py" = ["E501"]
 "src/veridra/core.py" = ["E501"]

--- a/src/veridra/review_intelligence_sampling_safe_cli.py
+++ b/src/veridra/review_intelligence_sampling_safe_cli.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from datetime import UTC, datetime
-from typing import cast
+from datetime import UTC, datetime, timedelta
 
 from . import review_intelligence_hardened_cli as hardened
 from .review_intelligence_cli import _text
@@ -29,9 +28,12 @@ def _parsed_dates(rows: list[dict[str, object]]) -> list[datetime]:
         if not raw:
             continue
         try:
-            values.append(datetime.fromisoformat(raw).replace(tzinfo=UTC))
+            parsed = datetime.fromisoformat(raw)
         except ValueError:
             continue
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        values.append(parsed.astimezone(UTC))
     return values
 
 
@@ -42,6 +44,15 @@ def _response_rate(rows: list[dict[str, object]]) -> float | None:
     return round(responses / len(rows), 3)
 
 
+def _negative_rows(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    output: list[dict[str, object]] = []
+    for row in rows:
+        rating = row.get("rating")
+        if isinstance(rating, int) and rating <= 3:
+            output.append(row)
+    return output
+
+
 def strategy_safe_statistics(
     reviews: list[dict[str, object]], *, now: datetime
 ) -> dict[str, object]:
@@ -49,57 +60,50 @@ def strategy_safe_statistics(
     lowest = _strategy_rows(reviews, "lowest")
     highest = _strategy_rows(reviews, "highest")
     newest_dates = _parsed_dates(newest)
+    negative_lowest = _negative_rows(lowest)
 
-    def recent_count(days: int) -> int:
-        cutoff = now - hardened.timedelta(days=days)
+    def recent_count(days: int) -> int | None:
+        if not newest:
+            return None
+        cutoff = now.astimezone(UTC) - timedelta(days=days)
         return sum(1 for value in newest_dates if value >= cutoff)
-
-    negative_lowest = [
-        row
-        for row in lowest
-        if isinstance(row.get("rating"), int) and cast(int, row["rating"]) <= 3
-    ]
-
-    oldest_newest = min(newest_dates).date().isoformat() if newest_dates else None
-    newest_limit_reached = len(newest) >= hardened._DEFAULT_PER_STRATEGY
 
     return {
         "merged_evidence_items": len(reviews),
         "newest_sample": {
+            "available": bool(newest),
             "sample_size": len(newest),
             "dated_sample_size": len(newest_dates),
             "sampled_reviews_within_30_days": recent_count(30),
             "sampled_reviews_within_90_days": recent_count(90),
             "sampled_reviews_within_365_days": recent_count(365),
-            "oldest_sampled_review_date": oldest_newest,
+            "oldest_sampled_review_date": (
+                min(newest_dates).date().isoformat() if newest_dates else None
+            ),
             "owner_response_rate_sample": _response_rate(newest),
             "scope_note": (
-                "These values describe only the reviews captured after explicitly selecting Newest. "
-                "Recent counts are sample counts, not total review-history counts. If the strategy "
-                "limit was reached, they are lower bounds for the corresponding period whenever all "
-                "sampled reviews fall inside that period."
+                "These values describe only reviews captured after explicitly selecting Newest. "
+                "Recent counts are bounded sample counts, not totals for the business's complete "
+                "review history. Review velocity is intentionally not inferred from this sample."
             ),
         },
         "lowest_sample": {
+            "available": bool(lowest),
             "sample_size": len(lowest),
             "negative_review_count_sample": len(negative_lowest),
             "negative_review_response_rate_sample": _response_rate(negative_lowest),
             "scope_note": (
-                "Negative-response behavior is measured only inside the explicitly selected Lowest "
-                "rating sample and must not be presented as an overall business response rate."
+                "Negative-review response behavior is measured only inside the explicitly selected "
+                "Lowest rating sample and must not be presented as an overall response rate."
             ),
         },
         "highest_sample": {
+            "available": bool(highest),
             "sample_size": len(highest),
             "scope_note": (
-                "Highest-rating reviews are preserved for positive-theme analysis; no population-level "
+                "Highest-rating reviews are retained for positive-theme evidence. No population-level "
                 "rating distribution is inferred from this intentionally biased sample."
             ),
-        },
-        "strategy_limit_reached": {
-            "newest": newest_limit_reached,
-            "lowest": len(lowest) >= hardened._DEFAULT_PER_STRATEGY,
-            "highest": len(highest) >= hardened._DEFAULT_PER_STRATEGY,
         },
         "population_metrics_suppressed": [
             "review_velocity",
@@ -107,9 +111,10 @@ def strategy_safe_statistics(
             "overall_rating_distribution",
         ],
         "scope_note": (
-            "VERIDRA uses a deliberately stratified newest/lowest/highest evidence sample. Merged "
-            "review rows are suitable for evidence inspection and AI theme analysis, but are not a "
-            "random or complete sample of the business's review population."
+            "VERIDRA deliberately combines newest, lowest-rating and highest-rating review evidence. "
+            "The merged rows are useful for inspection and AI theme analysis but are not a random or "
+            "complete sample of the business's review population. Every statistic is therefore scoped "
+            "to the sampling strategy that supports it."
         ),
     }
 

--- a/src/veridra/review_intelligence_sampling_safe_cli.py
+++ b/src/veridra/review_intelligence_sampling_safe_cli.py
@@ -101,8 +101,9 @@ def strategy_safe_statistics(
             "available": bool(highest),
             "sample_size": len(highest),
             "scope_note": (
-                "Highest-rating reviews are retained for positive-theme evidence. No population-level "
-                "rating distribution is inferred from this intentionally biased sample."
+                "Highest-rating reviews are retained for positive-theme evidence. "
+                "No population-level rating distribution is inferred from this intentionally "
+                "biased sample."
             ),
         },
         "population_metrics_suppressed": [
@@ -111,10 +112,10 @@ def strategy_safe_statistics(
             "overall_rating_distribution",
         ],
         "scope_note": (
-            "VERIDRA deliberately combines newest, lowest-rating and highest-rating review evidence. "
-            "The merged rows are useful for inspection and AI theme analysis but are not a random or "
-            "complete sample of the business's review population. Every statistic is therefore scoped "
-            "to the sampling strategy that supports it."
+            "VERIDRA deliberately combines newest, lowest-rating and highest-rating review "
+            "evidence. The merged rows are useful for inspection and AI theme analysis but are "
+            "not a random or complete sample of the business's review population. Every statistic "
+            "is therefore scoped to the sampling strategy that supports it."
         ),
     }
 

--- a/src/veridra/review_intelligence_sampling_safe_cli.py
+++ b/src/veridra/review_intelligence_sampling_safe_cli.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import cast
+
+from . import review_intelligence_hardened_cli as hardened
+from .review_intelligence_cli import _text
+
+
+def _strategy_rows(
+    reviews: list[dict[str, object]], strategy: str
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for review in reviews:
+        strategies = review.get("sample_strategies")
+        if isinstance(strategies, list) and strategy in strategies:
+            rows.append(review)
+            continue
+        if _text(review.get("sample_strategy")) == strategy:
+            rows.append(review)
+    return rows
+
+
+def _parsed_dates(rows: list[dict[str, object]]) -> list[datetime]:
+    values: list[datetime] = []
+    for row in rows:
+        raw = _text(row.get("approximate_review_date"))
+        if not raw:
+            continue
+        try:
+            values.append(datetime.fromisoformat(raw).replace(tzinfo=UTC))
+        except ValueError:
+            continue
+    return values
+
+
+def _response_rate(rows: list[dict[str, object]]) -> float | None:
+    if not rows:
+        return None
+    responses = sum(1 for row in rows if row.get("owner_response_present") is True)
+    return round(responses / len(rows), 3)
+
+
+def strategy_safe_statistics(
+    reviews: list[dict[str, object]], *, now: datetime
+) -> dict[str, object]:
+    newest = _strategy_rows(reviews, "newest")
+    lowest = _strategy_rows(reviews, "lowest")
+    highest = _strategy_rows(reviews, "highest")
+    newest_dates = _parsed_dates(newest)
+
+    def recent_count(days: int) -> int:
+        cutoff = now - hardened.timedelta(days=days)
+        return sum(1 for value in newest_dates if value >= cutoff)
+
+    negative_lowest = [
+        row
+        for row in lowest
+        if isinstance(row.get("rating"), int) and cast(int, row["rating"]) <= 3
+    ]
+
+    oldest_newest = min(newest_dates).date().isoformat() if newest_dates else None
+    newest_limit_reached = len(newest) >= hardened._DEFAULT_PER_STRATEGY
+
+    return {
+        "merged_evidence_items": len(reviews),
+        "newest_sample": {
+            "sample_size": len(newest),
+            "dated_sample_size": len(newest_dates),
+            "sampled_reviews_within_30_days": recent_count(30),
+            "sampled_reviews_within_90_days": recent_count(90),
+            "sampled_reviews_within_365_days": recent_count(365),
+            "oldest_sampled_review_date": oldest_newest,
+            "owner_response_rate_sample": _response_rate(newest),
+            "scope_note": (
+                "These values describe only the reviews captured after explicitly selecting Newest. "
+                "Recent counts are sample counts, not total review-history counts. If the strategy "
+                "limit was reached, they are lower bounds for the corresponding period whenever all "
+                "sampled reviews fall inside that period."
+            ),
+        },
+        "lowest_sample": {
+            "sample_size": len(lowest),
+            "negative_review_count_sample": len(negative_lowest),
+            "negative_review_response_rate_sample": _response_rate(negative_lowest),
+            "scope_note": (
+                "Negative-response behavior is measured only inside the explicitly selected Lowest "
+                "rating sample and must not be presented as an overall business response rate."
+            ),
+        },
+        "highest_sample": {
+            "sample_size": len(highest),
+            "scope_note": (
+                "Highest-rating reviews are preserved for positive-theme analysis; no population-level "
+                "rating distribution is inferred from this intentionally biased sample."
+            ),
+        },
+        "strategy_limit_reached": {
+            "newest": newest_limit_reached,
+            "lowest": len(lowest) >= hardened._DEFAULT_PER_STRATEGY,
+            "highest": len(highest) >= hardened._DEFAULT_PER_STRATEGY,
+        },
+        "population_metrics_suppressed": [
+            "review_velocity",
+            "overall_owner_response_rate",
+            "overall_rating_distribution",
+        ],
+        "scope_note": (
+            "VERIDRA uses a deliberately stratified newest/lowest/highest evidence sample. Merged "
+            "review rows are suitable for evidence inspection and AI theme analysis, but are not a "
+            "random or complete sample of the business's review population."
+        ),
+    }
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    hardened._statistics = strategy_safe_statistics
+    return hardened.run(argv)
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_review_intelligence_sampling_safe_cli.py
+++ b/tests/test_review_intelligence_sampling_safe_cli.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from veridra.review_intelligence_sampling_safe_cli import strategy_safe_statistics
+
+
+def _review(
+    evidence_id: str,
+    *,
+    strategy: str,
+    rating: int,
+    date: str,
+    responded: bool,
+    extra_strategies: list[str] | None = None,
+) -> dict[str, object]:
+    strategies = [strategy]
+    if extra_strategies:
+        strategies.extend(extra_strategies)
+    return {
+        "evidence_id": evidence_id,
+        "sample_strategy": strategy,
+        "sample_strategies": strategies,
+        "rating": rating,
+        "approximate_review_date": date,
+        "owner_response_present": responded,
+    }
+
+
+def test_statistics_keep_recency_scoped_to_newest_sample() -> None:
+    reviews = [
+        _review("new-1", strategy="newest", rating=5, date="2026-08-20", responded=True),
+        _review("new-2", strategy="newest", rating=4, date="2026-07-20", responded=False),
+        _review("low-old", strategy="lowest", rating=1, date="2024-01-01", responded=True),
+        _review("high-old", strategy="highest", rating=5, date="2023-01-01", responded=False),
+    ]
+
+    stats = strategy_safe_statistics(
+        reviews,
+        now=datetime(2026, 8, 27, 9, 0, tzinfo=UTC),
+    )
+
+    newest = stats["newest_sample"]
+    assert isinstance(newest, dict)
+    assert newest["sample_size"] == 2
+    assert newest["sampled_reviews_within_30_days"] == 1
+    assert newest["sampled_reviews_within_90_days"] == 2
+    assert newest["sampled_reviews_within_365_days"] == 2
+    assert newest["owner_response_rate_sample"] == 0.5
+    assert "sampled_review_velocity_per_month_365d" not in stats
+
+
+def test_negative_response_rate_uses_only_lowest_negative_sample() -> None:
+    reviews = [
+        _review("low-1", strategy="lowest", rating=1, date="2026-01-01", responded=True),
+        _review("low-2", strategy="lowest", rating=2, date="2026-01-02", responded=False),
+        _review("low-5", strategy="lowest", rating=5, date="2026-01-03", responded=True),
+        _review("new-1", strategy="newest", rating=1, date="2026-08-20", responded=False),
+    ]
+
+    stats = strategy_safe_statistics(
+        reviews,
+        now=datetime(2026, 8, 27, 9, 0, tzinfo=UTC),
+    )
+
+    lowest = stats["lowest_sample"]
+    assert isinstance(lowest, dict)
+    assert lowest["sample_size"] == 3
+    assert lowest["negative_review_count_sample"] == 2
+    assert lowest["negative_review_response_rate_sample"] == 0.5
+
+
+def test_merged_stratified_sample_suppresses_population_metrics() -> None:
+    reviews = [
+        _review("new", strategy="newest", rating=4, date="2026-08-20", responded=True),
+        _review("low", strategy="lowest", rating=1, date="2025-01-01", responded=False),
+        _review("high", strategy="highest", rating=5, date="2024-01-01", responded=True),
+    ]
+
+    stats = strategy_safe_statistics(
+        reviews,
+        now=datetime(2026, 8, 27, 9, 0, tzinfo=UTC),
+    )
+
+    assert stats["merged_evidence_items"] == 3
+    assert stats["population_metrics_suppressed"] == [
+        "review_velocity",
+        "overall_owner_response_rate",
+        "overall_rating_distribution",
+    ]
+    assert "rating_distribution_sample" not in stats
+    assert "owner_response_rate_sample" not in stats
+
+
+def test_review_seen_in_multiple_strategies_contributes_to_each_strategy_scope() -> None:
+    reviews = [
+        _review(
+            "shared",
+            strategy="newest",
+            rating=1,
+            date="2026-08-20",
+            responded=True,
+            extra_strategies=["lowest"],
+        )
+    ]
+
+    stats = strategy_safe_statistics(
+        reviews,
+        now=datetime(2026, 8, 27, 9, 0, tzinfo=UTC),
+    )
+
+    newest = stats["newest_sample"]
+    lowest = stats["lowest_sample"]
+    assert isinstance(newest, dict)
+    assert isinstance(lowest, dict)
+    assert newest["sample_size"] == 1
+    assert lowest["sample_size"] == 1
+    assert lowest["negative_review_response_rate_sample"] == 1.0
+
+
+def test_recency_is_unavailable_when_newest_sort_was_not_captured() -> None:
+    reviews = [
+        _review("visible", strategy="visible-default", rating=5, date="2026-08-20", responded=False),
+        _review("low", strategy="lowest", rating=1, date="2026-01-01", responded=False),
+    ]
+
+    stats = strategy_safe_statistics(
+        reviews,
+        now=datetime(2026, 8, 27, 9, 0, tzinfo=UTC),
+    )
+
+    newest = stats["newest_sample"]
+    assert isinstance(newest, dict)
+    assert newest["available"] is False
+    assert newest["sample_size"] == 0
+    assert newest["sampled_reviews_within_30_days"] is None
+    assert newest["sampled_reviews_within_365_days"] is None

--- a/tests/test_review_intelligence_sampling_safe_cli.py
+++ b/tests/test_review_intelligence_sampling_safe_cli.py
@@ -120,7 +120,13 @@ def test_review_seen_in_multiple_strategies_contributes_to_each_strategy_scope()
 
 def test_recency_is_unavailable_when_newest_sort_was_not_captured() -> None:
     reviews = [
-        _review("visible", strategy="visible-default", rating=5, date="2026-08-20", responded=False),
+        _review(
+            "visible",
+            strategy="visible-default",
+            rating=5,
+            date="2026-08-20",
+            responded=False,
+        ),
         _review("low", strategy="lowest", rating=1, date="2026-01-01", responded=False),
     ]
 


### PR DESCRIPTION
Closes #232.

Changes:
- route Review Intelligence through a sampling-safe statistics layer;
- compute recency counts and sample response rate only from explicitly `newest` review evidence;
- compute negative-review response rate only from negative rows in the `lowest` sample;
- preserve `highest` rows for positive-theme evidence without inferring a population rating distribution;
- suppress review velocity, overall owner-response rate and overall rating distribution because the merged newest/lowest/highest sample is intentionally biased;
- mark recency unavailable if `newest` sorting was not actually captured;
- keep merged deduplicated review evidence unchanged for future AI theme analysis;
- add regression tests for biased stratified samples and multi-strategy dedupe;
- no persistence, outreach or AI interpretation changes.

The already validated live Dublin ZIP remains usable as raw evidence; no new Google Maps scrape is required for this semantic hardening.