### PR TITLE
Enumerate local markets across multiple Google Maps queries

### DIFF
--- a/VERIDRA_MARKET_ENUMERATION.bat
+++ b/VERIDRA_MARKET_ENUMERATION.bat
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+echo [Veridra] Enumerating the Dublin dental market across bounded Google Maps queries...
+if not exist ".venv\Scripts\python.exe" (
+  echo [Veridra] Missing .venv. Create the VERIDRA virtual environment first.
+  exit /b 1
+)
+".venv\Scripts\python.exe" -m veridra.market_enumeration_cli --plan dublin-dentists --output-directory "%USERPROFILE%\Downloads"
+set EXITCODE=%ERRORLEVEL%
+if not "%EXITCODE%"=="0" (
+  echo [Veridra] Market enumeration failed with exit code %EXITCODE%.
+)
+exit /b %EXITCODE%

--- a/src/veridra/market_enumeration.py
+++ b/src/veridra/market_enumeration.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .assisted_discovery import TraversalObservation, TraversalResult
+from .prospect_discovery import ObservedBusiness
+
+
+@dataclass(frozen=True, slots=True)
+class MarketBusiness:
+    business: ObservedBusiness
+    first_query_text: str
+    first_query_sequence: int
+    first_result_rank: int
+    seen_in_queries: tuple[str, ...]
+    observation_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class QueryCoverage:
+    query_text: str
+    query_sequence: int
+    captured: int
+    new_unique: int
+    duplicate_observations: int
+    stop_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class MarketEnumeration:
+    businesses: tuple[MarketBusiness, ...]
+    coverage: tuple[QueryCoverage, ...]
+    raw_observation_count: int
+
+
+def _identity(observation: TraversalObservation) -> tuple[str, str]:
+    business = observation.business
+    return business.provider.casefold(), business.provider_key.casefold()
+
+
+def aggregate_market(results: list[TraversalResult]) -> MarketEnumeration:
+    first_seen: dict[tuple[str, str], TraversalObservation] = {}
+    query_hits: dict[tuple[str, str], list[str]] = {}
+    observation_counts: dict[tuple[str, str], int] = {}
+    coverage: list[QueryCoverage] = []
+    raw_count = 0
+
+    for result in results:
+        new_unique = 0
+        duplicate_observations = 0
+        for observation in result.observations:
+            raw_count += 1
+            key = _identity(observation)
+            observation_counts[key] = observation_counts.get(key, 0) + 1
+            queries = query_hits.setdefault(key, [])
+            if observation.query_text not in queries:
+                queries.append(observation.query_text)
+            if key in first_seen:
+                duplicate_observations += 1
+                continue
+            first_seen[key] = observation
+            new_unique += 1
+
+        reason = result.progress.stop_reason
+        coverage.append(
+            QueryCoverage(
+                query_text=result.progress.query_text,
+                query_sequence=result.progress.query_sequence,
+                captured=len(result.observations),
+                new_unique=new_unique,
+                duplicate_observations=duplicate_observations,
+                stop_reason=reason.value if reason is not None else None,
+            )
+        )
+
+    businesses = tuple(
+        MarketBusiness(
+            business=observation.business,
+            first_query_text=observation.query_text,
+            first_query_sequence=observation.query_sequence,
+            first_result_rank=observation.result_rank,
+            seen_in_queries=tuple(query_hits[key]),
+            observation_count=observation_counts[key],
+        )
+        for key, observation in first_seen.items()
+    )
+    return MarketEnumeration(
+        businesses=businesses,
+        coverage=tuple(coverage),
+        raw_observation_count=raw_count,
+    )
+
+
+def dublin_dentist_queries() -> tuple[str, ...]:
+    geographic = tuple(f"dentist in Dublin {district}, IE" for district in range(1, 25))
+    return (
+        "dentist in Dublin, IE",
+        *geographic,
+        "dentist in Dublin 6W, IE",
+        "dental clinic in Dublin, IE",
+        "family dentist in Dublin, IE",
+        "emergency dentist in Dublin, IE",
+        "orthodontist in Dublin, IE",
+    )

--- a/src/veridra/market_enumeration_cli.py
+++ b/src/veridra/market_enumeration_cli.py
@@ -14,7 +14,7 @@ from .assisted_browser_provider import (
 )
 from .assisted_discovery import BoundedDiscoveryLimits, TraversalResult
 from .assisted_discovery_acceptance_cli import build_start_url
-from .market_enumeration import aggregate_market, dublin_dentist_queries
+from .market_enumeration import MarketBusiness, aggregate_market, dublin_dentist_queries
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -47,16 +47,14 @@ def _queries(args: argparse.Namespace) -> tuple[str, ...]:
     raise ValueError("No market-enumeration query plan is available.")
 
 
