### PR TITLE
Feed broad discovery into GBP enrichment

### DIFF
--- a/VERIDRA_GBP_DISCOVERY_EVIDENCE.bat
+++ b/VERIDRA_GBP_DISCOVERY_EVIDENCE.bat
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+set "PYTHONPATH=%CD%\src;%PYTHONPATH%"
+if exist "%CD%\.venv\Scripts\python.exe" (
+  set "VERIDRA_PYTHON=%CD%\.venv\Scripts\python.exe"
+) else (
+  set "VERIDRA_PYTHON=python"
+)
+echo [Veridra] Enriching latest broad discovery pack with public GBP evidence...
+"%VERIDRA_PYTHON%" -m veridra.gbp_discovery_evidence_cli --downloads "%USERPROFILE%\Downloads" --output-directory "%USERPROFILE%\Downloads"
+set EXITCODE=%ERRORLEVEL%
+if not "%EXITCODE%"=="0" (
+  echo [Veridra] Discovery GBP evidence collection failed with exit code %EXITCODE%.
+)
+exit /b %EXITCODE%

--- a/src/veridra/automated_discovery_evidence_cli.py
+++ b/src/veridra/automated_discovery_evidence_cli.py
@@ -60,9 +60,13 @@ def _build_archive(*, result: TraversalResult, query_text: str, generated_at: st
             "prospect": _prospect_for_ingest(item).model_dump(mode="json"),
         }
         for item in result.observations
-        if item.business.website is not None
     ]
     progress = result.progress
