### PR TITLE
Gate market ranking by commercial eligibility

### DIFF
--- a/src/veridra/commercial_eligibility.py
+++ b/src/veridra/commercial_eligibility.py
@@ -20,6 +20,17 @@ class CommercialEligibility:
     evidence_urls: tuple[str, ...]
 
 
+def gate_opportunity_band(
+    band: str,
+    status: CommercialEligibilityStatus | None,
+) -> str:
+    if status is CommercialEligibilityStatus.ineligible:
+        return "low"
+    if status is CommercialEligibilityStatus.review_required and band in {"priority", "high"}:
+        return "medium"
+    return band
+
+
 def load_commercial_eligibility(path: Path) -> dict[str, CommercialEligibility]:
     raw = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(raw, list):

--- a/src/veridra/commercial_eligibility.py
+++ b/src/veridra/commercial_eligibility.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+
+class CommercialEligibilityStatus(StrEnum):
+    eligible = "eligible"
+    ineligible = "ineligible"
+    review_required = "review_required"
+
+
+@dataclass(frozen=True, slots=True)
+class CommercialEligibility:
+    business_name: str
+    status: CommercialEligibilityStatus
+    reason: str
+    evidence_urls: tuple[str, ...]
+
+
+def load_commercial_eligibility(path: Path) -> dict[str, CommercialEligibility]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise ValueError("Commercial eligibility file must contain a JSON list.")
+
+    result: dict[str, CommercialEligibility] = {}
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("business_name")
+        status_raw = item.get("status")
+        reason_raw = item.get("reason")
+        if (
+            not isinstance(name, str)
+            or not name.strip()
+            or not isinstance(status_raw, str)
+            or not isinstance(reason_raw, str)
+            or not reason_raw.strip()
+        ):
+            continue
+        try:
+            status = CommercialEligibilityStatus(status_raw)
+        except ValueError:
+            continue
+        urls_raw = item.get("evidence_urls")
+        evidence_urls = (
+            tuple(value.strip() for value in urls_raw if isinstance(value, str) and value.strip())
+            if isinstance(urls_raw, list)
+            else ()
+        )
+        result[name.strip().casefold()] = CommercialEligibility(
+            business_name=name.strip(),
+            status=status,
+            reason=reason_raw.strip(),
+            evidence_urls=evidence_urls,
+        )
+    return result

--- a/src/veridra/market_opportunity_cli.py
+++ b/src/veridra/market_opportunity_cli.py
@@ -9,6 +9,11 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 
+from .commercial_eligibility import (
+    CommercialEligibilityStatus,
+    gate_opportunity_band,
+    load_commercial_eligibility,
+)
 from .market_opportunity import assess_market_opportunity, review_benchmarks
 from .website_verification import (
     WebsiteVerificationStatus,
@@ -20,6 +25,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="veridra-market-opportunity")
     parser.add_argument("--input", type=Path)
     parser.add_argument("--website-verifications", type=Path)
+    parser.add_argument("--commercial-eligibility", type=Path)
     parser.add_argument("--downloads", type=Path, default=Path.home() / "Downloads")
     parser.add_argument("--output-directory", type=Path, default=Path.home() / "Downloads")
     return parser
@@ -60,6 +66,10 @@ def _load(path: Path) -> list[dict[str, object]]:
     return [item for item in raw if isinstance(item, dict)]
 
 
+def _band_order(value: object) -> int:
+    return {"priority": 0, "high": 1, "medium": 2, "low": 3}.get(_text(value), 4)
+
+
 def _csv_bytes(rows: list[dict[str, object]]) -> bytes:
     buffer = io.StringIO(newline="")
     fields = (
@@ -67,10 +77,14 @@ def _csv_bytes(rows: list[dict[str, object]]) -> bytes:
         "business_name",
         "score",
         "band",
+        "raw_band",
         "digital_gap_score",
         "activity_score",
         "website_verification_required",
         "website_verification_status",
+        "commercial_eligibility_status",
+        "commercial_eligibility_reason",
+        "outreach_eligible",
         "rating",
         "review_count",
         "website_url",
@@ -102,6 +116,15 @@ def run(argv: Sequence[str] | None = None) -> int:
         else {}
     )
 
+    eligibility_path = args.commercial_eligibility or _latest(
+        args.downloads, "VERIDRA_COMMERCIAL_ELIGIBILITY_*.json"
+    )
+    eligibility = (
+        load_commercial_eligibility(eligibility_path)
+        if eligibility_path is not None and eligibility_path.is_file()
+        else {}
+    )
+
     evidence = [row for row in _load(input_path) if row.get("collection_status") == "ok"]
     if not evidence:
         raise ValueError("The GBP market-evidence ZIP contains no successful observations.")
@@ -115,6 +138,7 @@ def run(argv: Sequence[str] | None = None) -> int:
 
     ranked: list[dict[str, object]] = []
     applied_verifications = 0
+    applied_eligibility = 0
     for row in evidence:
         business_name = _text(row.get("business_name"))
         website_url = _text(row.get("website_url")) or None
