### PR TITLE
Rank fully enriched market opportunities

### DIFF
--- a/VERIDRA_MARKET_OPPORTUNITIES.bat
+++ b/VERIDRA_MARKET_OPPORTUNITIES.bat
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+set "PYTHONPATH=%CD%\src;%PYTHONPATH%"
+set "VENV_PYTHON=%CD%\.venv\Scripts\python.exe"
+if not exist "%VENV_PYTHON%" (
+  echo [Veridra] Missing project virtual environment: %VENV_PYTHON%
+  exit /b 2
+)
+echo [Veridra] Ranking the latest fully enriched market evidence...
+"%VENV_PYTHON%" -m veridra.market_opportunity_cli --downloads "%USERPROFILE%\Downloads" --output-directory "%USERPROFILE%\Downloads"
+set EXITCODE=%ERRORLEVEL%
+if not "%EXITCODE%"=="0" echo [Veridra] Market opportunity ranking failed with exit code %EXITCODE%.
+exit /b %EXITCODE%

--- a/src/veridra/market_opportunity.py
+++ b/src/veridra/market_opportunity.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class MarketOpportunityBand(StrEnum):
+    priority = "priority"
+    high = "high"
+    medium = "medium"
+    low = "low"
+
+
+@dataclass(frozen=True, slots=True)
+class MarketBenchmarks:
+    review_q1: int
+    review_median: int
+    review_q3: int
+
+
+@dataclass(frozen=True, slots=True)
+class MarketOpportunityAssessment:
+    score: int
+    band: MarketOpportunityBand
+    digital_gap_score: int
+    activity_score: int
+    reasons: tuple[str, ...]
+
+
+def _quantile(sorted_values: list[int], fraction: float) -> int:
+    if not sorted_values:
+        return 0
+    index = round((len(sorted_values) - 1) * fraction)
+    return sorted_values[index]
+
+
+def review_benchmarks(review_counts: list[int]) -> MarketBenchmarks:
+    values = sorted(value for value in review_counts if value >= 0)
+    return MarketBenchmarks(
+        review_q1=_quantile(values, 0.25),
+        review_median=_quantile(values, 0.50),
+        review_q3=_quantile(values, 0.75),
+    )
+
+
+def _activity_score(review_count: int | None, benchmarks: MarketBenchmarks) -> tuple[int, str]:
+    if review_count is None:
+        return 0, "Google review activity was not available for comparison."
+    if review_count >= benchmarks.review_q3 and review_count > 0:
+        return 30, "Customer activity is in the top quartile of the observed market."
+    if review_count >= benchmarks.review_median and review_count > 0:
+        return 24, "Customer activity is at or above the observed market median."
+    if review_count >= benchmarks.review_q1 and review_count > 0:
+        return 16, "Customer activity is at or above the observed market lower quartile."
+    if review_count > 0:
+        return 8, "Some customer activity is visible, but it is below the market lower quartile."
+    return 0, "No Google review activity was observed."
+
+
+def assess_market_opportunity(
+    *,
+    website_url: str | None,
+    booking_links: tuple[str, ...],
+    rating: float | None,
+    review_count: int | None,
+    benchmarks: MarketBenchmarks,
+) -> MarketOpportunityAssessment:
+    """Score post-enrichment opportunity without treating weak reputation as a Webify problem."""
+
+    reasons: list[str] = []
+    gap = 0
+
+    if not website_url:
+        gap += 55
+        reasons.append("No official website was observed after GBP detail-page enrichment.")
+
+    if not booking_links:
+        gap += 10
+        reasons.append(
+            "No external booking or appointment action was observed on the public Google profile."
+        )
+    else:
+        reasons.append("A public Google booking or appointment action was observed.")
+
+    activity, activity_reason = _activity_score(review_count, benchmarks)
+    reasons.append(activity_reason)
+
+    if rating is not None and review_count and review_count >= 10:
+        if rating >= 4.5:
+            reasons.append(
+                "Strong rating supports the possibility of a healthy real-world business behind "
+                "the digital gap."
+            )
+        elif rating < 4.2:
+            reasons.append(
+                "Lower rating is treated as reputation context only and does not add opportunity "
+                "points."
+            )
+
+    score = min(100, gap + activity)
+    if not website_url and activity >= 16:
+        band = MarketOpportunityBand.priority
+    elif score >= 55 and activity >= 8:
+        band = MarketOpportunityBand.high
+    elif score >= 30:
+        band = MarketOpportunityBand.medium
+    else:
+        band = MarketOpportunityBand.low
+
+    return MarketOpportunityAssessment(
+        score=score,
+        band=band,
+        digital_gap_score=gap,
+        activity_score=activity,
+        reasons=tuple(reasons),
+    )