-def _business_payload(item: object) -> dict[str, object]:
-    market_business = item
-    business = market_business.business
+def _business_payload(item: MarketBusiness) -> dict[str, object]:
     return {
-        "business": business.model_dump(mode="json"),
-        "first_query_text": market_business.first_query_text,
-        "first_query_sequence": market_business.first_query_sequence,
-        "first_result_rank": market_business.first_result_rank,
-        "seen_in_queries": list(market_business.seen_in_queries),
-        "observation_count": market_business.observation_count,
+        "business": item.business.model_dump(mode="json"),
+        "first_query_text": item.first_query_text,
+        "first_query_sequence": item.first_query_sequence,
+        "first_result_rank": item.first_result_rank,
+        "seen_in_queries": list(item.seen_in_queries),
+        "observation_count": item.observation_count,
     }
 
 

--- a/src/veridra/market_enumeration_cli.py
+++ b/src/veridra/market_enumeration_cli.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import zipfile
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .assisted_browser_provider import (
+    SubprocessPlaywrightDiscoveryProvider,
+    VisibleBrowserUnavailable,
+)
+from .assisted_discovery import BoundedDiscoveryLimits, TraversalResult
+from .assisted_discovery_acceptance_cli import build_start_url
+from .market_enumeration import aggregate_market, dublin_dentist_queries
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="veridra-market-enumeration")
+    parser.add_argument(
+        "--plan",
+        choices=("dublin-dentists",),
+        default="dublin-dentists",
+    )
+    parser.add_argument("--query", action="append", default=[])
+    parser.add_argument("--country-code", default="IE")
+    parser.add_argument("--locality", default="Dublin")
+    parser.add_argument("--administrative-area", default="Dublin")
+    parser.add_argument("--max-results-per-query", type=int, default=50)
+    parser.add_argument("--max-scrolls-per-query", type=int, default=20)
+    parser.add_argument("--max-seconds-per-query", type=float, default=120.0)
+    parser.add_argument("--max-stagnant-scrolls", type=int, default=3)
+    parser.add_argument("--startup-wait-seconds", type=float, default=4.0)
+    parser.add_argument("--between-query-wait-seconds", type=float, default=1.0)
+    parser.add_argument("--output-directory", type=Path, default=Path.home() / "Downloads")
+    return parser
+
+
+def _queries(args: argparse.Namespace) -> tuple[str, ...]:
+    explicit = tuple(query.strip() for query in args.query if query.strip())
+    if explicit:
+        return explicit
+    if args.plan == "dublin-dentists":
+        return dublin_dentist_queries()
+    raise ValueError("No market-enumeration query plan is available.")
+
+
+def _business_payload(item: object) -> dict[str, object]:
+    market_business = item
+    business = market_business.business
+    return {
+        "business": business.model_dump(mode="json"),
+        "first_query_text": market_business.first_query_text,
+        "first_query_sequence": market_business.first_query_sequence,
+        "first_result_rank": market_business.first_result_rank,
+        "seen_in_queries": list(market_business.seen_in_queries),
+        "observation_count": market_business.observation_count,
+    }
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.startup_wait_seconds < 0 or args.startup_wait_seconds > 60:
+        raise ValueError("startup-wait-seconds must be between 0 and 60.")
+    if args.between_query_wait_seconds < 0 or args.between_query_wait_seconds > 60:
+        raise ValueError("between-query-wait-seconds must be between 0 and 60.")
+
+    queries = _queries(args)
+    if not queries:
+        raise ValueError("At least one query is required.")
+
+    limits = BoundedDiscoveryLimits(
+        max_results=args.max_results_per_query,
+        max_scrolls=args.max_scrolls_per_query,
+        max_elapsed_seconds=args.max_seconds_per_query,
+        max_stagnant_scrolls=args.max_stagnant_scrolls,
+    )
+
+    results: list[TraversalResult] = []
+    for sequence, query in enumerate(queries, start=1):
+        provider = SubprocessPlaywrightDiscoveryProvider(
+            country_code=args.country_code,
+            locality=args.locality,
+            administrative_area=args.administrative_area,
+        )
+        print(f"[Veridra] [{sequence}/{len(queries)}] Opening Google Maps for: {query}")
+        provider.launch(start_url=build_start_url(query))
+        try:
+            if args.startup_wait_seconds:
+                time.sleep(args.startup_wait_seconds)
+            print("[Veridra] Collecting bounded market-enumeration evidence...")
+            try:
+                result = provider.collect_bounded(
+                    query_text=query,
+                    query_sequence=sequence,
+                    limits=limits,
+                )
+            except VisibleBrowserUnavailable as exc:
+                print(f"[Veridra] Collection failed for query {sequence}: {exc}")
+                print(
+                    "[Veridra] Complete any ordinary Google consent/sign-in/CAPTCHA in the "
+                    "persistent browser profile and rerun the market enumeration."
+                )
+                return 2
+            results.append(result)
+            reason = result.progress.stop_reason
+            print(
+                json.dumps(
+                    {
+                        "query_sequence": sequence,
+                        "query": query,
+                        "captured": len(result.observations),
+                        "stop_reason": reason.value if reason is not None else None,
+                    },
+                    ensure_ascii=False,
+                )
+            )
+        finally:
+            provider.stop()
+        if args.between_query_wait_seconds and sequence < len(queries):
+            time.sleep(args.between_query_wait_seconds)
+
+    enumeration = aggregate_market(results)
+    generated_at = datetime.now(UTC).isoformat()
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    args.output_directory.mkdir(parents=True, exist_ok=True)
+    output = args.output_directory / f"VERIDRA_MARKET_ENUMERATION_{stamp}.zip"
+
+    businesses = [_business_payload(item) for item in enumeration.businesses]
+    coverage = [
+        {
+            "query_text": item.query_text,
+            "query_sequence": item.query_sequence,
+            "captured": item.captured,
+            "new_unique": item.new_unique,
+            "duplicate_observations": item.duplicate_observations,
+            "stop_reason": item.stop_reason,
+        }
+        for item in enumeration.coverage
+    ]
+    website_count = sum(
+        1 for item in enumeration.businesses if item.business.website is not None
+    )
+    manifest = {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "plan": args.plan,
+        "query_count": len(queries),
+        "raw_observation_count": enumeration.raw_observation_count,
+        "unique_business_count": len(enumeration.businesses),
+        "website_observed_count": website_count,
+        "no_website_observed_count": len(enumeration.businesses) - website_count,
+        "dedupe_identity": "provider + provider_key; Google Maps provider key is based on canonical place identity where available",
+        "selection_rule": "No opportunity ranking is applied during enumeration; Google result rank is retained only as provenance.",
+        "coverage_rule": "Every configured query is executed unless collection fails; low marginal yield does not stop later queries.",
+        "persistence": "none",
+        "outreach": "none",
+    }
+
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", json.dumps(manifest, indent=2, ensure_ascii=False))
+        archive.writestr(
+            "market_businesses.json",
+            json.dumps(businesses, indent=2, ensure_ascii=False),
+        )
+        archive.writestr(
+            "query_coverage.json",
+            json.dumps(coverage, indent=2, ensure_ascii=False),
+        )
+        archive.writestr(
+            "README.md",
+            "# VERIDRA Market Enumeration Evidence\n\n"
+            "This pack aggregates multiple bounded Google Maps result sets into one deduplicated "
+            "local-market candidate set. Google result rank is provenance only and is not used as "
+            "VERIDRA's opportunity ranking. Every configured query is attempted independently. "
+            "No prospect state is mutated and no outreach is sent.\n",
+        )
+
+    print(
+        json.dumps(
+            {
+                "output": str(output),
+                "queries_run": len(queries),
+                "raw_observations": enumeration.raw_observation_count,
+                "unique_businesses": len(enumeration.businesses),
+                "websites_observed": website_count,
+                "no_websites_observed": len(enumeration.businesses) - website_count,
+                "persistence": "none",
+                "outreach": "none",
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/veridra/market_enumeration_cli.py
+++ b/src/veridra/market_enumeration_cli.py
@@ -150,9 +150,18 @@ def run(argv: Sequence[str] | None = None) -> int:
         "unique_business_count": len(enumeration.businesses),
         "website_observed_count": website_count,
         "no_website_observed_count": len(enumeration.businesses) - website_count,
-        "dedupe_identity": "provider + provider_key; Google Maps provider key is based on canonical place identity where available",
-        "selection_rule": "No opportunity ranking is applied during enumeration; Google result rank is retained only as provenance.",
-        "coverage_rule": "Every configured query is executed unless collection fails; low marginal yield does not stop later queries.",
+        "dedupe_identity": (
+            "provider + provider_key; Google Maps provider key is based on canonical "
+            "place identity where available"
+        ),
+        "selection_rule": (
+            "No opportunity ranking is applied during enumeration; Google result rank is "
+            "retained only as provenance."
+        ),
+        "coverage_rule": (
+            "Every configured query is executed unless collection fails; low marginal yield "
+            "does not stop later queries."
+        ),
         "persistence": "none",
         "outreach": "none",
     }

--- a/tests/test_market_enumeration.py
+++ b/tests/test_market_enumeration.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from veridra.assisted_discovery import (
+    TraversalObservation,
+    TraversalProgress,
+    TraversalResult,
+    TraversalStopReason,
+)
+from veridra.market_enumeration import aggregate_market, dublin_dentist_queries
+from veridra.prospect_discovery import ObservedBusiness
+
+
+def _business(*, key: str, name: str, website: str | None = None) -> ObservedBusiness:
+    return ObservedBusiness.model_validate(
+        {
+            "provider": "assisted-google-maps",
+            "provider_key": key,
+            "name": name,
+            "category": "Dentist",
+            "locality": "Dublin",
+            "administrative_area": "Dublin",
+            "country_code": "IE",
+            "website": website,
+            "source_url": f"https://www.google.com/maps/place/{name.replace(' ', '+')}",
+            "rating": 4.7,
+            "review_count": 42,
+            "profile_photo_signal_count": 2,
+            "observed_at": datetime.now(UTC),
+        }
+    )
+
+
+def _result(sequence: int, query: str, businesses: list[ObservedBusiness]) -> TraversalResult:
+    observations = tuple(
+        TraversalObservation(
+            business=business,
+            query_text=query,
+            query_sequence=sequence,
+            result_rank=index,
+            first_seen_scroll_step=0,
+        )
+        for index, business in enumerate(businesses, start=1)
+    )
+    return TraversalResult(
+        observations=observations,
+        progress=TraversalProgress(
+            query_text=query,
+            query_sequence=sequence,
+            scroll_step=3,
+            unique_results=len(observations),
+            stagnant_scrolls=0,
+            elapsed_seconds=5.0,
+            stop_reason=TraversalStopReason.end_of_list,
+        ),
+    )
+
+
+def test_market_aggregation_deduplicates_across_queries_and_keeps_provenance() -> None:
+    shared = _business(key="place-1", name="Shared Dental", website=None)
+    first_only = _business(key="place-2", name="First Dental", website="https://first.ie")
+    second_only = _business(key="place-3", name="Second Dental", website=None)
+
+    market = aggregate_market(
+        [
+            _result(1, "dentist in Dublin 1, IE", [shared, first_only]),
+            _result(2, "dentist in Dublin 2, IE", [shared, second_only]),
+        ]
+    )
+
+    assert market.raw_observation_count == 4
+    assert len(market.businesses) == 3
+    assert market.coverage[0].new_unique == 2
+    assert market.coverage[1].new_unique == 1
+    assert market.coverage[1].duplicate_observations == 1
+
+    shared_market = next(item for item in market.businesses if item.business.name == "Shared Dental")
+    assert shared_market.first_query_sequence == 1
+    assert shared_market.observation_count == 2
+    assert shared_market.seen_in_queries == (
+        "dentist in Dublin 1, IE",
+        "dentist in Dublin 2, IE",
+    )
+    assert shared_market.business.website is None
+
+
+def test_dublin_plan_runs_city_and_all_district_queries() -> None:
+    queries = dublin_dentist_queries()
+
+    assert "dentist in Dublin, IE" in queries
+    assert "dentist in Dublin 1, IE" in queries
+    assert "dentist in Dublin 24, IE" in queries
+    assert "dentist in Dublin 6W, IE" in queries
+    assert "dental clinic in Dublin, IE" in queries
+    assert len(queries) == len(set(queries))

--- a/tests/test_market_enumeration.py
+++ b/tests/test_market_enumeration.py
@@ -75,7 +75,9 @@ def test_market_aggregation_deduplicates_across_queries_and_keeps_provenance() -
     assert market.coverage[1].new_unique == 1
     assert market.coverage[1].duplicate_observations == 1
 
-    shared_market = next(item for item in market.businesses if item.business.name == "Shared Dental")
+    shared_market = next(
+        item for item in market.businesses if item.business.name == "Shared Dental"
+    )
     assert shared_market.first_query_sequence == 1
     assert shared_market.observation_count == 2
     assert shared_market.seen_in_queries == (


### PR DESCRIPTION
Implements a market-enumeration layer so Google ranking is used only as an enumeration surface, not as VERIDRA's candidate selector.

Changes:
- adds a Dublin dentists query plan covering the citywide query, Dublin 1-24, Dublin 6W, and several service/category variants;
- executes every configured query independently with existing bounded discovery safeguards;
- aggregates all observations and deduplicates globally by provider + provider_key / canonical Google place identity;
- preserves first-seen rank/query plus every query that rediscovered each business;
- emits per-query coverage: captured, new unique, duplicates and stop reason;
- does not stop later geographic queries based on low marginal yield;
- outputs a read-only VERIDRA_MARKET_ENUMERATION ZIP with no persistence or outreach;
- adds a Windows launcher and regression tests for cross-query deduplication and Dublin plan coverage.

This is intentionally pre-scoring infrastructure: opportunity ranking happens only after market enumeration.