### PR TITLE
Guard market ranking with website verification

### DIFF
--- a/src/veridra/market_opportunity.py
+++ b/src/veridra/market_opportunity.py
@@ -24,6 +24,7 @@ class MarketOpportunityAssessment:
     band: MarketOpportunityBand
     digital_gap_score: int
     activity_score: int
+    website_verification_required: bool
     reasons: tuple[str, ...]
 
 
@@ -60,19 +61,28 @@ def _activity_score(review_count: int | None, benchmarks: MarketBenchmarks) -> t
 def assess_market_opportunity(
     *,
     website_url: str | None,
+    website_absence_verified: bool = False,
     booking_links: tuple[str, ...],
     rating: float | None,
     review_count: int | None,
     benchmarks: MarketBenchmarks,
 ) -> MarketOpportunityAssessment:
-    """Score post-enrichment opportunity without treating weak reputation as a Webify problem."""
+    """Score post-enrichment opportunity without overstating unverified website absence."""
 
     reasons: list[str] = []
     gap = 0
+    website_verification_required = False
 
     if not website_url:
-        gap += 55
-        reasons.append("No official website was observed after GBP detail-page enrichment.")
+        if website_absence_verified:
+            gap += 55
+            reasons.append("Website absence was independently verified.")
+        else:
+            gap += 15
+            website_verification_required = True
+            reasons.append(
+                "No official website was observed in Maps/GBP; independent verification is required."
+            )
 
     if not booking_links:
         gap += 10