+    website_count = sum(
+        1
+        for row in observations
+        if isinstance(row["business"], dict) and row["business"].get("website")
+    )
     manifest = {
         "schema_version": 1,
         "generated_at": generated_at,
@@ -70,11 +74,8 @@ def _build_archive(*, result: TraversalResult, query_text: str, generated_at: st
         "query_sequence": progress.query_sequence,
         "state": "review",
         "captured_count": len(observations),
-        "website_captured_count": sum(
-            1
-            for row in observations
-            if isinstance(row["business"], dict) and row["business"].get("website")
-        ),
+        "website_captured_count": website_count,
+        "no_website_captured_count": len(observations) - website_count,
         "ingest_preview_count": len(ingest_preview),
         "progress": {
             "scroll_step": progress.scroll_step,
@@ -158,6 +159,9 @@ def run(argv: Sequence[str] | None = None) -> int:
             "output": str(output_path),
             "captured": len(result.observations),
             "websites": sum(1 for item in result.observations if item.business.website is not None),
+            "no_websites": sum(
+                1 for item in result.observations if item.business.website is None
+            ),
             "stop_reason": stop_reason.value if stop_reason is not None else None,
             "persistence": "none",
         }

--- a/src/veridra/gbp_discovery_evidence_cli.py
+++ b/src/veridra/gbp_discovery_evidence_cli.py
@@ -6,7 +6,6 @@ import zipfile
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
 
 from .gbp_profile_evidence_cli import _capture, _failed
 

--- a/src/veridra/gbp_discovery_evidence_cli.py
+++ b/src/veridra/gbp_discovery_evidence_cli.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import argparse
+import json
+import zipfile
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .gbp_profile_evidence_cli import _capture, _failed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="veridra-gbp-discovery-evidence")
+    parser.add_argument("--input", type=Path)
+    parser.add_argument("--downloads", type=Path, default=Path.home() / "Downloads")
+    parser.add_argument("--output-directory", type=Path, default=Path.home() / "Downloads")
+    parser.add_argument(
+        "--profile-directory",
+        type=Path,
+        default=Path.home() / ".veridra" / "browser-profile",
+    )
+    parser.add_argument("--max-businesses", type=int, default=50)
+    parser.add_argument("--headless", action="store_true")
+    return parser
+
+
+def _latest(directory: Path, pattern: str) -> Path | None:
+    matches = sorted(directory.glob(pattern), key=lambda item: item.stat().st_mtime, reverse=True)
+    return matches[0] if matches else None
+
+
+def _text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _is_sponsored(category: str) -> bool:
+    return category.strip().casefold() in {"sponsored", "ad", "advertisement"}
+
+
+def _load_discovery_contexts(path: Path) -> list[dict[str, object]]:
+    with zipfile.ZipFile(path) as archive:
+        raw = json.loads(archive.read("captured_observations.json"))
+    if not isinstance(raw, list):
+        raise ValueError("captured_observations.json must contain a list.")
+
+    contexts: list[dict[str, object]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        business = item.get("business")
+        if not isinstance(business, dict):
+            continue
+        name = _text(business.get("name"))
+        source_url = _text(business.get("source_url"))
+        category = _text(business.get("category"))
+        if not name or not source_url or _is_sponsored(category):
+            continue
+        contexts.append(
+            {
+                "business_name": name,
+                "source_url": source_url,
+                "website": _text(business.get("website")) or None,
+                "category": category,
+                "signals": {
+                    "rating": _number(business.get("rating")),
+                    "review_count": _integer(business.get("review_count")),
+                },
+                "discovery_result_rank": item.get("result_rank"),
+                "query_text": item.get("query_text"),
+            }
+        )
+    return contexts
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.max_businesses < 1 or args.max_businesses > 200:
+        raise ValueError("max-businesses must be between 1 and 200.")
+
+    input_path = args.input or _latest(args.downloads, "VERIDRA_DISCOVERY_*.zip")
+    if input_path is None or not input_path.is_file():
+        raise FileNotFoundError("No VERIDRA discovery ZIP was found.")
+
+    contexts = _load_discovery_contexts(input_path)[: args.max_businesses]
+    if not contexts:
+        raise ValueError("The discovery ZIP contains no eligible Google Maps source URLs.")
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError as exc:
+        raise RuntimeError("Playwright is required for GBP evidence collection.") from exc
+
+    args.profile_directory.mkdir(parents=True, exist_ok=True)
+    collected: list[dict[str, object]] = []
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch_persistent_context(
+            str(args.profile_directory),
+            headless=args.headless,
+        )
+        page = browser.pages[0] if browser.pages else browser.new_page()
+        for context in contexts:
+            try:
+                evidence = _capture(page, context)
+                payload = evidence.model_dump(mode="json")
+                payload["discovery_result_rank"] = context.get("discovery_result_rank")
+                payload["query_text"] = context.get("query_text")
+                collected.append(payload)
+            except Exception as exc:
+                failure = _failed(context, exc)
+                failure["discovery_result_rank"] = context.get("discovery_result_rank")
+                failure["query_text"] = context.get("query_text")
+                collected.append(failure)
+        browser.close()
+
+    ok_count = sum(1 for row in collected if row.get("collection_status") == "ok")
+    without_website = sum(1 for context in contexts if not context.get("website"))
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    args.output_directory.mkdir(parents=True, exist_ok=True)
+    output = args.output_directory / f"VERIDRA_GBP_DISCOVERY_EVIDENCE_{stamp}.zip"
+    manifest = {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "source_discovery": input_path.name,
+        "businesses_requested": len(contexts),
+        "businesses_without_website_requested": without_website,
+        "businesses_collected": ok_count,
+        "businesses_failed": len(contexts) - ok_count,
+        "method": "broad Google Maps discovery followed by visible public detail-page observation",
+        "absence_rule": (
+            "An unobserved field is a collection result, not proof that the business owner "
+            "failed to configure the Google Business Profile field."
+        ),
+        "review_rule": (
+            "Review text, recency and owner-response analysis remain in Review Intelligence; "
+            "this layer does not duplicate or infer them."
+        ),
+        "persistence": "none",
+        "outreach": "none",
+    }
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", json.dumps(manifest, indent=2, ensure_ascii=False))
+        archive.writestr(
+            "gbp_evidence.json",
+            json.dumps(collected, indent=2, ensure_ascii=False),
+        )
+        archive.writestr(
+            "README.md",
+            "# VERIDRA GBP Discovery Evidence\n\n"
+            "Read-only enrichment of broad Google Maps discovery observations. Businesses are "
+            "eligible whether or not a website was observed during discovery. Sponsored rows are "
+            "excluded. The pack preserves discovery rank/query provenance and public GBP evidence. "
+            "No prospect state is mutated and no outreach is sent.\n",
+        )
+
+    print(
+        json.dumps(
+            {
+                "input": str(input_path),
+                "output": str(output),
+                "businesses_requested": len(contexts),
+                "businesses_without_website_requested": without_website,
+                "businesses_collected": ok_count,
+                "businesses_failed": len(contexts) - ok_count,
+                "persistence": "none",
+                "outreach": "none",
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_automated_discovery_evidence_cli.py
+++ b/tests/test_automated_discovery_evidence_cli.py
@@ -16,10 +16,10 @@ from veridra.prospect_discovery import ObservedBusiness
 
 
 def _result() -> TraversalResult:
-    business = ObservedBusiness.model_validate(
+    with_website = ObservedBusiness.model_validate(
         {
             "provider": "assisted-google-maps",
-            "provider_key": "google-maps:test",
+            "provider_key": "google-maps:test-website",
             "name": "Slievemore Dental",
             "category": "Emergency dental service",
             "locality": "Dublin",
@@ -30,13 +30,36 @@ def _result() -> TraversalResult:
             "observed_at": datetime(2026, 8, 24, tzinfo=UTC),
         }
     )
+    without_website = ObservedBusiness.model_validate(
+        {
+            "provider": "assisted-google-maps",
+            "provider_key": "google-maps:test-no-website",
+            "name": "No Website Dental",
+            "category": "Dentist",
+            "locality": "Dublin",
+            "administrative_area": "Dublin",
+            "country_code": "IE",
+            "website": None,
+            "source_url": "https://www.google.com/maps/place/No+Website+Dental/",
+            "rating": 4.8,
+            "review_count": 84,
+            "observed_at": datetime(2026, 8, 24, tzinfo=UTC),
+        }
+    )
     return TraversalResult(
         observations=(
             TraversalObservation(
-                business=business,
+                business=with_website,
                 query_text="dentist in Dublin, IE",
                 query_sequence=1,
                 result_rank=1,
+                first_seen_scroll_step=0,
+            ),
+            TraversalObservation(
+                business=without_website,
+                query_text="dentist in Dublin, IE",
+                query_sequence=1,
+                result_rank=2,
                 first_seen_scroll_step=0,
             ),
         ),
@@ -44,7 +67,7 @@ def _result() -> TraversalResult:
             query_text="dentist in Dublin, IE",
             query_sequence=1,
             scroll_step=0,
-            unique_results=1,
+            unique_results=2,
             stagnant_scrolls=0,
             elapsed_seconds=1.2,
             stop_reason=TraversalStopReason.max_results,
@@ -71,9 +94,13 @@ def test_build_archive_contains_capture_and_ingest_preview() -> None:
         captured = json.loads(archive.read("captured_observations.json"))
         preview = json.loads(archive.read("ingest_preview.json"))
 
-    assert manifest["captured_count"] == 1
+    assert manifest["captured_count"] == 2
     assert manifest["website_captured_count"] == 1
+    assert manifest["no_website_captured_count"] == 1
+    assert manifest["ingest_preview_count"] == 2
     assert manifest["persistence"] == "none"
     assert manifest["execution"] == "automated-local-backend"
     assert captured[0]["business"]["website"] == "https://www.slievemoredental.ie/"
+    assert captured[1]["business"]["website"] is None
     assert preview[0]["prospect"]["website"] == "https://www.slievemoredental.ie/"
+    assert preview[1]["prospect"]["website"] is None

--- a/tests/test_gbp_discovery_evidence_cli.py
+++ b/tests/test_gbp_discovery_evidence_cli.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import zipfile
+
+from veridra.gbp_discovery_evidence_cli import _load_discovery_contexts
+
+
+def test_load_discovery_contexts_keeps_no_website_and_excludes_sponsored(tmp_path) -> None:
+    source = tmp_path / "VERIDRA_DISCOVERY_dentist-in-dublin-ie.zip"
+    observations = [
+        {
+            "query_text": "dentist in Dublin, IE",
+            "result_rank": 1,
+            "business": {
+                "name": "No Website Dental",
+                "category": "Dentist",
+                "website": None,
+                "source_url": "https://www.google.com/maps/place/no-website-dental",
+                "rating": 4.8,
+                "review_count": 84,
+            },
+        },
+        {
+            "query_text": "dentist in Dublin, IE",
+            "result_rank": 2,
+            "business": {
+                "name": "Website Dental",
+                "category": "Dentist",
+                "website": "https://clinic.example/",
+                "source_url": "https://www.google.com/maps/place/website-dental",
+                "rating": 4.7,
+                "review_count": 120,
+            },
+        },
+        {
+            "query_text": "dentist in Dublin, IE",
+            "result_rank": 3,
+            "business": {
+                "name": "Sponsored Dental",
+                "category": "Sponsored",
+                "website": None,
+                "source_url": "https://www.google.com/maps/place/sponsored-dental",
+                "rating": 5.0,
+                "review_count": 999,
+            },
+        },
+    ]
+    with zipfile.ZipFile(source, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("captured_observations.json", json.dumps(observations))
+
+    contexts = _load_discovery_contexts(source)
+
+    assert [item["business_name"] for item in contexts] == [
+        "No Website Dental",
+        "Website Dental",
+    ]
+    assert contexts[0]["website"] is None
+    assert contexts[0]["signals"] == {"rating": 4.8, "review_count": 84}
+    assert contexts[0]["discovery_result_rank"] == 1

--- a/tests/test_gbp_discovery_evidence_cli.py
+++ b/tests/test_gbp_discovery_evidence_cli.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import json
 import zipfile
+from pathlib import Path
 
 from veridra.gbp_discovery_evidence_cli import _load_discovery_contexts
 
 
-def test_load_discovery_contexts_keeps_no_website_and_excludes_sponsored(tmp_path) -> None:
+def test_load_discovery_contexts_keeps_no_website_and_excludes_sponsored(
+    tmp_path: Path,
+) -> None:
     source = tmp_path / "VERIDRA_DISCOVERY_dentist-in-dublin-ie.zip"
     observations = [
         {


### PR DESCRIPTION
The first live Dublin GBP run proved the competitive-context input was too late in the funnel: it only contained website-bearing businesses, so the collector could never surface one of Webify's strongest opportunity classes — active businesses with no observed website.

This change:
- adds a GBP enrichment CLI that reads `captured_observations.json` directly from broad discovery packs;
- preserves no-website businesses while excluding sponsored rows;
- keeps discovery rank/query provenance in the GBP evidence output;
- adds a Windows launcher that prefers the repository `.venv` when available;
- removes the old website-only filter from automated discovery `ingest_preview` and reports explicit no-website counts;
- adds regression tests for both no-website preservation and sponsored exclusion.

The enrichment remains read-only: no prospect persistence and no outreach. Review text, recency and owner-response analysis remain in Review Intelligence.