### PR TITLE
Apply independent website verification to market ranking

### DIFF
--- a/src/veridra/market_opportunity_cli.py
+++ b/src/veridra/market_opportunity_cli.py
@@ -10,11 +10,16 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from .market_opportunity import assess_market_opportunity, review_benchmarks
+from .website_verification import (
+    WebsiteVerificationStatus,
+    load_website_verifications,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="veridra-market-opportunity")
     parser.add_argument("--input", type=Path)
+    parser.add_argument("--website-verifications", type=Path)
     parser.add_argument("--downloads", type=Path, default=Path.home() / "Downloads")
     parser.add_argument("--output-directory", type=Path, default=Path.home() / "Downloads")
     return parser
@@ -65,6 +70,7 @@ def _csv_bytes(rows: list[dict[str, object]]) -> bytes:
         "digital_gap_score",
         "activity_score",
         "website_verification_required",
+        "website_verification_status",
         "rating",
         "review_count",
         "website_url",
@@ -87,6 +93,15 @@ def run(argv: Sequence[str] | None = None) -> int:
     if input_path is None or not input_path.is_file():
         raise FileNotFoundError("No VERIDRA GBP market-evidence ZIP was found.")
 
+    verification_path = args.website_verifications or _latest(
+        args.downloads, "VERIDRA_WEBSITE_VERIFICATIONS_*.json"
+    )
+    verifications = (
+        load_website_verifications(verification_path)
+        if verification_path is not None and verification_path.is_file()
+        else {}
+    )
+
     evidence = [row for row in _load(input_path) if row.get("collection_status") == "ok"]
     if not evidence:
         raise ValueError("The GBP market-evidence ZIP contains no successful observations.")
@@ -99,9 +114,29 @@ def run(argv: Sequence[str] | None = None) -> int:
     benchmarks = review_benchmarks(counts)
 
     ranked: list[dict[str, object]] = []
+    applied_verifications = 0
     for row in evidence:
+        business_name = _text(row.get("business_name"))
+        website_url = _text(row.get("website_url")) or None
+        verification = verifications.get(business_name.casefold())
+        website_absence_verified = False
+        verification_status = ""
+        verification_evidence_urls: tuple[str, ...] = ()
+        verification_note = ""
+        if verification is not None:
+            applied_verifications += 1
+            verification_status = verification.status.value
+            verification_evidence_urls = verification.evidence_urls
+            verification_note = verification.note or ""
+            if verification.status is WebsiteVerificationStatus.website_found:
+                website_url = verification.website_url
+            elif verification.status is WebsiteVerificationStatus.absence_verified:
+                website_url = None
+                website_absence_verified = True
+
         assessment = assess_market_opportunity(
-            website_url=_text(row.get("website_url")) or None,
+            website_url=website_url,
+            website_absence_verified=website_absence_verified,
             booking_links=_strings(row.get("booking_links")),
             rating=_number(row.get("rating")),
             review_count=_integer(row.get("review_count")),
@@ -109,15 +144,18 @@ def run(argv: Sequence[str] | None = None) -> int:
         )
         ranked.append(
             {
-                "business_name": _text(row.get("business_name")),
+                "business_name": business_name,
                 "score": assessment.score,
                 "band": assessment.band.value,
                 "digital_gap_score": assessment.digital_gap_score,
                 "activity_score": assessment.activity_score,
                 "website_verification_required": assessment.website_verification_required,
+                "website_verification_status": verification_status,
+                "website_verification_evidence_urls": list(verification_evidence_urls),
+                "website_verification_note": verification_note,
                 "rating": _number(row.get("rating")),
                 "review_count": _integer(row.get("review_count")),
-                "website_url": _text(row.get("website_url")),
+                "website_url": website_url or "",
                 "booking_link_count": len(_strings(row.get("booking_links"))),
                 "first_query_text": _text(row.get("first_query_text")),
                 "first_result_rank": row.get("first_result_rank"),
@@ -153,9 +191,11 @@ def run(argv: Sequence[str] | None = None) -> int:
     args.output_directory.mkdir(parents=True, exist_ok=True)
     output = args.output_directory / f"VERIDRA_MARKET_OPPORTUNITIES_{stamp}.zip"
     manifest = {
-        "schema_version": 2,
+        "schema_version": 3,
         "generated_at": datetime.now(UTC).isoformat(),
         "source_gbp_market_evidence": input_path.name,
+        "source_website_verifications": verification_path.name if verification_path else None,
+        "website_verifications_applied": applied_verifications,
         "businesses_ranked": len(ranked),
         "priority": priority,
         "high": high,
@@ -168,10 +208,9 @@ def run(argv: Sequence[str] | None = None) -> int:
             "q3": benchmarks.review_q3,
         },
         "scoring_rule": (
-            "Maps/GBP website absence is treated as an unverified signal, not proof of no website. "
-            "Independent website verification is required before the full no-website opportunity "
-            "boost or Priority status can apply. Review volume is market-relative activity "
-            "evidence."
+            "Maps/GBP website absence is treated as unverified. Independent website verification "
+            "may either supply a website URL or explicitly verify absence before the full no-site "
+            "boost can apply. Review volume is market-relative activity evidence."
         ),
         "reputation_rule": (
             "An established rating below 4.2 blocks Priority because the business may have a "
@@ -192,11 +231,10 @@ def run(argv: Sequence[str] | None = None) -> int:
         archive.writestr(
             "README.md",
             "# VERIDRA Market Opportunities\n\n"
-            "Post-enrichment market triage. A website not observed in Google Maps or GBP remains "
-            "unverified until an independent web check confirms absence. Such rows are flagged for "
-            "verification and cannot become Priority automatically. Established low ratings also "
-            "block Priority because they may indicate a non-digital business problem. No prospect "
-            "state is mutated and no outreach is sent.\n",
+            "Post-enrichment market triage with optional independent website verification. "
+            "Maps/GBP absence alone remains unverified. A verification file may supply a found "
+            "website, verify absence, or record an inconclusive check. No prospect state is "
+            "mutated and no outreach is sent.\n",
         )
 
     top = [
@@ -208,6 +246,7 @@ def run(argv: Sequence[str] | None = None) -> int:
             "reviews": row["review_count"],
             "website": bool(row["website_url"]),
             "website_verification_required": row["website_verification_required"],
+            "website_verification_status": row["website_verification_status"],
             "booking_links": row["booking_link_count"],
         }
         for row in ranked[:20]
@@ -216,6 +255,8 @@ def run(argv: Sequence[str] | None = None) -> int:
         json.dumps(
             {
                 "input": str(input_path),
+                "website_verifications": str(verification_path) if verification_path else None,
+                "website_verifications_applied": applied_verifications,
                 "output": str(output),
                 "businesses_ranked": len(ranked),
                 "bands": {

--- a/src/veridra/website_verification.py
+++ b/src/veridra/website_verification.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+
+class WebsiteVerificationStatus(StrEnum):
+    website_found = "website_found"
+    absence_verified = "absence_verified"
+    inconclusive = "inconclusive"
+
+
+@dataclass(frozen=True, slots=True)
+class WebsiteVerification:
+    business_name: str
+    status: WebsiteVerificationStatus
+    website_url: str | None
+    evidence_urls: tuple[str, ...]
+    note: str | None
+
+
+def load_website_verifications(path: Path) -> dict[str, WebsiteVerification]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise ValueError("Website verification file must contain a JSON list.")
+
+    result: dict[str, WebsiteVerification] = {}
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("business_name")
+        status_raw = item.get("status")
+        if not isinstance(name, str) or not name.strip() or not isinstance(status_raw, str):
+            continue
+        try:
+            status = WebsiteVerificationStatus(status_raw)
+        except ValueError:
+            continue
+        website_url_raw = item.get("website_url")
+        website_url = website_url_raw.strip() if isinstance(website_url_raw, str) else None
+        urls_raw = item.get("evidence_urls")
+        evidence_urls = (
+            tuple(value.strip() for value in urls_raw if isinstance(value, str) and value.strip())
+            if isinstance(urls_raw, list)
+            else ()
+        )
+        note_raw = item.get("note")
+        note = note_raw.strip() if isinstance(note_raw, str) and note_raw.strip() else None
+
+        if status is WebsiteVerificationStatus.website_found and not website_url:
+            raise ValueError(f"website_found requires website_url for {name.strip()}")
+        if status is WebsiteVerificationStatus.absence_verified and website_url:
+            raise ValueError(f"absence_verified cannot include website_url for {name.strip()}")
+
+        result[name.strip().casefold()] = WebsiteVerification(
+            business_name=name.strip(),
+            status=status,
+            website_url=website_url,
+            evidence_urls=evidence_urls,
+            note=note,
+        )
+    return result

--- a/tests/test_website_verification.py
+++ b/tests/test_website_verification.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from veridra.website_verification import (
+    WebsiteVerificationStatus,
+    load_website_verifications,
+)
+
+
+def test_loads_found_absent_and_inconclusive_verifications(tmp_path: Path) -> None:
+    path = tmp_path / "verifications.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "business_name": "Found Dental",
+                    "status": "website_found",
+                    "website_url": "https://found.example",
+                    "evidence_urls": ["https://source.example/found"],
+                },
+                {
+                    "business_name": "Absent Dental",
+                    "status": "absence_verified",
+                    "evidence_urls": ["https://source.example/absent"],
+                    "note": "Independent check found no official site.",
+                },
+                {
+                    "business_name": "Maybe Dental",
+                    "status": "inconclusive",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = load_website_verifications(path)
+
+    assert result["found dental"].status is WebsiteVerificationStatus.website_found
+    assert result["found dental"].website_url == "https://found.example"
+    assert result["absent dental"].status is WebsiteVerificationStatus.absence_verified
+    assert result["absent dental"].website_url is None
+    assert result["maybe dental"].status is WebsiteVerificationStatus.inconclusive
+
+
+def test_website_found_requires_url(tmp_path: Path) -> None:
+    path = tmp_path / "verifications.json"
+    path.write_text(
+        json.dumps([{"business_name": "Found Dental", "status": "website_found"}]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="website_found requires website_url"):
+        load_website_verifications(path)
+
+
+def test_absence_verified_rejects_url(tmp_path: Path) -> None:
+    path = tmp_path / "verifications.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "business_name": "Absent Dental",
+                    "status": "absence_verified",
+                    "website_url": "https://should-not-exist.example",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="absence_verified cannot include website_url"):
+        load_website_verifications(path)


### PR DESCRIPTION
Adds a bounded independent website-verification layer to the 236-business market ranking.

Changes:
- new website verification evidence model with statuses: website_found, absence_verified, inconclusive;
- ranking optionally auto-loads the latest VERIDRA_WEBSITE_VERIFICATIONS_*.json from Downloads or accepts --website-verifications;
- verified website URLs override Maps/GBP misses;
- only explicitly verified absence can unlock the full no-site boost;
- verification provenance/status is preserved in ranked JSON/CSV/manifest/output;
- malformed verification states are rejected;
- no persistence or outreach.

This addresses false no-site positives such as Old Bawn Dental Practice and Crumlin Road Dental without rerunning market enumeration or GBP enrichment.