### PR TITLE
Advance virtualized Google Maps result lists reliably

### DIFF
--- a/src/veridra/assisted_google_maps.py
+++ b/src/veridra/assisted_google_maps.py
@@ -269,6 +269,34 @@ def capture_visible_google_maps_businesses(
     return captured
 
 
+def _advance_results_feed(page: Any, feed: Any) -> None:
+    """Advance a virtualized Google Maps result list and prompt the next cards to materialize."""
+
+    cards = page.locator('[role="feed"] [role="article"]')
+    try:
+        count = int(cards.count())
+    except Exception:
+        count = 0
+
+    if count > 0:
+        last_card = cards.nth(count - 1)
+        try:
+            last_card.scroll_into_view_if_needed(timeout=2_000)
+            last_card.hover(timeout=2_000)
+            page.mouse.wheel(0, 1_200)
+        except Exception:
+            pass
+
+    try:
+        feed.evaluate(
+            "(element) => element.scrollBy(0, Math.max(element.clientHeight * 1.25, 800))"
+        )
+    except Exception:
+        pass
+
+    page.wait_for_timeout(1_000)
+
+
 def traverse_google_maps_results(
     page: Any,
     *,
@@ -320,8 +348,5 @@ def traverse_google_maps_results(
                 stop_reason=stop_reason,
             )
 
-        feed.evaluate(
-            "(element) => element.scrollBy(0, Math.max(element.clientHeight * 0.8, 500))"
-        )
-        page.wait_for_timeout(750)
+        _advance_results_feed(page, feed)
         scroll_step += 1

--- a/tests/test_assisted_google_maps_quality.py
+++ b/tests/test_assisted_google_maps_quality.py
@@ -1,11 +1,67 @@
 from __future__ import annotations
 
 from veridra.assisted_google_maps import (
+    _advance_results_feed,
     _canonical_maps_identity,
     _clean_category,
     _external_website,
     _provider_key,
 )
+
+
+class _Card:
+    def __init__(self) -> None:
+        self.scrolled = False
+        self.hovered = False
+
+    def scroll_into_view_if_needed(self, *, timeout: int) -> None:
+        assert timeout == 2_000
+        self.scrolled = True
+
+    def hover(self, *, timeout: int) -> None:
+        assert timeout == 2_000
+        self.hovered = True
+
+
+class _Cards:
+    def __init__(self, cards: list[_Card]) -> None:
+        self.cards = cards
+
+    def count(self) -> int:
+        return len(self.cards)
+
+    def nth(self, index: int) -> _Card:
+        return self.cards[index]
+
+
+class _Mouse:
+    def __init__(self) -> None:
+        self.wheels: list[tuple[int, int]] = []
+
+    def wheel(self, x: int, y: int) -> None:
+        self.wheels.append((x, y))
+
+
+class _Page:
+    def __init__(self, cards: list[_Card]) -> None:
+        self.cards = _Cards(cards)
+        self.mouse = _Mouse()
+        self.waits: list[int] = []
+
+    def locator(self, selector: str) -> _Cards:
+        assert selector == '[role="feed"] [role="article"]'
+        return self.cards
+
+    def wait_for_timeout(self, milliseconds: int) -> None:
+        self.waits.append(milliseconds)
+
+
+class _Feed:
+    def __init__(self) -> None:
+        self.scripts: list[str] = []
+
+    def evaluate(self, script: str) -> None:
+        self.scripts.append(script)
 
 
 def test_same_google_place_identity_survives_url_variants() -> None:
@@ -42,3 +98,18 @@ def test_category_cleanup_rejects_non_categories() -> None:
     assert _clean_category("  Emergency dental service  ", name="Slievemore Dental") == (
         "Emergency dental service"
     )
+
+
+def test_virtualized_feed_advancement_uses_last_card_and_wheel() -> None:
+    cards = [_Card(), _Card(), _Card()]
+    page = _Page(cards)
+    feed = _Feed()
+
+    _advance_results_feed(page, feed)
+
+    assert cards[-1].scrolled is True
+    assert cards[-1].hovered is True
+    assert page.mouse.wheels == [(0, 1_200)]
+    assert len(feed.scripts) == 1
+    assert "scrollBy" in feed.scripts[0]
+    assert page.waits == [1_000]


### PR DESCRIPTION
The first broad Dublin discovery run after PR #240 captured only 5 businesses and stopped as `no_new_results` despite `--max-results 50`. The traversal loop was repeatedly reading the same virtualized Google Maps cards while only calling `feed.scrollBy(...)`.

This change advances the result list by:
- scrolling the last materialized result card into view;
- hovering that card and dispatching a downward wheel event so Google Maps' actual scrollable ancestor receives user-like traversal input;
- retaining the existing feed scroll as a fallback;
- waiting for the next virtualized batch to materialize.

A regression test verifies that the last card, wheel event, feed fallback, and bounded wait are all exercised. Capture, opportunity scoring, persistence, and outreach logic are unchanged.