### PR TITLE
Prioritize digital-presence opportunity during discovery

### DIFF
--- a/VERIDRA_GBP_EVIDENCE.bat
+++ b/VERIDRA_GBP_EVIDENCE.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+echo [Veridra] Collecting bounded public Google Business Profile evidence...
+python -m veridra.gbp_profile_evidence_cli --downloads "%USERPROFILE%\Downloads" --output-directory "%USERPROFILE%\Downloads"
+set EXITCODE=%ERRORLEVEL%
+if not "%EXITCODE%"=="0" (
+  echo [Veridra] GBP evidence collection failed with exit code %EXITCODE%.
+)
+exit /b %EXITCODE%

--- a/scripts/browser/discovery_workflow_acceptance.py
+++ b/scripts/browser/discovery_workflow_acceptance.py
@@ -62,7 +62,7 @@ class _FixtureProvider:
         now = datetime(2026, 8, 23, 16, 0, tzinfo=UTC)
         records = (
             ("Acceptance Dental One", "Dentist", "https://acceptance-one.example/"),
-            ("Acceptance Dental Two", "Acceptance Dental Two", "https://acceptance-two.example/"),
+            ("Acceptance Dental Two", "Dentist", None),
             ("Sponsored Acceptance", "Sponsored", None),
         )
         observations: list[TraversalObservation] = []
@@ -273,11 +273,11 @@ def main() -> int:
                 report["steps"].append("discovery_session_started")
 
                 page.get_by_role("button", name="Collect visible results").click()
-                _assert_text(page, "Review discovered businesses")
+                _assert_text(page, "Review digital-presence opportunities")
                 _assert_text(page, "Acceptance Dental One")
                 _assert_text(page, "Acceptance Dental Two")
                 _assert_text(page, "Sponsored Acceptance")
-                _assert_text(page, "No website")
+                _assert_text(page, "No website observed")
                 _shot(page, evidence, "05-review")
                 report["steps"].append("bounded_results_presented_for_review")
 
@@ -285,11 +285,11 @@ def main() -> int:
                 count = checkboxes.count()
                 if count != 2:
                     raise AssertionError(
-                        f"Expected exactly two selectable website prospects, got {count}."
+                        f"Expected website and no-website opportunities to be selectable, got {count}."
                     )
                 checkboxes.nth(0).check()
                 checkboxes.nth(1).check()
-                page.get_by_role("button", name="Ingest selected prospects").click()
+                page.get_by_role("button", name="Ingest selected opportunities").click()
                 _assert_text(page, "Selected prospects ingested")
                 _shot(page, evidence, "06-ingest-complete")
                 report["steps"].append("explicit_selection_safely_ingested")
@@ -299,9 +299,7 @@ def main() -> int:
                 _assert_text(page, "Acceptance Dental One")
                 _assert_text(page, "Acceptance Dental Two")
                 if page.get_by_text("Sponsored Acceptance", exact=False).count() != 0:
-                    raise AssertionError(
-                        "No-website sponsored observation was incorrectly ingested."
-                    )
+                    raise AssertionError("Sponsored observation was incorrectly ingested.")
                 _shot(page, evidence, "07-ingested-workbench")
                 report["steps"].append("ingested_prospects_verified_in_workbench")
 

--- a/scripts/browser/discovery_workflow_acceptance.py
+++ b/scripts/browser/discovery_workflow_acceptance.py
@@ -285,7 +285,8 @@ def main() -> int:
                 count = checkboxes.count()
                 if count != 2:
                     raise AssertionError(
-                        f"Expected website and no-website opportunities to be selectable, got {count}."
+                        "Expected website and no-website opportunities "
+                        f"to be selectable, got {count}."
                     )
                 checkboxes.nth(0).check()
                 checkboxes.nth(1).check()

--- a/src/veridra/agency_prospect_discovery_web.py
+++ b/src/veridra/agency_prospect_discovery_web.py
@@ -243,6 +243,8 @@ def _review_table(observations: tuple[TraversalObservation, ...]) -> str:
         reason_html = "".join(
             f"<span>{html.escape(reason)}</span>" for reason in opportunity.reasons[:3]
         )
+        if not reason_html:
+            reason_html = "<span class='muted'>No observed digital gap from discovery signals.</span>"
         rows.append(
             "<tr>"
             f"<td>{checkbox}</td>"
@@ -251,7 +253,7 @@ def _review_table(observations: tuple[TraversalObservation, ...]) -> str:
             f"<td><span class='badge'>{html.escape(opportunity.band.value.upper())} {opportunity.score}/100</span><br><span class='muted'>gap {opportunity.digital_gap_score} · activity {opportunity.business_activity_score}</span></td>"
             f"<td>{html.escape(website)}</td>"
             f"<td>{rating}</td><td>{reviews}</td><td>{photos}</td>"
-            f"<td class='reason'>{reason_html or '<span class=\"muted\">No observed digital gap from discovery signals.</span>'}</td>"
+            f"<td class='reason'>{reason_html}</td>"
             f"<td>{source_link}</td>"
             "</tr>"
         )