@@ -142,17 +166,52 @@ def run(argv: Sequence[str] | None = None) -> int:
             review_count=_integer(row.get("review_count")),
             benchmarks=benchmarks,
         )
+
+        commercial = eligibility.get(business_name.casefold())
+        commercial_status: CommercialEligibilityStatus | None = None
+        commercial_reason = ""
+        commercial_evidence_urls: tuple[str, ...] = ()
+        if commercial is not None:
+            applied_eligibility += 1
+            commercial_status = commercial.status
+            commercial_reason = commercial.reason
+            commercial_evidence_urls = commercial.evidence_urls
+
+        raw_band = assessment.band.value
+        band = gate_opportunity_band(raw_band, commercial_status)
+        outreach_eligible: bool | None
+        if commercial_status is CommercialEligibilityStatus.eligible:
+            outreach_eligible = True
+        elif commercial_status in {
+            CommercialEligibilityStatus.ineligible,
+            CommercialEligibilityStatus.review_required,
+        }:
+            outreach_eligible = False
+        else:
+            outreach_eligible = None
+
+        reasons = list(assessment.reasons)
+        if commercial_reason:
+            reasons.append(f"Commercial eligibility: {commercial_reason}")
+
         ranked.append(
             {
                 "business_name": business_name,
                 "score": assessment.score,
-                "band": assessment.band.value,
+                "band": band,
+                "raw_band": raw_band,
                 "digital_gap_score": assessment.digital_gap_score,
                 "activity_score": assessment.activity_score,
                 "website_verification_required": assessment.website_verification_required,
                 "website_verification_status": verification_status,
                 "website_verification_evidence_urls": list(verification_evidence_urls),
                 "website_verification_note": verification_note,
+                "commercial_eligibility_status": (
+                    commercial_status.value if commercial_status is not None else ""
+                ),
+                "commercial_eligibility_reason": commercial_reason,
+                "commercial_eligibility_evidence_urls": list(commercial_evidence_urls),
+                "outreach_eligible": outreach_eligible,
                 "rating": _number(row.get("rating")),
                 "review_count": _integer(row.get("review_count")),
                 "website_url": website_url or "",
@@ -163,12 +222,13 @@ def run(argv: Sequence[str] | None = None) -> int:
                 "observation_count": row.get("observation_count"),
                 "provider_key": row.get("provider_key"),
                 "source_url": row.get("source_url"),
-                "reasons": list(assessment.reasons),
+                "reasons": reasons,
             }
         )
 
     ranked.sort(
         key=lambda row: (
+            _band_order(row.get("band")),
             -(_integer(row.get("score")) or 0),
             -(_integer(row.get("review_count")) or 0),
             _text(row.get("business_name")).casefold(),
@@ -186,16 +246,26 @@ def run(argv: Sequence[str] | None = None) -> int:
     verification_required = sum(
         1 for row in ranked if row.get("website_verification_required") is True
     )
+    ineligible = sum(
+        1 for row in ranked if row.get("commercial_eligibility_status") == "ineligible"
+    )
+    eligibility_review = sum(
+        1 for row in ranked if row.get("commercial_eligibility_status") == "review_required"
+    )
 
     stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     args.output_directory.mkdir(parents=True, exist_ok=True)
     output = args.output_directory / f"VERIDRA_MARKET_OPPORTUNITIES_{stamp}.zip"
     manifest = {
-        "schema_version": 3,
+        "schema_version": 4,
         "generated_at": datetime.now(UTC).isoformat(),
         "source_gbp_market_evidence": input_path.name,
         "source_website_verifications": verification_path.name if verification_path else None,
         "website_verifications_applied": applied_verifications,
+        "source_commercial_eligibility": eligibility_path.name if eligibility_path else None,
+        "commercial_eligibility_applied": applied_eligibility,
+        "commercial_ineligible": ineligible,
+        "commercial_review_required": eligibility_review,
         "businesses_ranked": len(ranked),
         "priority": priority,
         "high": high,
@@ -211,6 +281,10 @@ def run(argv: Sequence[str] | None = None) -> int:
             "Maps/GBP website absence is treated as unverified. Independent website verification "
             "may either supply a website URL or explicitly verify absence before the full no-site "
             "boost can apply. Review volume is market-relative activity evidence."
+        ),
+        "commercial_rule": (
+            "Commercial eligibility is a separate gate. Ineligible businesses are forced to Low; "
+            "review-required businesses cannot remain Priority or High until resolved."
         ),
         "reputation_rule": (
             "An established rating below 4.2 blocks Priority because the business may have a "
@@ -231,10 +305,11 @@ def run(argv: Sequence[str] | None = None) -> int:
         archive.writestr(
             "README.md",
             "# VERIDRA Market Opportunities\n\n"
-            "Post-enrichment market triage with optional independent website verification. "
-            "Maps/GBP absence alone remains unverified. A verification file may supply a found "
-            "website, verify absence, or record an inconclusive check. No prospect state is "
-            "mutated and no outreach is sent.\n",
+            "Post-enrichment market triage with optional independent website verification and "
+            "commercial eligibility evidence. Maps/GBP absence alone remains unverified. Public, "
+            "closed, ambiguous, or otherwise non-buyable entities can be gated from outreach "
+            "without deleting their evidence. No prospect state is mutated and no outreach is "
+            "sent.\n",
         )
 
     top = [
@@ -247,6 +322,8 @@ def run(argv: Sequence[str] | None = None) -> int:
             "website": bool(row["website_url"]),
             "website_verification_required": row["website_verification_required"],
             "website_verification_status": row["website_verification_status"],
+            "commercial_eligibility_status": row["commercial_eligibility_status"],
+            "outreach_eligible": row["outreach_eligible"],
             "booking_links": row["booking_link_count"],
         }
         for row in ranked[:20]
@@ -257,6 +334,10 @@ def run(argv: Sequence[str] | None = None) -> int:
                 "input": str(input_path),
                 "website_verifications": str(verification_path) if verification_path else None,
                 "website_verifications_applied": applied_verifications,
+                "commercial_eligibility": str(eligibility_path) if eligibility_path else None,
+                "commercial_eligibility_applied": applied_eligibility,
+                "commercial_ineligible": ineligible,
+                "commercial_review_required": eligibility_review,
                 "output": str(output),
                 "businesses_ranked": len(ranked),
                 "bands": {

--- a/tests/test_commercial_eligibility.py
+++ b/tests/test_commercial_eligibility.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from veridra.commercial_eligibility import (
     CommercialEligibilityStatus,
@@ -36,7 +37,7 @@ def test_eligible_business_keeps_opportunity_band() -> None:
     assert gate_opportunity_band("high", CommercialEligibilityStatus.eligible) == "high"
 
 
-def test_loader_preserves_reason_and_evidence(tmp_path) -> None:
+def test_loader_preserves_reason_and_evidence(tmp_path: Path) -> None:
     path = tmp_path / "eligibility.json"
     path.write_text(
         json.dumps(
@@ -60,7 +61,7 @@ def test_loader_preserves_reason_and_evidence(tmp_path) -> None:
     assert item.evidence_urls == ("https://www.hse.ie/example",)
 
 
-def test_loader_rejects_non_list(tmp_path) -> None:
+def test_loader_rejects_non_list(tmp_path: Path) -> None:
     path = tmp_path / "eligibility.json"
     path.write_text("{}", encoding="utf-8")
 

--- a/tests/test_commercial_eligibility.py
+++ b/tests/test_commercial_eligibility.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+
+from veridra.commercial_eligibility import (
+    CommercialEligibilityStatus,
+    gate_opportunity_band,
+    load_commercial_eligibility,
+)
+
+
+def test_ineligible_business_is_forced_low() -> None:
+    assert (
+        gate_opportunity_band("priority", CommercialEligibilityStatus.ineligible)
+        == "low"
+    )
+
+
+def test_review_required_blocks_priority_and_high() -> None:
+    assert (
+        gate_opportunity_band("priority", CommercialEligibilityStatus.review_required)
+        == "medium"
+    )
+    assert (
+        gate_opportunity_band("high", CommercialEligibilityStatus.review_required)
+        == "medium"
+    )
+    assert (
+        gate_opportunity_band("medium", CommercialEligibilityStatus.review_required)
+        == "medium"
+    )
+
+
+def test_eligible_business_keeps_opportunity_band() -> None:
+    assert gate_opportunity_band("priority", CommercialEligibilityStatus.eligible) == "priority"
+    assert gate_opportunity_band("high", CommercialEligibilityStatus.eligible) == "high"
+
+
+def test_loader_preserves_reason_and_evidence(tmp_path) -> None:
+    path = tmp_path / "eligibility.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "business_name": "HSE Dental Clinic, Crumlin",
+                    "status": "ineligible",
+                    "reason": "Public HSE dental service, not a normal private-business prospect.",
+                    "evidence_urls": ["https://www.hse.ie/example"],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = load_commercial_eligibility(path)
+    item = result["hse dental clinic, crumlin"]
+
+    assert item.status is CommercialEligibilityStatus.ineligible
+    assert "Public HSE" in item.reason
+    assert item.evidence_urls == ("https://www.hse.ie/example",)
+
+
+def test_loader_rejects_non_list(tmp_path) -> None:
+    path = tmp_path / "eligibility.json"
+    path.write_text("{}", encoding="utf-8")
+
+    try:
+        load_commercial_eligibility(path)
+    except ValueError as exc:
+        assert "JSON list" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError")


### PR DESCRIPTION
Adds a separate commercial-eligibility layer to the post-enrichment market ranking.

Changes:
- new eligibility evidence model with statuses: eligible, ineligible, review_required;
- ranking auto-loads the latest VERIDRA_COMMERCIAL_ELIGIBILITY_*.json or accepts --commercial-eligibility;
- ineligible businesses are forced to Low without deleting evidence;
- review-required businesses cannot remain Priority/High until resolved;
- ranked JSON/CSV/manifest/output preserve eligibility status, reason, evidence URLs and outreach eligibility;
- ranking order now respects effective opportunity band before raw score;
- tests cover gating and loader behavior.

No persistence or outreach.