### PR TITLE
Fix GBP evidence launcher import path

### DIFF
--- a/VERIDRA_GBP_EVIDENCE.bat
+++ b/VERIDRA_GBP_EVIDENCE.bat
@@ -1,6 +1,7 @@
 @echo off
 setlocal
 cd /d "%~dp0"
+set "PYTHONPATH=%CD%\src;%PYTHONPATH%"
 echo [Veridra] Collecting bounded public Google Business Profile evidence...
 python -m veridra.gbp_profile_evidence_cli --downloads "%USERPROFILE%\Downloads" --output-directory "%USERPROFILE%\Downloads"
 set EXITCODE=%ERRORLEVEL%


### PR DESCRIPTION
The Windows GBP evidence launcher currently invokes the global Python interpreter from the repository root, but VERIDRA uses a `src/` package layout. On a fresh checkout this causes `ModuleNotFoundError: No module named 'veridra'` unless the project is installed first.

This change prepends the repository `src` directory to `PYTHONPATH` inside the launcher so the collector can run directly from a checkout without requiring a global editable install.