--- a/src/veridra/agency_prospect_discovery_web.py
+++ b/src/veridra/agency_prospect_discovery_web.py
@@ -27,13 +27,14 @@ from .identity_tenancy import (
 )
 from .prospect_discovery import prospect_from_observation
 from .prospect_ingest import DiscoveryIngestAction, TenantProspectDiscoveryIngestor
+from .prospect_opportunity import assess_opportunity
 from .request_security import require_request_identity
 from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
 
 router = APIRouter(prefix="/agency/prospects/discover", tags=["agency-prospect-discovery"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1100px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.warning{border-left-color:#b7791f;background:#fff8e6}.actions{display:flex;gap:8px;flex-wrap:wrap}label{display:block;font-weight:700;margin:12px 0 5px}input{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.row{display:grid;grid-template-columns:2fr 1fr;gap:14px}.row.three{grid-template-columns:1fr 1fr 1fr}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}th{font-size:12px;color:#5d6670}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}.check{width:auto}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}@media(max-width:760px){.row,.row.three{grid-template-columns:1fr}table{display:block;overflow:auto}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1250px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.warning{border-left-color:#b7791f;background:#fff8e6}.actions{display:flex;gap:8px;flex-wrap:wrap}label{display:block;font-weight:700;margin:12px 0 5px}input{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}.row{display:grid;grid-template-columns:2fr 1fr;gap:14px}.row.three{grid-template-columns:1fr 1fr 1fr}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}th{font-size:12px;color:#5d6670}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}.check{width:auto}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}.priority{font-weight:700}.reason{max-width:330px}.reason span{display:block;margin-bottom:4px}@media(max-width:760px){.row,.row.three{grid-template-columns:1fr}table{display:block;overflow:auto}}
 """
 
 
@@ -175,27 +176,56 @@ def _clean_sector(observation: TraversalObservation) -> str:
     return category
 
 
+def _is_sponsored(observation: TraversalObservation) -> bool:
+    return observation.business.category.strip().casefold() in {
+        "sponsored",
+        "ad",
+        "advertisement",
+    }
+
+
 def _prospect_for_ingest(observation: TraversalObservation):  # type: ignore[no-untyped-def]
     business = observation.business.model_copy(update={"category": _clean_sector(observation)})
     prospect = prospect_from_observation(business)
+    opportunity = assess_opportunity(business)
+    rating = f"{business.rating:g}" if business.rating is not None else "unknown"
+    reviews = str(business.review_count) if business.review_count is not None else "unknown"
+    photos = (
+        str(business.profile_photo_signal_count)
+        if business.profile_photo_signal_count is not None
+        else "unknown"
+    )
+    reasons = " ".join(opportunity.reasons)
     evidence = (
         f"{prospect.evidence_summary}\nGoogle Maps discovery query: {observation.query_text}. "
-        f"Result rank: {observation.result_rank}."
+        f"Result rank: {observation.result_rank}. Rating: {rating}. Reviews: {reviews}. "
+        f"Photo signal: {photos}. Digital-presence opportunity: {opportunity.band.value} "
+        f"({opportunity.score}/100; gap {opportunity.digital_gap_score}, activity "
+        f"{opportunity.business_activity_score}). {reasons}"
     )
     return prospect.model_copy(update={"evidence_summary": evidence[-4000:]})
 
 
 def _review_table(observations: tuple[TraversalObservation, ...]) -> str:
     rows: list[str] = []
-    for item in observations:
+    ranked = sorted(
+        observations,
+        key=lambda item: (
+            assess_opportunity(item.business).score,
+            item.business.review_count or 0,
+            -item.result_rank,
+        ),
+        reverse=True,
+    )
+    for item in ranked:
         business = item.business
-        website = str(business.website) if business.website is not None else "—"
+        opportunity = assess_opportunity(business)
+        website = str(business.website) if business.website is not None else "No website observed"
         source = str(business.source_url) if business.source_url is not None else ""
-        selectable = business.website is not None
         checkbox = (
-            f"<input class='check' type='checkbox' name='selected_rank' value='{item.result_rank}'>"
-            if selectable
-            else "<span class='muted'>No website</span>"
+            "<span class='muted'>Sponsored</span>"
+            if _is_sponsored(item)
+            else f"<input class='check' type='checkbox' name='selected_rank' value='{item.result_rank}'>"
         )
         sector = _clean_sector(item) or "Unclassified"
         source_link = (
@@ -203,23 +233,36 @@ def _review_table(observations: tuple[TraversalObservation, ...]) -> str:
             if source
             else "—"
         )
+        rating = f"{business.rating:g}" if business.rating is not None else "—"
+        reviews = str(business.review_count) if business.review_count is not None else "—"
+        photos = (
+            str(business.profile_photo_signal_count)
+            if business.profile_photo_signal_count is not None
+            else "—"
+        )
+        reason_html = "".join(
+            f"<span>{html.escape(reason)}</span>" for reason in opportunity.reasons[:3]
+        )
         rows.append(
             "<tr>"
             f"<td>{checkbox}</td>"
             f"<td>{item.result_rank}</td>"
             f"<td><strong>{html.escape(business.name)}</strong><br><span class='muted'>{html.escape(sector)}</span></td>"
+            f"<td><span class='badge'>{html.escape(opportunity.band.value.upper())} {opportunity.score}/100</span><br><span class='muted'>gap {opportunity.digital_gap_score} · activity {opportunity.business_activity_score}</span></td>"
             f"<td>{html.escape(website)}</td>"
+            f"<td>{rating}</td><td>{reviews}</td><td>{photos}</td>"
+            f"<td class='reason'>{reason_html or '<span class=\"muted\">No observed digital gap from discovery signals.</span>'}</td>"
             f"<td>{source_link}</td>"
             "</tr>"
         )
-    return "<table><thead><tr><th>Keep</th><th>Rank</th><th>Business</th><th>Website</th><th>Source</th></tr></thead><tbody>" + "".join(rows) + "</tbody></table>"
+    return "<table><thead><tr><th>Keep</th><th>Maps rank</th><th>Business</th><th>Opportunity</th><th>Website</th><th>Rating</th><th>Reviews</th><th>Photo signal</th><th>Why</th><th>Source</th></tr></thead><tbody>" + "".join(rows) + "</tbody></table>"
 
 
 @router.get("", response_class=HTMLResponse)
 def discovery_page(request: Request) -> str:
     identity = _identity(request)
     navigation = agency_navigation(identity, current="prospect-discovery")
-    body = f"{navigation}<section><p><a href='/agency/prospects'>← Prospects</a></p><h1>Discover prospects</h1><p class='muted'>Open a bounded Google Maps search in visible Chromium. Nothing is saved until you review the captured businesses and explicitly select them.</p><form method='post' action='/agency/prospects/discover/start'><div class='row'><div><label for='query'>Search query</label><input id='query' name='query' maxlength='240' value='dentist in Vigo, ES' required></div><div><label for='country_code'>Country code</label><input id='country_code' name='country_code' maxlength='2' value='ES' required></div></div><div class='row'><div><label for='locality'>Locality</label><input id='locality' name='locality' maxlength='120' value='Vigo'></div><div><label for='administrative_area'>Administrative area</label><input id='administrative_area' name='administrative_area' maxlength='120' value='Pontevedra'></div></div><div class='row three'><div><label for='max_results'>Maximum results</label><input id='max_results' name='max_results' type='number' min='1' max='200' value='20'></div><div><label for='max_scrolls'>Maximum scrolls</label><input id='max_scrolls' name='max_scrolls' type='number' min='0' max='100' value='10'></div><div><label for='max_seconds'>Maximum seconds</label><input id='max_seconds' name='max_seconds' type='number' min='1' max='300' value='45'></div></div><button type='submit'>Open discovery browser</button></form></section>"
+    body = f"{navigation}<section><p><a href='/agency/prospects'>← Prospects</a></p><h1>Discover prospects</h1><p class='muted'>Open a bounded Google Maps search in visible Chromium. VERIDRA will surface observed digital-presence gaps and customer-activity signals; nothing is saved until you review and explicitly select a business.</p><form method='post' action='/agency/prospects/discover/start'><div class='row'><div><label for='query'>Search query</label><input id='query' name='query' maxlength='240' value='dentist in Vigo, ES' required></div><div><label for='country_code'>Country code</label><input id='country_code' name='country_code' maxlength='2' value='ES' required></div></div><div class='row'><div><label for='locality'>Locality</label><input id='locality' name='locality' maxlength='120' value='Vigo'></div><div><label for='administrative_area'>Administrative area</label><input id='administrative_area' name='administrative_area' maxlength='120' value='Pontevedra'></div></div><div class='row three'><div><label for='max_results'>Maximum results</label><input id='max_results' name='max_results' type='number' min='1' max='200' value='20'></div><div><label for='max_scrolls'>Maximum scrolls</label><input id='max_scrolls' name='max_scrolls' type='number' min='0' max='100' value='10'></div><div><label for='max_seconds'>Maximum seconds</label><input id='max_seconds' name='max_seconds' type='number' min='1' max='300' value='45'></div></div><button type='submit'>Open discovery browser</button></form></section>"
     return _page("Discover prospects", body)
 
 
@@ -278,9 +321,14 @@ def discovery_collect(session_id: str, request: Request) -> HTMLResponse:
             status_code=400,
         )
     navigation = agency_navigation(identity, current="prospect-discovery")
-    selectable = sum(1 for item in batch.observations if item.business.website is not None)
-    body = f"{navigation}<section><h1>Review discovered businesses</h1><p><strong>{len(batch.observations)}</strong> captured · <strong>{selectable}</strong> currently have a website and can be selected for the Webify prospect workbench.</p><p class='notice warning'>Nothing has been saved yet. Sponsored/no-website rows remain visible as evidence but cannot be ingested for website auditing.</p><form method='post' action='/agency/prospects/discover/{html.escape(session_id, quote=True)}/ingest'>{_review_table(batch.observations)}<p><button type='submit'>Ingest selected prospects</button></p></form><form method='post' action='/agency/prospects/discover/{html.escape(session_id, quote=True)}/cancel'><button class='secondary' type='submit'>Discard review</button></form></section>"
-    return HTMLResponse(_page("Review discovered businesses", body))
+    selectable = sum(1 for item in batch.observations if not _is_sponsored(item))
+    no_website = sum(
+        1
+        for item in batch.observations
+        if item.business.website is None and not _is_sponsored(item)
+    )
+    body = f"{navigation}<section><h1>Review digital-presence opportunities</h1><p><strong>{len(batch.observations)}</strong> captured · <strong>{selectable}</strong> selectable · <strong>{no_website}</strong> have no website observed.</p><p class='notice warning'>Rows are ordered by deterministic opportunity score, not Google rank. A missing website is now a valid Webify opportunity. The score uses only observed website/review/photo/customer-activity evidence; it does not claim full Google Business Profile completeness and it does not make outreach automatic.</p><form method='post' action='/agency/prospects/discover/{html.escape(session_id, quote=True)}/ingest'>{_review_table(batch.observations)}<p><button type='submit'>Ingest selected opportunities</button></p></form><form method='post' action='/agency/prospects/discover/{html.escape(session_id, quote=True)}/cancel'><button class='secondary' type='submit'>Discard review</button></form></section>"
+    return HTMLResponse(_page("Review discovered opportunities", body))
 
 
 @router.post("/{session_id}/ingest", response_class=HTMLResponse)
@@ -294,10 +342,10 @@ async def discovery_ingest(session_id: str, request: Request) -> HTMLResponse:
         observations = tuple(
             item
             for item in batch.observations
-            if item.result_rank in selected and item.business.website is not None
+            if item.result_rank in selected and not _is_sponsored(item)
         )
         if not observations:
-            raise ValueError("Select at least one discovered business with a website.")
+            raise ValueError("Select at least one discovered business opportunity.")
         prospects = [_prospect_for_ingest(item) for item in observations]
         outcomes = TenantProspectDiscoveryIngestor(_root(request)).ingest(identity, prospects)
     except (TypeError, ValueError) as exc:
@@ -306,7 +354,7 @@ async def discovery_ingest(session_id: str, request: Request) -> HTMLResponse:
             status_code=400,
         )
     finally:
-        if 'outcomes' in locals():
+        if "outcomes" in locals():
             _REGISTRY.finish(tenant_id=identity.tenant_id, session_id=session_id)
 
     counts = {action: 0 for action in DiscoveryIngestAction}
@@ -318,7 +366,7 @@ async def discovery_ingest(session_id: str, request: Request) -> HTMLResponse:
         f"{counts[DiscoveryIngestAction.created]} created, "
         f"{counts[DiscoveryIngestAction.enriched]} safely enriched, "
         f"{counts[DiscoveryIngestAction.unchanged]} unchanged.</p>"
-        "<p class='notice'>Only the businesses you selected were processed. Existing human qualification, rejection, contact, audit and outreach state remains protected by the discovery ingest policy.</p>"
+        "<p class='notice'>Only the businesses you selected were processed. Existing human qualification, rejection, contact, audit and outreach state remains protected by the discovery ingest policy. No-website prospects remain valid leads but cannot enter website-audit stages until a website exists or a website-creation opportunity is handled separately.</p>"
         "<p><a class='button' href='/agency/prospects'>Open prospect workbench</a></p></section>"
     )
     return HTMLResponse(_page("Discovery ingest complete", body))

--- a/src/veridra/gbp_profile_evidence.py
+++ b/src/veridra/gbp_profile_evidence.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from urllib.parse import urlsplit
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+
+
+class GbpProfileEvidence(BaseModel):
+    """Public Google Business Profile evidence captured from a visible Maps detail page."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    business_name: str = Field(min_length=1, max_length=200)
+    source_url: HttpUrl
+    observed_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    collection_status: str = Field(default="ok", max_length=80)
+    category: str = Field(default="", max_length=160)
+    rating: float | None = Field(default=None, ge=0, le=5)
+    review_count: int | None = Field(default=None, ge=0)
+    website_url: HttpUrl | None = None
+    address_text: str = Field(default="", max_length=1000)
+    phone_text: str = Field(default="", max_length=500)
+    hours_text: str = Field(default="", max_length=2000)
+    booking_links: tuple[HttpUrl, ...] = Field(default=(), max_length=30)
+    external_action_links: tuple[HttpUrl, ...] = Field(default=(), max_length=100)
+    profile_item_ids: tuple[str, ...] = Field(default=(), max_length=500)
+    photo_control_labels: tuple[str, ...] = Field(default=(), max_length=200)
+    raw_action_labels: tuple[str, ...] = Field(default=(), max_length=300)
+    coverage_note: str = Field(
+        default=(
+            "Fields describe what the public Google Maps detail page exposed during this "
+            "bounded observation. An unobserved field is not by itself proof that the business "
+            "owner failed to configure it."
+        ),
+        max_length=1000,
+    )
+
+
+_BOOKING_TERMS = (
+    "appointment",
+    "appointments",
+    "book",
+    "booking",
+    "reserve",
+    "reservation",
+    "schedule",
+)
+
+
+def external_http_url(value: str, *, google_host: str = "google") -> str | None:
+    """Return an external HTTP(S) URL, excluding Google-owned navigation links."""
+
+    candidate = value.strip()
+    if not candidate.startswith(("http://", "https://")):
+        return None
+    parsed = urlsplit(candidate)
+    host = (parsed.hostname or "").casefold().strip(".")
+    if not host:
+        return None
+    if host.startswith(f"{google_host}.") or f".{google_host}." in host:
+        return None
+    if host.endswith("google.com") or host.endswith("googleusercontent.com"):
+        return None
+    return candidate
+
+
+def classify_booking_links(
+    links: list[tuple[str, str, str]],
+) -> tuple[str, ...]:
+    """Classify externally hosted appointment/booking actions from observable labels/item IDs."""
+
+    found: list[str] = []
+    for href, label, item_id in links:
+        external = external_http_url(href)
+        if external is None:
+            continue
+        haystack = f"{label} {item_id}".casefold()
+        if not any(term in haystack for term in _BOOKING_TERMS):
+            continue
+        if external not in found:
+            found.append(external)
+    return tuple(found)
+
+
+def unique_external_links(links: list[tuple[str, str, str]]) -> tuple[str, ...]:
+    found: list[str] = []
+    for href, _label, _item_id in links:
+        external = external_http_url(href)
+        if external is not None and external not in found:
+            found.append(external)
+    return tuple(found)

--- a/src/veridra/gbp_profile_evidence_cli.py
+++ b/src/veridra/gbp_profile_evidence_cli.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import zipfile
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .gbp_profile_evidence import (
+    GbpProfileEvidence,
+    classify_booking_links,
+    unique_external_links,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="veridra-gbp-profile-evidence")
+    parser.add_argument("--input", type=Path)
+    parser.add_argument("--downloads", type=Path, default=Path.home() / "Downloads")
+    parser.add_argument("--output-directory", type=Path, default=Path.home() / "Downloads")
+    parser.add_argument(
+        "--profile-directory",
+        type=Path,
+        default=Path.home() / ".veridra" / "browser-profile",
+    )
+    parser.add_argument("--max-businesses", type=int, default=50)
+    parser.add_argument("--headless", action="store_true")
+    return parser
+
+
+def _latest(directory: Path, pattern: str) -> Path | None:
+    matches = sorted(directory.glob(pattern), key=lambda item: item.stat().st_mtime, reverse=True)
+    return matches[0] if matches else None
+
+
+def _text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _load_contexts(path: Path) -> list[dict[str, object]]:
+    with zipfile.ZipFile(path) as archive:
+        raw = json.loads(archive.read("competitive_context.json"))
+    if not isinstance(raw, list):
+        raise ValueError("competitive_context.json must contain a list.")
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def _safe_inner_text(locator: Any) -> str:
+    try:
+        if int(locator.count()) < 1:
+            return ""
+        return " ".join(str(locator.first.inner_text(timeout=1_500)).split())
+    except Exception:
+        return ""
+
+
+def _first_text(page: Any, selectors: tuple[str, ...]) -> str:
+    for selector in selectors:
+        value = _safe_inner_text(page.locator(selector))
+        if value:
+            return value
+    return ""
+
+
+def _profile_item_ids(page: Any) -> tuple[str, ...]:
+    try:
+        values = page.eval_on_selector_all(
+            "[data-item-id]",
+            "els => els.map(el => el.getAttribute('data-item-id')).filter(Boolean)",
+        )
+    except Exception:
+        return ()
+    if not isinstance(values, list):
+        return ()
+    result: list[str] = []
+    for value in values:
+        clean = _text(value)
+        if clean and clean not in result:
+            result.append(clean[:300])
+    return tuple(result[:500])
+
+
+def _action_rows(page: Any) -> list[tuple[str, str, str]]:
+    try:
+        rows = page.eval_on_selector_all(
+            "a[href]",
+            """
+            els => els.map(el => ({
+              href: el.href || '',
+              label: el.getAttribute('aria-label') || el.innerText || '',
+              item_id: el.getAttribute('data-item-id') || ''
+            }))
+            """,
+        )
+    except Exception:
+        return []
+    if not isinstance(rows, list):
+        return []
+    result: list[tuple[str, str, str]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        result.append(
+            (
+                _text(row.get("href")),
+                _text(row.get("label")),
+                _text(row.get("item_id")),
+            )
+        )
+    return result
+
+
+def _action_labels(page: Any) -> tuple[str, ...]:
+    try:
+        values = page.eval_on_selector_all(
+            "button[aria-label],a[aria-label]",
+            "els => els.map(el => el.getAttribute('aria-label')).filter(Boolean)",
+        )
+    except Exception:
+        return ()
+    if not isinstance(values, list):
+        return ()
+    result: list[str] = []
+    for value in values:
+        clean = _text(value)
+        if clean and clean not in result:
+            result.append(clean[:500])
+    return tuple(result[:300])
+
+
+def _photo_labels(labels: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(label for label in labels if "photo" in label.casefold())[:200]
+
+
+def _website(page: Any) -> str | None:
+    try:
+        locator = page.locator('a[data-item-id="authority"][href]')
+        if int(locator.count()) < 1:
+            return None
+        href = locator.first.get_attribute("href")
+    except Exception:
+        return None
+    return href if isinstance(href, str) and href.startswith(("http://", "https://")) else None
+
+
+def _category(page: Any) -> str:
+    selectors = (
+        'button[jsaction*="category"]',
+        '[data-item-id="category"]',
+    )
+    return _first_text(page, selectors)
+
+
+def _signals(context: dict[str, object]) -> tuple[float | None, int | None]:
+    raw = context.get("signals")
+    signals = raw if isinstance(raw, dict) else {}
+    return _number(signals.get("rating")), _integer(signals.get("review_count"))
+
+
+def _capture(page: Any, context: dict[str, object]) -> GbpProfileEvidence:
+    name = _text(context.get("business_name"))
+    source_url = _text(context.get("source_url"))
+    if not name or not source_url:
+        raise ValueError("Business name and Google Maps source URL are required.")
+
+    page.goto(source_url, wait_until="domcontentloaded", timeout=15_000)
+    page.wait_for_timeout(900)
+
+    item_ids = _profile_item_ids(page)
+    actions = _action_rows(page)
+    labels = _action_labels(page)
+    rating, review_count = _signals(context)
+    website = _website(page) or _text(context.get("website")) or None
+
+    return GbpProfileEvidence.model_validate(
+        {
+            "business_name": name,
+            "source_url": source_url,
+            "observed_at": datetime.now(UTC),
+            "collection_status": "ok",
+            "category": _category(page) or _text(context.get("category")),
+            "rating": rating,
+            "review_count": review_count,
+            "website_url": website,
+            "address_text": _first_text(
+                page,
+                (
+                    'button[data-item-id="address"]',
+                    '[data-item-id="address"]',
+                ),
+            ),
+            "phone_text": _first_text(
+                page,
+                (
+                    'button[data-item-id^="phone:tel:"]',
+                    '[data-item-id^="phone:tel:"]',
+                ),
+            ),
+            "hours_text": _first_text(
+                page,
+                (
+                    'button[data-item-id="oh"]',
+                    '[data-item-id="oh"]',
+                ),
+            ),
+            "booking_links": classify_booking_links(actions),
+            "external_action_links": unique_external_links(actions),
+            "profile_item_ids": item_ids,
+            "photo_control_labels": _photo_labels(labels),
+            "raw_action_labels": labels,
+        }
+    )
+
+
+def _failed(context: dict[str, object], error: Exception) -> dict[str, object]:
+    detail = re.sub(r"\s+", " ", str(error)).strip()[:500]
+    return {
+        "business_name": _text(context.get("business_name")),
+        "source_url": _text(context.get("source_url")),
+        "collection_status": "failed",
+        "error_type": type(error).__name__,
+        "error": detail,
+    }
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.max_businesses < 1 or args.max_businesses > 200:
+        raise ValueError("max-businesses must be between 1 and 200.")
+
+    input_path = args.input or _latest(args.downloads, "VERIDRA_COMPETITIVE_*.zip")
+    if input_path is None or not input_path.is_file():
+        raise FileNotFoundError("No VERIDRA competitive-context ZIP was found.")
+
+    contexts = [
+        item
+        for item in _load_contexts(input_path)
+        if item.get("cohort_member") is not False and _text(item.get("source_url"))
+    ][: args.max_businesses]
+    if not contexts:
+        raise ValueError("The competitive-context ZIP contains no Google Maps source URLs.")
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        raise RuntimeError("Playwright is required for GBP evidence collection.") from exc
+
+    args.profile_directory.mkdir(parents=True, exist_ok=True)
+    collected: list[dict[str, object]] = []
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch_persistent_context(
+            str(args.profile_directory),
+            headless=args.headless,
+        )
+        page = browser.pages[0] if browser.pages else browser.new_page()
+        for context in contexts:
+            try:
+                evidence = _capture(page, context)
+                collected.append(evidence.model_dump(mode="json"))
+            except Exception as exc:
+                collected.append(_failed(context, exc))
+        browser.close()
+
+    ok_count = sum(1 for row in collected if row.get("collection_status") == "ok")
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    args.output_directory.mkdir(parents=True, exist_ok=True)
+    output = args.output_directory / f"VERIDRA_GBP_EVIDENCE_{stamp}.zip"
+    manifest = {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "source_competitive_context": input_path.name,
+        "businesses_requested": len(contexts),
+        "businesses_collected": ok_count,
+        "businesses_failed": len(contexts) - ok_count,
+        "method": "visible public Google Maps detail-page observation",
+        "absence_rule": (
+            "An unobserved field is a collection result, not proof that the business owner "
+            "failed to configure the Google Business Profile field."
+        ),
+        "review_rule": (
+            "Review text, recency and owner-response analysis remain in Review Intelligence; "
+            "this layer does not duplicate or infer them."
+        ),
+        "persistence": "none",
+        "outreach": "none",
+    }
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", json.dumps(manifest, indent=2, ensure_ascii=False))
+        archive.writestr(
+            "gbp_evidence.json",
+            json.dumps(collected, indent=2, ensure_ascii=False),
+        )
+        archive.writestr(
+            "README.md",
+            "# VERIDRA Google Business Profile Evidence\n\n"
+            "Read-only bounded observation of fields exposed by public Google Maps detail pages. "
+            "The pack preserves observed profile item IDs and action labels alongside normalized "
+            "website, address, phone, hours, booking/action-link and photo-control evidence. "
+            "Absence means not observed in this run, not proven unconfigured. Review text and "
+            "owner-response analysis remain authoritative in Review Intelligence. No prospect "
+            "state is mutated and no outreach is sent.\n",
+        )
+
+    print(
+        json.dumps(
+            {
+                "input": str(input_path),
+                "output": str(output),
+                "businesses_requested": len(contexts),
+                "businesses_collected": ok_count,
+                "businesses_failed": len(contexts) - ok_count,
+                "persistence": "none",
+                "outreach": "none",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/veridra/prospect_opportunity.py
+++ b/src/veridra/prospect_opportunity.py
@@ -96,11 +96,13 @@ def assess_opportunity(business: ObservedBusiness) -> OpportunityAssessment:
     if business.rating is not None and business.review_count and business.review_count >= 10:
         if business.rating >= 4.5:
             reasons.append(
-                "Strong rating suggests the underlying customer experience may be healthier than the digital gap."
+                "Strong rating suggests the underlying customer experience may be "
+                "healthier than the digital gap."
             )
         elif business.rating < 4.2:
             reasons.append(
-                "Lower rating is a reputation signal only; it is not treated as a Webify-fixable problem by itself."
+                "Lower rating is a reputation signal only; it is not treated as a "
+                "Webify-fixable problem by itself."
             )
 
     score = min(100, gap + activity)

--- a/src/veridra/prospect_opportunity.py
+++ b/src/veridra/prospect_opportunity.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .prospect_discovery import ObservedBusiness
+
+
+class OpportunityBand(StrEnum):
+    priority = "priority"
+    high = "high"
+    medium = "medium"
+    low = "low"
+
+
+@dataclass(frozen=True, slots=True)
+class OpportunityAssessment:
+    score: int
+    band: OpportunityBand
+    digital_gap_score: int
+    business_activity_score: int
+    reasons: tuple[str, ...]
+
+
+def _review_activity(review_count: int | None) -> tuple[int, str | None]:
+    if review_count is None:
+        return 0, None
+    if review_count >= 200:
+        return 30, "Strong customer activity signal: 200+ Google reviews observed."
+    if review_count >= 50:
+        return 24, "Healthy customer activity signal: 50+ Google reviews observed."
+    if review_count >= 20:
+        return 18, "Established customer activity signal: 20+ Google reviews observed."
+    if review_count >= 5:
+        return 12, "Some customer activity is visible in Google reviews."
+    if review_count > 0:
+        return 6, "Limited customer activity is visible in Google reviews."
+    return 0, "No Google reviews were observed in discovery."
+
+
+def _review_gap(review_count: int | None) -> tuple[int, str | None]:
+    if review_count is None:
+        return 0, None
+    if review_count == 0:
+        return 12, "No Google reviews were observed; reputation presence appears undeveloped."
+    if review_count < 5:
+        return 10, "Very few Google reviews were observed."
+    if review_count < 20:
+        return 7, "Google review presence is still relatively small."
+    if review_count < 50:
+        return 4, "Google review presence is moderate rather than strong."
+    return 0, None
+
+
+def _photo_gap(photo_count: int | None) -> tuple[int, str | None]:
+    if photo_count is None:
+        return 0, None
+    if photo_count <= 1:
+        return 13, "Very weak Google Maps photo signal was observed."
+    if photo_count <= 3:
+        return 8, "Only a small Google Maps photo signal was observed."
+    if photo_count <= 5:
+        return 4, "Google Maps photo presence appears limited."
+    return 0, None
+
+
+def assess_opportunity(business: ObservedBusiness) -> OpportunityAssessment:
+    """Rank observable Webify opportunity without inventing unobserved GBP facts.
+
+    The model deliberately separates the digital gap from evidence that a real business
+    has customer activity. A missing website is a large gap, but a business with no
+    activity evidence is not automatically promoted to the highest-priority band.
+    """
+
+    reasons: list[str] = []
+    gap = 0
+
+    if business.website is None:
+        gap += 45
+        reasons.append("No business website was observed from the Google Maps profile.")
+
+    review_gap, review_reason = _review_gap(business.review_count)
+    gap += review_gap
+    if review_reason:
+        reasons.append(review_reason)
+
+    photo_gap, photo_reason = _photo_gap(business.profile_photo_signal_count)
+    gap += photo_gap
+    if photo_reason:
+        reasons.append(photo_reason)
+
+    activity, activity_reason = _review_activity(business.review_count)
+    if activity_reason:
+        reasons.append(activity_reason)
+
+    if business.rating is not None and business.review_count and business.review_count >= 10:
+        if business.rating >= 4.5:
+            reasons.append(
+                "Strong rating suggests the underlying customer experience may be healthier than the digital gap."
+            )
+        elif business.rating < 4.2:
+            reasons.append(
+                "Lower rating is a reputation signal only; it is not treated as a Webify-fixable problem by itself."
+            )
+
+    score = min(100, gap + activity)
+
+    if score >= 65 and activity >= 12:
+        band = OpportunityBand.priority
+    elif score >= 50 and activity >= 6:
+        band = OpportunityBand.high
+    elif score >= 30:
+        band = OpportunityBand.medium
+    else:
+        band = OpportunityBand.low
+
+    return OpportunityAssessment(
+        score=score,
+        band=band,
+        digital_gap_score=gap,
+        business_activity_score=activity,
+        reasons=tuple(reasons),
+    )

--- a/tests/test_gbp_profile_evidence.py
+++ b/tests/test_gbp_profile_evidence.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from veridra.gbp_profile_evidence import (
+    GbpProfileEvidence,
+    classify_booking_links,
+    external_http_url,
+    unique_external_links,
+)
+
+
+def test_external_http_url_rejects_google_navigation() -> None:
+    assert external_http_url("https://www.google.com/maps/place/example") is None
+    assert external_http_url("https://lh5.googleusercontent.com/image") is None
+    assert external_http_url("https://clinic.example/book") == "https://clinic.example/book"
+
+
+def test_booking_links_require_external_url_and_booking_signal() -> None:
+    links = [
+        ("https://clinic.example/book", "Book an appointment", "appointment"),
+        ("https://clinic.example/about", "About us", "authority"),
+        ("https://www.google.com/maps/dir/", "Directions", "directions"),
+    ]
+
+    assert classify_booking_links(links) == ("https://clinic.example/book",)
+    assert unique_external_links(links) == (
+        "https://clinic.example/book",
+        "https://clinic.example/about",
+    )
+
+
+def test_profile_evidence_keeps_absence_as_observation_not_claim() -> None:
+    evidence = GbpProfileEvidence.model_validate(
+        {
+            "business_name": "Example Clinic",
+            "source_url": "https://www.google.com/maps/place/example",
+            "address_text": "",
+            "phone_text": "",
+            "hours_text": "",
+        }
+    )
+
+    assert evidence.address_text == ""
+    assert "not by itself proof" in evidence.coverage_note
+    assert evidence.collection_status == "ok"

--- a/tests/test_prospect_opportunity.py
+++ b/tests/test_prospect_opportunity.py
@@ -1,0 +1,73 @@
+from veridra.prospect_discovery import ObservedBusiness
+from veridra.prospect_opportunity import OpportunityBand, assess_opportunity
+
+
+def _business(**updates: object) -> ObservedBusiness:
+    payload: dict[str, object] = {
+        "provider": "assisted-google-maps",
+        "provider_key": "google-maps:test",
+        "name": "Example Dental",
+        "country_code": "IE",
+        "website": "https://example.ie",
+        "rating": 4.8,
+        "review_count": 80,
+        "profile_photo_signal_count": 8,
+    }
+    payload.update(updates)
+    return ObservedBusiness.model_validate(payload)
+
+
+def test_missing_website_with_real_activity_is_priority() -> None:
+    assessment = assess_opportunity(
+        _business(website=None, review_count=80, profile_photo_signal_count=2)
+    )
+
+    assert assessment.band is OpportunityBand.priority
+    assert assessment.score == 77
+    assert assessment.digital_gap_score == 53
+    assert assessment.business_activity_score == 24
+    assert any("No business website" in reason for reason in assessment.reasons)
+
+
+def test_missing_website_without_activity_is_not_promoted_to_priority() -> None:
+    assessment = assess_opportunity(
+        _business(
+            website=None,
+            rating=None,
+            review_count=0,
+            profile_photo_signal_count=0,
+        )
+    )
+
+    assert assessment.score == 70
+    assert assessment.band is OpportunityBand.medium
+    assert assessment.business_activity_score == 0
+
+
+def test_mature_digital_presence_is_low_opportunity() -> None:
+    assessment = assess_opportunity(_business())
+
+    assert assessment.band is OpportunityBand.low
+    assert assessment.digital_gap_score == 0
+    assert assessment.business_activity_score == 24
+    assert assessment.score == 24
+
+
+def test_sparse_reviews_and_photos_can_be_high_opportunity() -> None:
+    assessment = assess_opportunity(
+        _business(review_count=8, profile_photo_signal_count=1)
+    )
+
+    assert assessment.digital_gap_score == 20
+    assert assessment.business_activity_score == 12
+    assert assessment.score == 32
+    assert assessment.band is OpportunityBand.medium
+
+
+def test_low_rating_does_not_add_opportunity_points() -> None:
+    strong = assess_opportunity(_business(rating=4.8, review_count=80))
+    weak_rating = assess_opportunity(_business(rating=3.8, review_count=80))
+
+    assert weak_rating.score == strong.score
+    assert weak_rating.band is strong.band
+    assert any("not treated as a Webify-fixable" in reason for reason in weak_rating.reasons)


### PR DESCRIPTION
Closes #236.

## What changes
- Adds a deterministic digital-presence opportunity assessment that separates observable digital gaps from evidence of real customer activity.
- Treats a missing website as a strong Webify opportunity instead of excluding the business.
- Surfaces rating, review count, photo signal, opportunity band, gap/activity split and evidence-backed reasons in assisted discovery.
- Orders the review table by opportunity rather than Google Maps rank while preserving the original Maps rank as provenance.
- Keeps sponsored results non-selectable.
- Stores the observed opportunity evidence in the prospect evidence summary.
- Adds unit coverage for missing-site, mature-presence and low-rating boundaries.

## Important boundary
This version uses only evidence VERIDRA already observes. It does not infer full GBP completeness, photo/review recency, owner-response behavior, booking availability, NAP consistency or competitor-relative performance. Those require explicit collection before they should influence lead qualification.

No automated outreach or persistence beyond explicit human selection is introduced.