@@ -85,22 +95,25 @@ def assess_market_opportunity(
     activity, activity_reason = _activity_score(review_count, benchmarks)
     reasons.append(activity_reason)
 
+    low_reputation_guard = bool(
+        rating is not None and review_count is not None and review_count >= 10 and rating < 4.2
+    )
     if rating is not None and review_count and review_count >= 10:
         if rating >= 4.5:
             reasons.append(
                 "Strong rating supports the possibility of a healthy real-world business behind "
                 "the digital gap."
             )
-        elif rating < 4.2:
+        elif low_reputation_guard:
             reasons.append(
-                "Lower rating is treated as reputation context only and does not add opportunity "
-                "points."
+                "Established low rating is a reputation-health warning; Priority is blocked because "
+                "the problem may not be primarily digital."
             )
 
     score = min(100, gap + activity)
-    if not website_url and activity >= 16:
+    if website_absence_verified and activity >= 16 and not low_reputation_guard:
         band = MarketOpportunityBand.priority
-    elif score >= 55 and activity >= 8:
+    elif score >= 55 and activity >= 8 and not low_reputation_guard:
         band = MarketOpportunityBand.high
     elif score >= 30:
         band = MarketOpportunityBand.medium
@@ -112,5 +125,6 @@ def assess_market_opportunity(
         band=band,
         digital_gap_score=gap,
         activity_score=activity,
+        website_verification_required=website_verification_required,
         reasons=tuple(reasons),
     )

--- a/src/veridra/market_opportunity.py
+++ b/src/veridra/market_opportunity.py
@@ -81,7 +81,8 @@ def assess_market_opportunity(
             gap += 15
             website_verification_required = True
             reasons.append(
-                "No official website was observed in Maps/GBP; independent verification is required."
+                "No official website was observed in Maps/GBP; independent verification "
+                "is required."
             )
 
     if not booking_links:
@@ -106,8 +107,8 @@ def assess_market_opportunity(
             )
         elif low_reputation_guard:
             reasons.append(
-                "Established low rating is a reputation-health warning; Priority is blocked because "
-                "the problem may not be primarily digital."
+                "Established low rating is a reputation-health warning; Priority is blocked "
+                "because the problem may not be primarily digital."
             )
 
     score = min(100, gap + activity)

--- a/src/veridra/market_opportunity_cli.py
+++ b/src/veridra/market_opportunity_cli.py
@@ -170,7 +170,8 @@ def run(argv: Sequence[str] | None = None) -> int:
         "scoring_rule": (
             "Maps/GBP website absence is treated as an unverified signal, not proof of no website. "
             "Independent website verification is required before the full no-website opportunity "
-            "boost or Priority status can apply. Review volume is market-relative activity evidence."
+            "boost or Priority status can apply. Review volume is market-relative activity "
+            "evidence."
         ),
         "reputation_rule": (
             "An established rating below 4.2 blocks Priority because the business may have a "

--- a/src/veridra/market_opportunity_cli.py
+++ b/src/veridra/market_opportunity_cli.py
@@ -64,6 +64,7 @@ def _csv_bytes(rows: list[dict[str, object]]) -> bytes:
         "band",
         "digital_gap_score",
         "activity_score",
+        "website_verification_required",
         "rating",
         "review_count",
         "website_url",
@@ -113,6 +114,7 @@ def run(argv: Sequence[str] | None = None) -> int:
                 "band": assessment.band.value,
                 "digital_gap_score": assessment.digital_gap_score,
                 "activity_score": assessment.activity_score,
+                "website_verification_required": assessment.website_verification_required,
                 "rating": _number(row.get("rating")),
                 "review_count": _integer(row.get("review_count")),
                 "website_url": _text(row.get("website_url")),
@@ -143,12 +145,15 @@ def run(argv: Sequence[str] | None = None) -> int:
     high = sum(1 for row in ranked if row.get("band") == "high")
     medium = sum(1 for row in ranked if row.get("band") == "medium")
     low = sum(1 for row in ranked if row.get("band") == "low")
+    verification_required = sum(
+        1 for row in ranked if row.get("website_verification_required") is True
+    )
 
     stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     args.output_directory.mkdir(parents=True, exist_ok=True)
     output = args.output_directory / f"VERIDRA_MARKET_OPPORTUNITIES_{stamp}.zip"
     manifest = {
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_at": datetime.now(UTC).isoformat(),
         "source_gbp_market_evidence": input_path.name,
         "businesses_ranked": len(ranked),
@@ -156,16 +161,20 @@ def run(argv: Sequence[str] | None = None) -> int:
         "high": high,
         "medium": medium,
         "low": low,
+        "website_verification_required": verification_required,
         "review_benchmarks": {
             "q1": benchmarks.review_q1,
             "median": benchmarks.review_median,
             "q3": benchmarks.review_q3,
         },
         "scoring_rule": (
-            "Ranking occurs only after full-market GBP enrichment. Confirmed website absence and "
-            "observed booking-action absence are digital-gap signals; review volume is used only "
-            "as market-relative customer-activity evidence. Rating does not add negative-gap "
-            "points."
+            "Maps/GBP website absence is treated as an unverified signal, not proof of no website. "
+            "Independent website verification is required before the full no-website opportunity "
+            "boost or Priority status can apply. Review volume is market-relative activity evidence."
+        ),
+        "reputation_rule": (
+            "An established rating below 4.2 blocks Priority because the business may have a "
+            "non-digital reputation problem that Webify cannot solve by itself."
         ),
         "photo_rule": "Raw Google Maps photo-control counts are not scored.",
         "persistence": "none",
@@ -182,11 +191,11 @@ def run(argv: Sequence[str] | None = None) -> int:
         archive.writestr(
             "README.md",
             "# VERIDRA Market Opportunities\n\n"
-            "Post-enrichment market triage. The ranking is applied only after the deduplicated "
-            "market has been enriched with public GBP evidence. Missing website is treated as a "
-            "strong digital gap only after the GBP detail-page pass. Review volume is "
-            "market-relative activity evidence, not a weakness score. Raw photo controls are not "
-            "scored. No prospect state is mutated and no outreach is sent.\n",
+            "Post-enrichment market triage. A website not observed in Google Maps or GBP remains "
+            "unverified until an independent web check confirms absence. Such rows are flagged for "
+            "verification and cannot become Priority automatically. Established low ratings also "
+            "block Priority because they may indicate a non-digital business problem. No prospect "
+            "state is mutated and no outreach is sent.\n",
         )
 
     top = [
@@ -197,6 +206,7 @@ def run(argv: Sequence[str] | None = None) -> int:
             "band": row["band"],
             "reviews": row["review_count"],
             "website": bool(row["website_url"]),
+            "website_verification_required": row["website_verification_required"],
             "booking_links": row["booking_link_count"],
         }
         for row in ranked[:20]
@@ -213,6 +223,7 @@ def run(argv: Sequence[str] | None = None) -> int:
                     "medium": medium,
                     "low": low,
                 },
+                "website_verification_required": verification_required,
                 "review_benchmarks": manifest["review_benchmarks"],
                 "top_20": top,
                 "persistence": "none",

--- a/tests/test_market_opportunity.py
+++ b/tests/test_market_opportunity.py
@@ -15,7 +15,25 @@ def test_review_benchmarks_are_market_relative() -> None:
     assert benchmarks.review_q3 == 40
 
 
-def test_no_website_with_healthy_activity_is_priority() -> None:
+def test_verified_no_website_with_healthy_activity_is_priority() -> None:
+    benchmarks = review_benchmarks([10, 20, 40, 80])
+
+    result = assess_market_opportunity(
+        website_url=None,
+        website_absence_verified=True,
+        booking_links=(),
+        rating=4.8,
+        review_count=40,
+        benchmarks=benchmarks,
+    )
+
+    assert result.band is MarketOpportunityBand.priority
+    assert result.digital_gap_score == 65
+    assert result.activity_score >= 16
+    assert result.website_verification_required is False
+
+
+def test_unverified_maps_website_absence_is_not_priority() -> None:
     benchmarks = review_benchmarks([10, 20, 40, 80])
 
     result = assess_market_opportunity(
@@ -26,10 +44,9 @@ def test_no_website_with_healthy_activity_is_priority() -> None:
         benchmarks=benchmarks,
     )
 
-    assert result.band is MarketOpportunityBand.priority
-    assert result.digital_gap_score == 65
-    assert result.activity_score >= 16
-    assert result.score >= 81
+    assert result.band is MarketOpportunityBand.medium
+    assert result.digital_gap_score == 25
+    assert result.website_verification_required is True
 
 
 def test_no_website_without_activity_is_not_priority() -> None:
@@ -37,6 +54,7 @@ def test_no_website_without_activity_is_not_priority() -> None:
 
     result = assess_market_opportunity(
         website_url=None,
+        website_absence_verified=True,
         booking_links=(),
         rating=None,
         review_count=0,
@@ -45,6 +63,23 @@ def test_no_website_without_activity_is_not_priority() -> None:
 
     assert result.band is MarketOpportunityBand.medium
     assert result.activity_score == 0
+
+
+def test_low_reputation_blocks_priority_even_when_no_website_is_verified() -> None:
+    benchmarks = review_benchmarks([10, 20, 40, 80])
+
+    result = assess_market_opportunity(
+        website_url=None,
+        website_absence_verified=True,
+        booking_links=(),
+        rating=3.6,
+        review_count=80,
+        benchmarks=benchmarks,
+    )
+
+    assert result.band is MarketOpportunityBand.medium
+    assert result.score == 95
+    assert any("Priority is blocked" in reason for reason in result.reasons)
 
 
 def test_mature_website_with_booking_stays_low_even_with_strong_activity() -> None:

--- a/tests/test_market_opportunity.py
+++ b/tests/test_market_opportunity.py
@@ -44,7 +44,7 @@ def test_unverified_maps_website_absence_is_not_priority() -> None:
         benchmarks=benchmarks,
     )
 
-    assert result.band is MarketOpportunityBand.medium
+    assert result.band is MarketOpportunityBand.high
     assert result.digital_gap_score == 25
     assert result.website_verification_required is True
 


### PR DESCRIPTION
Corrects two issues found during external verification of the first 236-business market ranking.

Changes:
- Maps/GBP website absence is now treated as unverified rather than proof of no website;
- unverified absence gets only a modest provisional gap and is flagged for independent verification;
- full no-website boost and Priority require verified absence;
- established rating below 4.2 blocks Priority because reputation problems may not be Webify-fixable;
- CLI/CSV/manifest expose website_verification_required;
- tests cover verified absence, unverified absence, low-reputation guard, and existing booking/activity behavior.

No persistence or outreach.