### PR TITLE
P0 customer record and onboarding foundation

### DIFF
--- a/src/veridra/agency_customer_web.py
+++ b/src/veridra/agency_customer_web.py
@@ -1,0 +1,170 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .agency_navigation import agency_navigation
+from .customer_store import CustomerOnboardingChecklist, CustomerRecord, CustomerStatus
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .request_security import require_request_identity
+from .tenant_customer_store import TenantCustomerStore, TenantCustomerStoreError
+
+router = APIRouter(prefix="/agency/customers", tags=["agency-customers"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1100px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.card{border:1px solid #dfe3e8;border-radius:9px;padding:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:110px}.check{display:flex;gap:9px;align-items:center;margin:12px 0}.check input{width:auto}.actions{display:flex;gap:8px;flex-wrap:wrap}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:760px){.cards,.row{grid-template-columns:1fr}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request, *, manage: bool = False) -> RequestIdentity:
+    identity = require_request_identity(request)
+    capability = TenantCapability.manage_projects if manage else TenantCapability.view_data
+    try:
+        require_tenant_capability(identity, capability)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _checked(values: dict[str, list[str]], name: str) -> bool:
+    return _one(values, name) == "on"
+
+
+def _progress(checklist: CustomerOnboardingChecklist) -> str:
+    completed = sum(
+        (
+            checklist.contact_confirmed,
+            checklist.scope_confirmed,
+            checklist.commercial_terms_confirmed,
+            checklist.access_requirements_confirmed,
+            checklist.kickoff_completed,
+        )
+    )
+    return f"{completed}/5"
+
+
+@router.get("", response_class=HTMLResponse)
+def customers(request: Request) -> str:
+    identity = _identity(request)
+    entries = TenantCustomerStore(_root(request)).list(identity)
+    cards = "".join(
+        "<article class='card'><p class='muted'>{status} · onboarding {progress}</p><h2>{name}</h2><p><strong>Website:</strong> {website}<br><strong>Offer:</strong> {offer}<br><strong>Projects:</strong> {projects}</p><a class='button' href='/agency/customers/{customer_id}'>Open customer</a></article>".format(
+            status=html.escape(customer.status.value.title()),
+            progress=html.escape(_progress(customer.onboarding)),
+            name=html.escape(customer.business_name),
+            website=html.escape(str(customer.website) if customer.website is not None else "No website yet"),
+            offer=html.escape(customer.offer_service or "Not recorded"),
+            projects=len(customer.project_ids),
+            customer_id=html.escape(customer_id, quote=True),
+        )
+        for customer_id, customer in entries
+    ) or "<p class='notice'>No customers yet. A won inbound lead or an outbound prospect marked Customer will create the first onboarding record.</p>"
+    body = f"{agency_navigation(identity, current='customers')}<section><h1>Customers</h1><p class='muted'>Won business relationships, onboarding state and linked delivery projects.</p></section><section><div class='cards'>{cards}</div></section>"
+    return _page("Customers", body)
+
+
+@router.get("/{customer_id}", response_class=HTMLResponse)
+def customer_detail(customer_id: str, request: Request) -> str:
+    identity = _identity(request)
+    store = TenantCustomerStore(_root(request))
+    try:
+        customer = store.load(identity, store.ref(identity, customer_id))
+    except TenantCustomerStoreError as exc:
+        raise HTTPException(status_code=404, detail="Customer not found.") from exc
+    source_href = (
+        f"/agency/leads/{customer.source_id}"
+        if customer.source_type.value == "lead"
+        else f"/agency/prospects/{customer.source_id}"
+        if customer.source_type.value == "prospect"
+        else ""
+    )
+    source_link = f"<a class='button secondary' href='{html.escape(source_href, quote=True)}'>Open source {html.escape(customer.source_type.value)}</a>" if source_href else ""
+    project_links = "".join(
+        f"<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}'>Open project {html.escape(project_id[:8])}</a>"
+        for project_id in customer.project_ids
+    ) or "<span class='muted'>No delivery project yet. This is valid for a no-website customer during onboarding.</span>"
+    status_options = "".join(
+        f"<option value='{item.value}'{' selected' if item is customer.status else ''}>{item.value.title()}</option>"
+        for item in CustomerStatus
+    )
+    checks = "".join(
+        f"<label class='check'><input type='checkbox' name='{name}'{' checked' if value else ''}>{html.escape(label)}</label>"
+        for name, label, value in (
+            ("contact_confirmed", "Primary contact confirmed", customer.onboarding.contact_confirmed),
+            ("scope_confirmed", "Service scope confirmed", customer.onboarding.scope_confirmed),
+            ("commercial_terms_confirmed", "Commercial terms confirmed", customer.onboarding.commercial_terms_confirmed),
+            ("access_requirements_confirmed", "Access/domain/hosting requirements confirmed", customer.onboarding.access_requirements_confirmed),
+            ("kickoff_completed", "Kickoff completed", customer.onboarding.kickoff_completed),
+        )
+    )
+    body = f"""{agency_navigation(identity, current='customers')}<section><p><a href='/agency/customers'>← Customers</a></p><h1>{html.escape(customer.business_name)}</h1><p><strong>Status:</strong> {html.escape(customer.status.value.title())}<br><strong>Contact:</strong> {html.escape(customer.contact_name or 'Not recorded')} · {html.escape(customer.contact_email or 'No email')} · {html.escape(customer.phone or 'No phone')}<br><strong>Website:</strong> {html.escape(str(customer.website) if customer.website is not None else 'No website yet')}<br><strong>Offer:</strong> {html.escape(customer.offer_service or 'Not recorded')}<br><strong>Quoted:</strong> {html.escape(f'{customer.currency} {customer.quoted_value}' if customer.quoted_value is not None else 'Not recorded')}<br><strong>Onboarding:</strong> {html.escape(_progress(customer.onboarding))}</p><div class='actions'>{source_link}{project_links}</div></section><section><h2>Customer onboarding</h2><p class='muted'>A customer cannot become Active until all five required onboarding checks are complete.</p><form method='post' action='/agency/customers/{html.escape(customer_id, quote=True)}'><div class='row'><div><label for='status'>Customer status</label><select id='status' name='status'>{status_options}</select></div><div><label for='commercial_notes'>Commercial / onboarding notes</label><textarea id='commercial_notes' name='commercial_notes' maxlength='5000'>{html.escape(customer.commercial_notes)}</textarea></div></div>{checks}<p><button type='submit'>Save customer</button></p></form></section>"""
+    return _page(customer.business_name, body)
+
+
+@router.post("/{customer_id}")
+async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
+    identity = _identity(request, manage=True)
+    store = TenantCustomerStore(_root(request))
+    try:
+        customer = store.load(identity, store.ref(identity, customer_id))
+    except TenantCustomerStoreError as exc:
+        raise HTTPException(status_code=404, detail="Customer not found.") from exc
+    values = _values(await request.body())
+    try:
+        next_status = CustomerStatus(_one(values, "status"))
+        checklist = CustomerOnboardingChecklist(
+            contact_confirmed=_checked(values, "contact_confirmed"),
+            scope_confirmed=_checked(values, "scope_confirmed"),
+            commercial_terms_confirmed=_checked(values, "commercial_terms_confirmed"),
+            access_requirements_confirmed=_checked(values, "access_requirements_confirmed"),
+            kickoff_completed=_checked(values, "kickoff_completed"),
+        )
+        activated_at = customer.activated_at
+        if next_status is CustomerStatus.active and activated_at is None:
+            activated_at = datetime.now(UTC)
+        updated = CustomerRecord.model_validate(
+            {
+                **customer.model_dump(mode="json"),
+                "status": next_status.value,
+                "onboarding": checklist.model_dump(mode="json"),
+                "commercial_notes": _one(values, "commercial_notes"),
+                "updated_at": datetime.now(UTC),
+                "activated_at": activated_at,
+            }
+        )
+        store.replace(identity, store.ref(identity, customer_id), updated)
+    except (ValueError, ValidationError, TenantCustomerStoreError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="Customer update is invalid. Complete onboarding before activation.",
+        ) from exc
+    return RedirectResponse(f"/agency/customers/{customer_id}", status_code=303)

--- a/src/veridra/agency_navigation.py
+++ b/src/veridra/agency_navigation.py
@@ -9,6 +9,7 @@ def agency_navigation(identity: RequestIdentity, *, current: str | None = None) 
     capabilities = TENANT_ROLE_CAPABILITIES[identity.membership_role]
     destinations: list[tuple[str, str, str]] = [
         ("home", "/agency", "Agency home"),
+        ("customers", "/agency/customers", "Customers"),
         ("projects", "/agency/projects", "Client projects"),
     ]
     if TenantCapability.manage_leads in capabilities:

--- a/src/veridra/customer_lifecycle.py
+++ b/src/veridra/customer_lifecycle.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from .customer_store import (
+    CustomerRecord,
+    CustomerSourceType,
+    customer_identifier,
+)
+from .identity_tenancy import RequestIdentity
+from .lead_store import AuditLead
+from .prospect import Prospect
+from .tenant_customer_store import TenantCustomerStore, TenantCustomerStoreError
+
+
+def _existing(
+    store: TenantCustomerStore,
+    identity: RequestIdentity,
+    source_type: CustomerSourceType,
+    source_id: str,
+) -> tuple[str, CustomerRecord | None]:
+    customer_id = customer_identifier(source_type, source_id)
+    try:
+        customer = store.load(identity, store.ref(identity, customer_id))
+    except TenantCustomerStoreError:
+        customer = None
+    return customer_id, customer
+
+
+def upsert_customer_from_lead(
+    store: TenantCustomerStore,
+    identity: RequestIdentity,
+    *,
+    lead_id: str,
+    lead: AuditLead,
+    project_id: str | None = None,
+) -> str:
+    customer_id, current = _existing(
+        store,
+        identity,
+        CustomerSourceType.lead,
+        lead_id,
+    )
+    projects = set(current.project_ids if current is not None else ())
+    if project_id:
+        projects.add(project_id)
+    created_at = current.created_at if current is not None else datetime.now(UTC)
+    customer = CustomerRecord(
+        business_name=lead.company or lead.name,
+        contact_name=lead.name,
+        contact_email=str(lead.email),
+        phone=lead.phone,
+        website=lead.website,
+        source_type=CustomerSourceType.lead,
+        source_id=lead_id,
+        project_ids=tuple(sorted(projects)),
+        offer_service=lead.offer_service,
+        quoted_value=lead.quoted_value,
+        currency=lead.currency,
+        commercial_notes=current.commercial_notes if current is not None else lead.notes,
+        status=current.status if current is not None else "onboarding",
+        onboarding=current.onboarding if current is not None else {},
+        created_at=created_at,
+        updated_at=datetime.now(UTC),
+        activated_at=current.activated_at if current is not None else None,
+    )
+    saved_id = store.upsert(identity, customer)
+    if saved_id != customer_id:
+        raise TenantCustomerStoreError("Customer identity changed unexpectedly.")
+    return saved_id
+
+
+def upsert_customer_from_prospect(
+    store: TenantCustomerStore,
+    identity: RequestIdentity,
+    *,
+    prospect_id: str,
+    prospect: Prospect,
+) -> str:
+    customer_id, current = _existing(
+        store,
+        identity,
+        CustomerSourceType.prospect,
+        prospect_id,
+    )
+    created_at = current.created_at if current is not None else datetime.now(UTC)
+    customer = CustomerRecord(
+        business_name=prospect.business_name,
+        contact_name=prospect.contact_name,
+        contact_email=prospect.contact_email,
+        phone=prospect.phone,
+        website=prospect.website,
+        source_type=CustomerSourceType.prospect,
+        source_id=prospect_id,
+        project_ids=current.project_ids if current is not None else (),
+        offer_service=prospect.outreach_offer or prospect.likely_offer,
+        commercial_notes=(
+            current.commercial_notes if current is not None else prospect.commercial_note
+        ),
+        status=current.status if current is not None else "onboarding",
+        onboarding=current.onboarding if current is not None else {},
+        created_at=created_at,
+        updated_at=datetime.now(UTC),
+        activated_at=current.activated_at if current is not None else None,
+    )
+    saved_id = store.upsert(identity, customer)
+    if saved_id != customer_id:
+        raise TenantCustomerStoreError("Customer identity changed unexpectedly.")
+    return saved_id

--- a/src/veridra/customer_lifecycle.py
+++ b/src/veridra/customer_lifecycle.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from .customer_store import (
+    CustomerOnboardingChecklist,
     CustomerRecord,
     CustomerSourceType,
+    CustomerStatus,
     customer_identifier,
 )
 from .identity_tenancy import RequestIdentity
@@ -44,7 +46,6 @@ def upsert_customer_from_lead(
     projects = set(current.project_ids if current is not None else ())
     if project_id:
         projects.add(project_id)
-    created_at = current.created_at if current is not None else datetime.now(UTC)
     customer = CustomerRecord(
         business_name=lead.company or lead.name,
         contact_name=lead.name,
@@ -58,9 +59,11 @@ def upsert_customer_from_lead(
         quoted_value=lead.quoted_value,
         currency=lead.currency,
         commercial_notes=current.commercial_notes if current is not None else lead.notes,
-        status=current.status if current is not None else "onboarding",
-        onboarding=current.onboarding if current is not None else {},
-        created_at=created_at,
+        status=current.status if current is not None else CustomerStatus.onboarding,
+        onboarding=(
+            current.onboarding if current is not None else CustomerOnboardingChecklist()
+        ),
+        created_at=current.created_at if current is not None else datetime.now(UTC),
         updated_at=datetime.now(UTC),
         activated_at=current.activated_at if current is not None else None,
     )
@@ -83,7 +86,6 @@ def upsert_customer_from_prospect(
         CustomerSourceType.prospect,
         prospect_id,
     )
-    created_at = current.created_at if current is not None else datetime.now(UTC)
     customer = CustomerRecord(
         business_name=prospect.business_name,
         contact_name=prospect.contact_name,
@@ -97,9 +99,11 @@ def upsert_customer_from_prospect(
         commercial_notes=(
             current.commercial_notes if current is not None else prospect.commercial_note
         ),
-        status=current.status if current is not None else "onboarding",
-        onboarding=current.onboarding if current is not None else {},
-        created_at=created_at,
+        status=current.status if current is not None else CustomerStatus.onboarding,
+        onboarding=(
+            current.onboarding if current is not None else CustomerOnboardingChecklist()
+        ),
+        created_at=current.created_at if current is not None else datetime.now(UTC),
         updated_at=datetime.now(UTC),
         activated_at=current.activated_at if current is not None else None,
     )

--- a/src/veridra/customer_store.py
+++ b/src/veridra/customer_store.py
@@ -75,15 +75,20 @@ class CustomerRecord(BaseModel):
     @model_validator(mode="after")
     def validate_relationships(self) -> CustomerRecord:
         for project_id in self.project_ids:
-            if len(project_id) != 24 or any(char not in "0123456789abcdef" for char in project_id):
-                raise ValueError("Customer project identifiers must be 24 lowercase hex characters.")
+            invalid = len(project_id) != 24 or any(
+                char not in "0123456789abcdef" for char in project_id
+            )
+            if invalid:
+                raise ValueError(
+                    "Customer project identifiers must be 24 lowercase hex characters."
+                )
         if self.status is CustomerStatus.active and not self.onboarding.complete:
             raise ValueError("Customer onboarding must be complete before activation.")
         return self
 
 
 def customer_identifier(source_type: CustomerSourceType, source_id: str) -> str:
-    canonical = f"{source_type.value}|{source_id}".encode("utf-8")
+    canonical = f"{source_type.value}|{source_id}".encode()
     return hashlib.sha256(canonical).hexdigest()[:24]
 
 

--- a/src/veridra/customer_store.py
+++ b/src/veridra/customer_store.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
+
+
+class CustomerStoreError(RuntimeError):
+    pass
+
+
+class CustomerSourceType(StrEnum):
+    lead = "lead"
+    prospect = "prospect"
+    manual = "manual"
+
+
+class CustomerStatus(StrEnum):
+    onboarding = "onboarding"
+    active = "active"
+    paused = "paused"
+    closed = "closed"
+
+
+class CustomerOnboardingChecklist(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    contact_confirmed: bool = False
+    scope_confirmed: bool = False
+    commercial_terms_confirmed: bool = False
+    access_requirements_confirmed: bool = False
+    kickoff_completed: bool = False
+
+    @property
+    def complete(self) -> bool:
+        return all(
+            (
+                self.contact_confirmed,
+                self.scope_confirmed,
+                self.commercial_terms_confirmed,
+                self.access_requirements_confirmed,
+                self.kickoff_completed,
+            )
+        )
+
+
+class CustomerRecord(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    business_name: str = Field(min_length=1, max_length=200)
+    contact_name: str = Field(default="", max_length=160)
+    contact_email: str = Field(default="", max_length=254)
+    phone: str = Field(default="", max_length=80)
+    website: HttpUrl | None = None
+    source_type: CustomerSourceType
+    source_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    project_ids: tuple[str, ...] = ()
+    offer_service: str = Field(default="", max_length=240)
+    quoted_value: Decimal | None = Field(default=None, ge=0, decimal_places=2)
+    currency: str = Field(default="EUR", min_length=3, max_length=3, pattern=r"^[A-Z]{3}$")
+    commercial_notes: str = Field(default="", max_length=5000)
+    status: CustomerStatus = CustomerStatus.onboarding
+    onboarding: CustomerOnboardingChecklist = Field(default_factory=CustomerOnboardingChecklist)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    activated_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def validate_relationships(self) -> CustomerRecord:
+        for project_id in self.project_ids:
+            if len(project_id) != 24 or any(char not in "0123456789abcdef" for char in project_id):
+                raise ValueError("Customer project identifiers must be 24 lowercase hex characters.")
+        if self.status is CustomerStatus.active and not self.onboarding.complete:
+            raise ValueError("Customer onboarding must be complete before activation.")
+        return self
+
+
+def customer_identifier(source_type: CustomerSourceType, source_id: str) -> str:
+    canonical = f"{source_type.value}|{source_id}".encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()[:24]
+
+
+def _atomic_write(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile(
+        mode="wb",
+        dir=path.parent,
+        prefix=f".{path.stem}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        temporary.write(content)
+        temporary.flush()
+        os.fsync(temporary.fileno())
+        temporary_path = Path(temporary.name)
+    temporary_path.replace(path)
+
+
+class CustomerStore:
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def _path(self, customer_id: str) -> Path:
+        valid = len(customer_id) == 24 and all(
+            character in "0123456789abcdef" for character in customer_id
+        )
+        if not valid:
+            raise CustomerStoreError("Invalid customer identifier.")
+        return self.directory / f"{customer_id}.json"
+
+    @staticmethod
+    def _bytes(customer: CustomerRecord) -> bytes:
+        return json.dumps(
+            customer.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+
+    def save(self, customer: CustomerRecord) -> str:
+        customer_id = customer_identifier(customer.source_type, customer.source_id)
+        destination = self._path(customer_id)
+        if destination.exists():
+            raise CustomerStoreError("Customer record already exists.")
+        _atomic_write(destination, self._bytes(customer))
+        return customer_id
+
+    def upsert(self, customer: CustomerRecord) -> str:
+        customer_id = customer_identifier(customer.source_type, customer.source_id)
+        _atomic_write(self._path(customer_id), self._bytes(customer))
+        return customer_id
+
+    def load(self, customer_id: str) -> CustomerRecord:
+        try:
+            return CustomerRecord.model_validate_json(
+                self._path(customer_id).read_text(encoding="utf-8")
+            )
+        except (OSError, ValueError) as exc:
+            raise CustomerStoreError("Saved customer was not found or is invalid.") from exc
+
+    def list(self) -> list[tuple[str, CustomerRecord]]:
+        if not self.directory.exists():
+            return []
+        entries: list[tuple[str, CustomerRecord]] = []
+        for path in sorted(self.directory.glob("*.json")):
+            try:
+                customer = CustomerRecord.model_validate_json(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            entries.append((path.stem, customer))
+        return sorted(entries, key=lambda item: (item[1].updated_at, item[0]), reverse=True)
+
+    def replace(self, customer_id: str, customer: CustomerRecord) -> None:
+        destination = self._path(customer_id)
+        if not destination.exists():
+            raise CustomerStoreError("Saved customer was not found.")
+        expected = customer_identifier(customer.source_type, customer.source_id)
+        if expected != customer_id:
+            raise CustomerStoreError("Customer source identity cannot be changed in place.")
+        _atomic_write(destination, self._bytes(customer))

--- a/src/veridra/lead_project_conversion_api.py
+++ b/src/veridra/lead_project_conversion_api.py
@@ -12,6 +12,7 @@ from .assessment_project_conversion_api import (
     AssessmentProjectCreated,
     convert_assessment,
 )
+from .customer_lifecycle import upsert_customer_from_lead
 from .history import HistoryError, HistoryStore
 from .identity_tenancy import (
     IdentityBoundaryError,
@@ -25,8 +26,9 @@ from .lead_project_link_store import (
     LeadProjectLinkError,
     LeadProjectLinkStore,
 )
-from .lead_store import LeadStatus
+from .lead_store import AuditLead, LeadStatus
 from .request_security import require_request_capability
+from .tenant_customer_store import TenantCustomerStore, TenantCustomerStoreError
 from .tenant_lead_form_store import TenantLeadFormStore, TenantLeadFormStoreError
 from .tenant_lead_store import TenantLeadStore, TenantLeadStoreError
 from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
@@ -68,14 +70,38 @@ def _not_found(exc: Exception) -> HTTPException:
     return HTTPException(status_code=404, detail="Lead conversion source not found.")
 
 
-def _won_update(lead: object) -> dict[str, object]:
-    current = getattr(lead, "won_at", None)
-    return {
-        "status": LeadStatus.won,
-        "won_at": current or datetime.now(UTC),
-        "lost_at": None,
-        "loss_reason": "",
-    }
+def _won_lead(lead: AuditLead) -> AuditLead:
+    return lead.model_copy(
+        update={
+            "status": LeadStatus.won,
+            "won_at": lead.won_at or datetime.now(UTC),
+            "lost_at": None,
+            "loss_reason": "",
+        }
+    )
+
+
+def _ensure_customer(
+    request: Request,
+    identity: RequestIdentity,
+    *,
+    lead_id: str,
+    lead: AuditLead,
+    project_id: str,
+) -> None:
+    try:
+        upsert_customer_from_lead(
+            TenantCustomerStore(_root(request)),
+            identity,
+            lead_id=lead_id,
+            lead=lead,
+            project_id=project_id,
+        )
+    except TenantCustomerStoreError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Customer onboarding record could not be created.",
+        ) from exc
 
 
 def convert_lead_to_project(
@@ -100,17 +126,21 @@ def convert_lead_to_project(
     except (TenantLeadStoreError, LeadProjectLinkError) as exc:
         raise _not_found(exc) from exc
 
+    won_lead = _won_lead(lead)
     if existing is not None:
         try:
             projects.load(identity, projects.ref(identity, existing.project_id))
+            if lead != won_lead:
+                leads.replace(identity, leads.ref(identity, lead_id), won_lead)
+            _ensure_customer(
+                request,
+                identity,
+                lead_id=lead_id,
+                lead=won_lead,
+                project_id=existing.project_id,
+            )
         except TenantProjectStoreError as exc:
             raise _not_found(exc) from exc
-        if lead.status != LeadStatus.won:
-            leads.replace(
-                identity,
-                leads.ref(identity, lead_id),
-                lead.model_copy(update=_won_update(lead)),
-            )
         return LeadProjectCreated(
             lead_id=lead_id,
             project_id=existing.project_id,
@@ -145,17 +175,20 @@ def convert_lead_to_project(
                 assessment_id=created.assessment_id,
             )
         )
-        leads.replace(
-            identity,
-            leads.ref(identity, lead_id),
-            lead.model_copy(update=_won_update(lead)),
-        )
+        leads.replace(identity, leads.ref(identity, lead_id), won_lead)
         activity.append(
             identity,
             lead_id,
             LeadActivityType.project_converted,
             "Lead converted to client project",
             metadata={"project_id": created.project_id},
+        )
+        _ensure_customer(
+            request,
+            identity,
+            lead_id=lead_id,
+            lead=won_lead,
+            project_id=created.project_id,
         )
     except (LeadProjectLinkError, TenantLeadStoreError, LeadActivityError) as exc:
         raise HTTPException(

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -8,6 +8,7 @@ from . import public_web
 from .access_logging import StructuredAccessLogMiddleware, configure_access_logger
 from .agency_conversion_web import router as agency_conversion_router
 from .agency_crawl_profile_web import router as agency_crawl_profile_router
+from .agency_customer_web import router as agency_customer_router
 from .agency_lead_form_web import router as agency_lead_form_router
 from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
@@ -156,6 +157,7 @@ app.include_router(tenant_team_router)
 app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)
+app.include_router(agency_customer_router)
 app.include_router(agency_project_index_router)
 app.include_router(agency_conversion_router)
 app.include_router(agency_crawl_profile_router)

--- a/src/veridra/tenant_customer_store.py
+++ b/src/veridra/tenant_customer_store.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .customer_store import CustomerRecord, CustomerStore, CustomerStoreError
+from .identity_tenancy import (
+    RequestIdentity,
+    TenantCapability,
+    TenantObjectRef,
+    require_tenant_capability,
+    require_tenant_scope,
+)
+from .tenant_project_store import default_tenant_data_directory
+
+
+class TenantCustomerStoreError(RuntimeError):
+    pass
+
+
+class TenantCustomerStore:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or default_tenant_data_directory()
+
+    def _store(self, identity: RequestIdentity) -> CustomerStore:
+        return CustomerStore(self.root / identity.tenant_id / "customers")
+
+    @staticmethod
+    def ref(identity: RequestIdentity, customer_id: str) -> TenantObjectRef:
+        return TenantObjectRef(
+            tenant_id=identity.tenant_id,
+            object_type="customer",
+            object_id=customer_id,
+        )
+
+    def upsert(self, identity: RequestIdentity, customer: CustomerRecord) -> str:
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+        try:
+            return self._store(identity).upsert(customer)
+        except CustomerStoreError as exc:
+            raise TenantCustomerStoreError("Customer record could not be saved.") from exc
+
+    def load(self, identity: RequestIdentity, target: TenantObjectRef) -> CustomerRecord:
+        require_tenant_scope(identity, target)
+        if target.object_type != "customer":
+            raise TenantCustomerStoreError("Tenant object is not a customer reference.")
+        try:
+            return self._store(identity).load(target.object_id)
+        except CustomerStoreError as exc:
+            raise TenantCustomerStoreError("Saved customer was not found.") from exc
+
+    def list(self, identity: RequestIdentity) -> list[tuple[str, CustomerRecord]]:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        return self._store(identity).list()
+
+    def replace(
+        self,
+        identity: RequestIdentity,
+        target: TenantObjectRef,
+        customer: CustomerRecord,
+    ) -> None:
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+        require_tenant_scope(identity, target)
+        if target.object_type != "customer":
+            raise TenantCustomerStoreError("Tenant object is not a customer reference.")
+        try:
+            self._store(identity).replace(target.object_id, customer)
+        except CustomerStoreError as exc:
+            raise TenantCustomerStoreError("Saved customer could not be updated.") from exc

--- a/src/veridra/tenant_prospect_store.py
+++ b/src/veridra/tenant_prospect_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from .customer_lifecycle import upsert_customer_from_prospect
 from .identity_tenancy import (
     RequestIdentity,
     TenantCapability,
@@ -10,6 +11,7 @@ from .identity_tenancy import (
     require_tenant_scope,
 )
 from .prospect import Prospect, ProspectStatus, ProspectStore, ProspectStoreError
+from .tenant_customer_store import TenantCustomerStore, TenantCustomerStoreError
 from .tenant_project_store import default_tenant_data_directory
 
 
@@ -66,8 +68,17 @@ class TenantProspectStore:
             raise TenantProspectStoreError("Tenant object is not a prospect reference.")
         try:
             self._store(identity).replace(target.object_id, prospect)
+            if prospect.status is ProspectStatus.customer:
+                upsert_customer_from_prospect(
+                    TenantCustomerStore(self.root),
+                    identity,
+                    prospect_id=target.object_id,
+                    prospect=prospect,
+                )
         except ProspectStoreError as exc:
             raise TenantProspectStoreError("Saved prospect was not found.") from exc
+        except TenantCustomerStoreError as exc:
+            raise TenantProspectStoreError("Customer onboarding record could not be saved.") from exc
 
     def delete(self, identity: RequestIdentity, target: TenantObjectRef) -> None:
         require_tenant_capability(identity, TenantCapability.manage_leads)

--- a/src/veridra/tenant_prospect_store.py
+++ b/src/veridra/tenant_prospect_store.py
@@ -78,7 +78,9 @@ class TenantProspectStore:
         except ProspectStoreError as exc:
             raise TenantProspectStoreError("Saved prospect was not found.") from exc
         except TenantCustomerStoreError as exc:
-            raise TenantProspectStoreError("Customer onboarding record could not be saved.") from exc
+            raise TenantProspectStoreError(
+                "Customer onboarding record could not be saved."
+            ) from exc
 
     def delete(self, identity: RequestIdentity, target: TenantObjectRef) -> None:
         require_tenant_capability(identity, TenantCapability.manage_leads)

--- a/tests/test_customer_onboarding.py
+++ b/tests/test_customer_onboarding.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from pydantic import HttpUrl, ValidationError
+
+from veridra.customer_lifecycle import upsert_customer_from_lead
+from veridra.customer_store import (
+    CustomerOnboardingChecklist,
+    CustomerRecord,
+    CustomerSourceType,
+    CustomerStatus,
+)
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.lead_store import AuditLead, LeadStatus
+from veridra.prospect import Prospect, ProspectStatus
+from veridra.tenant_customer_store import TenantCustomerStore
+from veridra.tenant_prospect_store import TenantProspectStore
+
+
+def _identity(tenant: str = "b") -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id=tenant * 24,
+        membership_role=TenantRole.owner,
+        session_id="c" * 24,
+        authenticated_at=datetime.now(UTC),
+    )
+
+
+def test_no_website_outbound_customer_is_created_without_project(tmp_path: Path) -> None:
+    identity = _identity()
+    prospects = TenantProspectStore(tmp_path)
+    prospect = Prospect(
+        business_name="Daragh Example Dental",
+        website=None,
+        contact_name="Daragh Example",
+        contact_email="daragh@example.ie",
+        phone="01 555 0101",
+        status=ProspectStatus.proposal,
+        outreach_offer="Website Improvement Sprint",
+        commercial_note="Website absence independently verified.",
+    )
+    prospect_id = prospects.save(identity, prospect)
+
+    won = prospect.model_copy(update={"status": ProspectStatus.customer})
+    prospects.replace(identity, prospects.ref(identity, prospect_id), won)
+
+    customers = TenantCustomerStore(tmp_path).list(identity)
+    assert len(customers) == 1
+    customer_id, customer = customers[0]
+    assert customer_id
+    assert customer.source_type is CustomerSourceType.prospect
+    assert customer.source_id == prospect_id
+    assert customer.website is None
+    assert customer.project_ids == ()
+    assert customer.status is CustomerStatus.onboarding
+
+    prospects.replace(identity, prospects.ref(identity, prospect_id), won)
+    assert len(TenantCustomerStore(tmp_path).list(identity)) == 1
+
+
+def test_customer_activation_requires_complete_onboarding() -> None:
+    base = CustomerRecord(
+        business_name="Example Ltd",
+        source_type=CustomerSourceType.manual,
+        source_id="d" * 24,
+    )
+
+    with pytest.raises(ValidationError):
+        CustomerRecord.model_validate(
+            {
+                **base.model_dump(mode="json"),
+                "status": CustomerStatus.active.value,
+            }
+        )
+
+    checklist = CustomerOnboardingChecklist(
+        contact_confirmed=True,
+        scope_confirmed=True,
+        commercial_terms_confirmed=True,
+        access_requirements_confirmed=True,
+        kickoff_completed=True,
+    )
+    active = CustomerRecord.model_validate(
+        {
+            **base.model_dump(mode="json"),
+            "status": CustomerStatus.active.value,
+            "onboarding": checklist.model_dump(mode="json"),
+            "activated_at": datetime.now(UTC),
+        }
+    )
+    assert active.status is CustomerStatus.active
+    assert active.onboarding.complete is True
+
+
+def test_won_inbound_lead_customer_keeps_project_and_commercial_value(tmp_path: Path) -> None:
+    identity = _identity()
+    lead = AuditLead(
+        form_id="d" * 24,
+        website=HttpUrl("https://example.com"),
+        name="Alex Client",
+        email="alex@example.com",
+        company="Example Ltd",
+        consent_text="I agree",
+        consented_at=datetime.now(UTC),
+        assessment_id="e" * 24,
+        status=LeadStatus.won,
+        offer_service="Website Improvement Sprint",
+        quoted_value=Decimal("650.00"),
+        currency="EUR",
+    )
+
+    customer_id = upsert_customer_from_lead(
+        TenantCustomerStore(tmp_path),
+        identity,
+        lead_id="f" * 24,
+        lead=lead,
+        project_id="1" * 24,
+    )
+    customer = TenantCustomerStore(tmp_path).load(
+        identity,
+        TenantCustomerStore.ref(identity, customer_id),
+    )
+
+    assert customer.business_name == "Example Ltd"
+    assert customer.project_ids == ("1" * 24,)
+    assert customer.quoted_value == Decimal("650.00")
+    assert customer.offer_service == "Website Improvement Sprint"
+
+
+def test_customers_are_tenant_isolated(tmp_path: Path) -> None:
+    owner = _identity("b")
+    other = _identity("f")
+    prospect = Prospect(business_name="Tenant A Client", status=ProspectStatus.proposal)
+    prospect_id = TenantProspectStore(tmp_path).save(owner, prospect)
+    TenantProspectStore(tmp_path).replace(
+        owner,
+        TenantProspectStore.ref(owner, prospect_id),
+        prospect.model_copy(update={"status": ProspectStatus.customer}),
+    )
+
+    assert len(TenantCustomerStore(tmp_path).list(owner)) == 1
+    assert TenantCustomerStore(tmp_path).list(other) == []


### PR DESCRIPTION
Implements issue #252 as the next first-customer-readiness block.

Changes:
- tenant-scoped Webify customer model/store with onboarding, active, paused and closed states;
- five-step onboarding checklist and activation guard;
- explicit source relationship to either an inbound lead or outbound prospect;
- outbound prospects can become customers with no website and zero projects during onboarding;
- inbound lead-to-project conversion creates/updates the linked customer record idempotently;
- marking an outbound prospect as Customer creates/updates the customer record at the tenant-store boundary;
- Customers list/detail UI with onboarding progress, source links and project links;
- Customers added to agency navigation and runtime routes;
- tests for no-site prospect conversion, idempotency, onboarding activation guard, inbound commercial/project preservation and tenant isolation.

Important boundary: ClientProject still requires a target URL. We intentionally do not make audit project URLs nullable. A no-site customer can complete early onboarding before a domain/staging/live target exists; the normal project/audit engine can attach once a target exists.