--- a/src/veridra/market_opportunity_cli.py
+++ b/src/veridra/market_opportunity_cli.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import zipfile
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .market_opportunity import assess_market_opportunity, review_benchmarks
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="veridra-market-opportunity")
+    parser.add_argument("--input", type=Path)
+    parser.add_argument("--downloads", type=Path, default=Path.home() / "Downloads")
+    parser.add_argument("--output-directory", type=Path, default=Path.home() / "Downloads")
+    return parser
+
+
+def _latest(directory: Path, pattern: str) -> Path | None:
+    matches = sorted(directory.glob(pattern), key=lambda item: item.stat().st_mtime, reverse=True)
+    return matches[0] if matches else None
+
+
+def _text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _strings(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str) and item.strip())
+
+
+def _load(path: Path) -> list[dict[str, object]]:
+    with zipfile.ZipFile(path) as archive:
+        raw = json.loads(archive.read("gbp_market_evidence.json"))
+    if not isinstance(raw, list):
+        raise ValueError("gbp_market_evidence.json must contain a list.")
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def _csv_bytes(rows: list[dict[str, object]]) -> bytes:
+    buffer = io.StringIO(newline="")
+    fields = (
+        "rank",
+        "business_name",
+        "score",
+        "band",
+        "digital_gap_score",
+        "activity_score",
+        "rating",
+        "review_count",
+        "website_url",
+        "booking_link_count",
+        "first_query_text",
+        "first_result_rank",
+        "observation_count",
+        "reasons",
+    )
+    writer = csv.DictWriter(buffer, fieldnames=fields)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({field: row.get(field, "") for field in fields})
+    return buffer.getvalue().encode("utf-8")
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    input_path = args.input or _latest(args.downloads, "VERIDRA_GBP_MARKET_EVIDENCE_*.zip")
+    if input_path is None or not input_path.is_file():
+        raise FileNotFoundError("No VERIDRA GBP market-evidence ZIP was found.")
+
+    evidence = [row for row in _load(input_path) if row.get("collection_status") == "ok"]
+    if not evidence:
+        raise ValueError("The GBP market-evidence ZIP contains no successful observations.")
+
+    counts = [
+        count
+        for row in evidence
+        if (count := _integer(row.get("review_count"))) is not None
+    ]
+    benchmarks = review_benchmarks(counts)
+
+    ranked: list[dict[str, object]] = []
+    for row in evidence:
+        assessment = assess_market_opportunity(
+            website_url=_text(row.get("website_url")) or None,
+            booking_links=_strings(row.get("booking_links")),
+            rating=_number(row.get("rating")),
+            review_count=_integer(row.get("review_count")),
+            benchmarks=benchmarks,
+        )
+        ranked.append(
+            {
+                "business_name": _text(row.get("business_name")),
+                "score": assessment.score,
+                "band": assessment.band.value,
+                "digital_gap_score": assessment.digital_gap_score,
+                "activity_score": assessment.activity_score,
+                "rating": _number(row.get("rating")),
+                "review_count": _integer(row.get("review_count")),
+                "website_url": _text(row.get("website_url")),
+                "booking_link_count": len(_strings(row.get("booking_links"))),
+                "first_query_text": _text(row.get("first_query_text")),
+                "first_result_rank": row.get("first_result_rank"),
+                "seen_in_queries": row.get("seen_in_queries"),
+                "observation_count": row.get("observation_count"),
+                "provider_key": row.get("provider_key"),
+                "source_url": row.get("source_url"),
+                "reasons": list(assessment.reasons),
+            }
+        )
+
+    ranked.sort(
+        key=lambda row: (
+            -int(row["score"]),
+            -(_integer(row.get("review_count")) or 0),
+            _text(row.get("business_name")).casefold(),
+        )
+    )
+    for index, row in enumerate(ranked, start=1):
+        row["rank"] = index
+        row["reasons_text"] = " | ".join(_strings(row.get("reasons")))
+        row["reasons"] = row["reasons_text"]
+
+    priority = sum(1 for row in ranked if row.get("band") == "priority")
+    high = sum(1 for row in ranked if row.get("band") == "high")
+    medium = sum(1 for row in ranked if row.get("band") == "medium")
+    low = sum(1 for row in ranked if row.get("band") == "low")
+
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    args.output_directory.mkdir(parents=True, exist_ok=True)
+    output = args.output_directory / f"VERIDRA_MARKET_OPPORTUNITIES_{stamp}.zip"
+    manifest = {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "source_gbp_market_evidence": input_path.name,
+        "businesses_ranked": len(ranked),
+        "priority": priority,
+        "high": high,
+        "medium": medium,
+        "low": low,
+        "review_benchmarks": {
+            "q1": benchmarks.review_q1,
+            "median": benchmarks.review_median,
+            "q3": benchmarks.review_q3,
+        },
+        "scoring_rule": (
+            "Ranking occurs only after full-market GBP enrichment. Confirmed website absence and "
+            "observed booking-action absence are digital-gap signals; review volume is used only "
+            "as market-relative customer-activity evidence. Rating does not add negative-gap points."
+        ),
+        "photo_rule": "Raw Google Maps photo-control counts are not scored.",
+        "persistence": "none",
+        "outreach": "none",
+    }
+
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("manifest.json", json.dumps(manifest, indent=2, ensure_ascii=False))
+        archive.writestr(
+            "ranked_opportunities.json",
+            json.dumps(ranked, indent=2, ensure_ascii=False),
+        )
+        archive.writestr("ranked_opportunities.csv", _csv_bytes(ranked))
+        archive.writestr(
+            "README.md",
+            "# VERIDRA Market Opportunities\n\n"
+            "Post-enrichment market triage. The ranking is applied only after the deduplicated "
+            "market has been enriched with public GBP evidence. Missing website is treated as a "
+            "strong digital gap only after the GBP detail-page pass. Review volume is market-relative "
+            "activity evidence, not a weakness score. Raw photo controls are not scored. No prospect "
+            "state is mutated and no outreach is sent.\n",
+        )
+
+    top = [
+        {
+            "rank": row["rank"],
+            "business": row["business_name"],
+            "score": row["score"],
+            "band": row["band"],
+            "reviews": row["review_count"],
+            "website": bool(row["website_url"]),
+            "booking_links": row["booking_link_count"],
+        }
+        for row in ranked[:20]
+    ]
+    print(
+        json.dumps(
+            {
+                "input": str(input_path),
+                "output": str(output),
+                "businesses_ranked": len(ranked),
+                "bands": {
+                    "priority": priority,
+                    "high": high,
+                    "medium": medium,
+                    "low": low,
+                },
+                "review_benchmarks": manifest["review_benchmarks"],
+                "top_20": top,
+                "persistence": "none",
+                "outreach": "none",
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/veridra/market_opportunity_cli.py
+++ b/src/veridra/market_opportunity_cli.py
@@ -164,7 +164,8 @@ def run(argv: Sequence[str] | None = None) -> int:
         "scoring_rule": (
             "Ranking occurs only after full-market GBP enrichment. Confirmed website absence and "
             "observed booking-action absence are digital-gap signals; review volume is used only "
-            "as market-relative customer-activity evidence. Rating does not add negative-gap points."
+            "as market-relative customer-activity evidence. Rating does not add negative-gap "
+            "points."
         ),
         "photo_rule": "Raw Google Maps photo-control counts are not scored.",
         "persistence": "none",
@@ -183,9 +184,9 @@ def run(argv: Sequence[str] | None = None) -> int:
             "# VERIDRA Market Opportunities\n\n"
             "Post-enrichment market triage. The ranking is applied only after the deduplicated "
             "market has been enriched with public GBP evidence. Missing website is treated as a "
-            "strong digital gap only after the GBP detail-page pass. Review volume is market-relative "
-            "activity evidence, not a weakness score. Raw photo controls are not scored. No prospect "
-            "state is mutated and no outreach is sent.\n",
+            "strong digital gap only after the GBP detail-page pass. Review volume is "
+            "market-relative activity evidence, not a weakness score. Raw photo controls are not "
+            "scored. No prospect state is mutated and no outreach is sent.\n",
         )
 
     top = [

--- a/src/veridra/market_opportunity_cli.py
+++ b/src/veridra/market_opportunity_cli.py
@@ -129,7 +129,7 @@ def run(argv: Sequence[str] | None = None) -> int:
 
     ranked.sort(
         key=lambda row: (
-            -int(row["score"]),
+            -(_integer(row.get("score")) or 0),
             -(_integer(row.get("review_count")) or 0),
             _text(row.get("business_name")).casefold(),
         )

--- a/tests/test_market_opportunity.py
+++ b/tests/test_market_opportunity.py
@@ -43,7 +43,7 @@ def test_no_website_without_activity_is_not_priority() -> None:
         benchmarks=benchmarks,
     )
 
-    assert result.band is MarketOpportunityBand.high
+    assert result.band is MarketOpportunityBand.medium
     assert result.activity_score == 0
 
 

--- a/tests/test_market_opportunity.py
+++ b/tests/test_market_opportunity.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from veridra.market_opportunity import (
+    MarketOpportunityBand,
+    assess_market_opportunity,
+    review_benchmarks,
+)
+
+
+def test_review_benchmarks_are_market_relative() -> None:
+    benchmarks = review_benchmarks([5, 10, 20, 40, 80])
+
+    assert benchmarks.review_q1 == 10
+    assert benchmarks.review_median == 20
+    assert benchmarks.review_q3 == 40
+
+
+def test_no_website_with_healthy_activity_is_priority() -> None:
+    benchmarks = review_benchmarks([10, 20, 40, 80])
+
+    result = assess_market_opportunity(
+        website_url=None,
+        booking_links=(),
+        rating=4.8,
+        review_count=40,
+        benchmarks=benchmarks,
+    )
+
+    assert result.band is MarketOpportunityBand.priority
+    assert result.digital_gap_score == 65
+    assert result.activity_score >= 16
+    assert result.score >= 81
+
+
+def test_no_website_without_activity_is_not_priority() -> None:
+    benchmarks = review_benchmarks([10, 20, 40, 80])
+
+    result = assess_market_opportunity(
+        website_url=None,
+        booking_links=(),
+        rating=None,
+        review_count=0,
+        benchmarks=benchmarks,
+    )
+
+    assert result.band is MarketOpportunityBand.high
+    assert result.activity_score == 0
+
+
+def test_mature_website_with_booking_stays_low_even_with_strong_activity() -> None:
+    benchmarks = review_benchmarks([10, 20, 40, 80])
+
+    result = assess_market_opportunity(
+        website_url="https://clinic.example",
+        booking_links=("https://booking.example/clinic",),
+        rating=4.9,
+        review_count=80,
+        benchmarks=benchmarks,
+    )
+
+    assert result.digital_gap_score == 0
+    assert result.activity_score == 30
+    assert result.band is MarketOpportunityBand.medium
+
+
+def test_missing_booking_action_is_only_a_modest_gap() -> None:
+    benchmarks = review_benchmarks([10, 20, 40, 80])
+
+    result = assess_market_opportunity(
+        website_url="https://clinic.example",
+        booking_links=(),
+        rating=4.9,
+        review_count=80,
+        benchmarks=benchmarks,
+    )
+
+    assert result.digital_gap_score == 10
+    assert result.score == 40
+    assert result.band is MarketOpportunityBand.medium


### PR DESCRIPTION
Adds conservative post-enrichment market opportunity ranking for the fully enumerated Dublin dental market.

Changes:
- ranks only after GBP market enrichment; Google result rank remains provenance only;
- treats confirmed no-website state after GBP detail-page enrichment as the strongest digital-gap signal;
- treats absence of an observed GBP booking/appointment action as a modest gap, not proof that online booking is impossible;
- uses review volume only as market-relative customer-activity evidence via cohort quartiles;
- rating is context only and never creates negative-gap opportunity points;
- explicitly does not score raw Google photo-control counts because live evidence showed those mix UI/reviewer/owner signals;
- prevents inactive no-site businesses from becoming priority without customer-activity evidence;
- emits ranked JSON + CSV + manifest and prints a top-20 summary;
- adds a Windows launcher and regression tests.

No persistence or outreach is performed.