### PR TITLE
Normalize Google Maps opening-hours evidence

### DIFF
--- a/src/veridra/gbp_profile_evidence.py
+++ b/src/veridra/gbp_profile_evidence.py
@@ -65,6 +65,19 @@ def external_http_url(value: str, *, google_host: str = "google") -> str | None:
     return candidate
 
 
+def hours_from_action_labels(labels: tuple[str, ...]) -> str:
+    """Normalize visible day/hour labels when Maps exposes no stable hours item selector."""
+
+    rows: list[str] = []
+    for label in labels:
+        if "copy open hours" not in label.casefold():
+            continue
+        clean = label.replace(", Copy open hours", "").strip()
+        if clean and clean not in rows:
+            rows.append(clean)
+    return " | ".join(rows)
+
+
 def classify_booking_links(
     links: list[tuple[str, str, str]],
 ) -> tuple[str, ...]:

--- a/src/veridra/gbp_profile_evidence_cli.py
+++ b/src/veridra/gbp_profile_evidence_cli.py
@@ -12,6 +12,7 @@ from typing import Any
 from .gbp_profile_evidence import (
     GbpProfileEvidence,
     classify_booking_links,
+    hours_from_action_labels,
     unique_external_links,
 )
 
@@ -186,6 +187,13 @@ def _capture(page: Any, context: dict[str, object]) -> GbpProfileEvidence:
     labels = _action_labels(page)
     rating, review_count = _signals(context)
     website = _website(page) or _text(context.get("website")) or None
+    hours = _first_text(
+        page,
+        (
+            'button[data-item-id="oh"]',
+            '[data-item-id="oh"]',
+        ),
+    ) or hours_from_action_labels(labels)
 
     return GbpProfileEvidence.model_validate(
         {
@@ -211,13 +219,7 @@ def _capture(page: Any, context: dict[str, object]) -> GbpProfileEvidence:
                     '[data-item-id^="phone:tel:"]',
                 ),
             ),
-            "hours_text": _first_text(
-                page,
-                (
-                    'button[data-item-id="oh"]',
-                    '[data-item-id="oh"]',
-                ),
-            ),
+            "hours_text": hours,
             "booking_links": classify_booking_links(actions),
             "external_action_links": unique_external_links(actions),
             "profile_item_ids": item_ids,

--- a/tests/test_gbp_profile_evidence.py
+++ b/tests/test_gbp_profile_evidence.py
@@ -4,6 +4,7 @@ from veridra.gbp_profile_evidence import (
     GbpProfileEvidence,
     classify_booking_links,
     external_http_url,
+    hours_from_action_labels,
     unique_external_links,
 )
 
@@ -25,6 +26,19 @@ def test_booking_links_require_external_url_and_booking_signal() -> None:
     assert unique_external_links(links) == (
         "https://clinic.example/book",
         "https://clinic.example/about",
+    )
+
+
+def test_hours_from_action_labels_keeps_visible_day_rows_only() -> None:
+    labels = (
+        "Thursday, 8 am to 8 pm, Copy open hours",
+        "Friday, 8 am to 8 pm, Copy open hours",
+        "Website: clinic.example",
+        "Thursday, 8 am to 8 pm, Copy open hours",
+    )
+
+    assert hours_from_action_labels(labels) == (
+        "Thursday, 8 am to 8 pm | Friday, 8 am to 8 pm"
     )
 
 


### PR DESCRIPTION
Live Dublin GBP evidence collection on 27 Aug 2026 showed `hours_text` empty for all 49 businesses even though 47 profiles exposed seven visible `Copy open hours` action labels. This change preserves the existing stable selector when available and falls back to those visible day/hour labels when it is not.

The fallback is deterministic, read-only, deduplicated, and tested. It does not alter lead scoring yet.