### PR TITLE
P0 agency client billing state

### DIFF
--- a/src/veridra/agency_customer_web.py
+++ b/src/veridra/agency_customer_web.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import html
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from urllib.parse import parse_qs
 
@@ -84,6 +85,14 @@ def _date_value(value: object) -> str:
 
 def _money(value: object) -> str:
     return "" if value is None else str(value)
+
+
+def _optional_decimal(value: str) -> Decimal | None:
+    return Decimal(value) if value else None
+
+
+def _optional_date(value: str) -> date | None:
+    return date.fromisoformat(value) if value else None
 
 
 @router.get("", response_class=HTMLResponse)
@@ -180,10 +189,10 @@ async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
         billing = CustomerBillingState(
             status=next_billing_status,
             invoice_reference=_one(values, "invoice_reference"),
-            invoice_amount=_one(values, "invoice_amount") or None,
+            invoice_amount=_optional_decimal(_one(values, "invoice_amount")),
             currency=(_one(values, "billing_currency") or "EUR").upper(),
-            issued_on=_one(values, "issued_on") or None,
-            due_on=_one(values, "due_on") or None,
+            issued_on=_optional_date(_one(values, "issued_on")),
+            due_on=_optional_date(_one(values, "due_on")),
             paid_at=paid_at,
             note=_one(values, "billing_note"),
         )
@@ -199,7 +208,7 @@ async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
             }
         )
         store.replace(identity, store.ref(identity, customer_id), updated)
-    except (ValueError, ValidationError, TenantCustomerStoreError) as exc:
+    except (InvalidOperation, ValueError, ValidationError, TenantCustomerStoreError) as exc:
         raise HTTPException(
             status_code=400,
             detail=(

--- a/src/veridra/agency_customer_web.py
+++ b/src/veridra/agency_customer_web.py
@@ -11,7 +11,13 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
 
 from .agency_navigation import agency_navigation
-from .customer_store import CustomerOnboardingChecklist, CustomerRecord, CustomerStatus
+from .customer_store import (
+    CustomerBillingState,
+    CustomerBillingStatus,
+    CustomerOnboardingChecklist,
+    CustomerRecord,
+    CustomerStatus,
+)
 from .identity_tenancy import (
     IdentityBoundaryError,
     RequestIdentity,
@@ -72,23 +78,32 @@ def _progress(checklist: CustomerOnboardingChecklist) -> str:
     return f"{completed}/5"
 
 
+def _date_value(value: object) -> str:
+    return "" if value is None else str(value)
+
+
+def _money(value: object) -> str:
+    return "" if value is None else str(value)
+
+
 @router.get("", response_class=HTMLResponse)
 def customers(request: Request) -> str:
     identity = _identity(request)
     entries = TenantCustomerStore(_root(request)).list(identity)
     cards = "".join(
-        "<article class='card'><p class='muted'>{status} · onboarding {progress}</p><h2>{name}</h2><p><strong>Website:</strong> {website}<br><strong>Offer:</strong> {offer}<br><strong>Projects:</strong> {projects}</p><a class='button' href='/agency/customers/{customer_id}'>Open customer</a></article>".format(
+        "<article class='card'><p class='muted'>{status} · onboarding {progress}</p><h2>{name}</h2><p><strong>Website:</strong> {website}<br><strong>Offer:</strong> {offer}<br><strong>Billing:</strong> {billing}<br><strong>Projects:</strong> {projects}</p><a class='button' href='/agency/customers/{customer_id}'>Open customer</a></article>".format(
             status=html.escape(customer.status.value.title()),
             progress=html.escape(_progress(customer.onboarding)),
             name=html.escape(customer.business_name),
             website=html.escape(str(customer.website) if customer.website is not None else "No website yet"),
             offer=html.escape(customer.offer_service or "Not recorded"),
+            billing=html.escape(customer.billing.status.value.replace("_", " ").title()),
             projects=len(customer.project_ids),
             customer_id=html.escape(customer_id, quote=True),
         )
         for customer_id, customer in entries
     ) or "<p class='notice'>No customers yet. A won inbound lead or an outbound prospect marked Customer will create the first onboarding record.</p>"
-    body = f"{agency_navigation(identity, current='customers')}<section><h1>Customers</h1><p class='muted'>Won business relationships, onboarding state and linked delivery projects.</p></section><section><div class='cards'>{cards}</div></section>"
+    body = f"{agency_navigation(identity, current='customers')}<section><h1>Customers</h1><p class='muted'>Won business relationships, onboarding state, billing state and linked delivery projects.</p></section><section><div class='cards'>{cards}</div></section>"
     return _page("Customers", body)
 
 
@@ -116,6 +131,10 @@ def customer_detail(customer_id: str, request: Request) -> str:
         f"<option value='{item.value}'{' selected' if item is customer.status else ''}>{item.value.title()}</option>"
         for item in CustomerStatus
     )
+    billing_options = "".join(
+        f"<option value='{item.value}'{' selected' if item is customer.billing.status else ''}>{item.value.replace('_', ' ').title()}</option>"
+        for item in CustomerBillingStatus
+    )
     checks = "".join(
         f"<label class='check'><input type='checkbox' name='{name}'{' checked' if value else ''}>{html.escape(label)}</label>"
         for name, label, value in (
@@ -126,7 +145,8 @@ def customer_detail(customer_id: str, request: Request) -> str:
             ("kickoff_completed", "Kickoff completed", customer.onboarding.kickoff_completed),
         )
     )
-    body = f"""{agency_navigation(identity, current='customers')}<section><p><a href='/agency/customers'>← Customers</a></p><h1>{html.escape(customer.business_name)}</h1><p><strong>Status:</strong> {html.escape(customer.status.value.title())}<br><strong>Contact:</strong> {html.escape(customer.contact_name or 'Not recorded')} · {html.escape(customer.contact_email or 'No email')} · {html.escape(customer.phone or 'No phone')}<br><strong>Website:</strong> {html.escape(str(customer.website) if customer.website is not None else 'No website yet')}<br><strong>Offer:</strong> {html.escape(customer.offer_service or 'Not recorded')}<br><strong>Quoted:</strong> {html.escape(f'{customer.currency} {customer.quoted_value}' if customer.quoted_value is not None else 'Not recorded')}<br><strong>Onboarding:</strong> {html.escape(_progress(customer.onboarding))}</p><div class='actions'>{source_link}{project_links}</div></section><section><h2>Customer onboarding</h2><p class='muted'>A customer cannot become Active until all five required onboarding checks are complete.</p><form method='post' action='/agency/customers/{html.escape(customer_id, quote=True)}'><div class='row'><div><label for='status'>Customer status</label><select id='status' name='status'>{status_options}</select></div><div><label for='commercial_notes'>Commercial / onboarding notes</label><textarea id='commercial_notes' name='commercial_notes' maxlength='5000'>{html.escape(customer.commercial_notes)}</textarea></div></div>{checks}<p><button type='submit'>Save customer</button></p></form></section>"""
+    paid = customer.billing.paid_at.isoformat() if customer.billing.paid_at is not None else "Not paid"
+    body = f"""{agency_navigation(identity, current='customers')}<section><p><a href='/agency/customers'>← Customers</a></p><h1>{html.escape(customer.business_name)}</h1><p><strong>Status:</strong> {html.escape(customer.status.value.title())}<br><strong>Contact:</strong> {html.escape(customer.contact_name or 'Not recorded')} · {html.escape(customer.contact_email or 'No email')} · {html.escape(customer.phone or 'No phone')}<br><strong>Website:</strong> {html.escape(str(customer.website) if customer.website is not None else 'No website yet')}<br><strong>Offer:</strong> {html.escape(customer.offer_service or 'Not recorded')}<br><strong>Quoted:</strong> {html.escape(f'{customer.currency} {customer.quoted_value}' if customer.quoted_value is not None else 'Not recorded')}<br><strong>Onboarding:</strong> {html.escape(_progress(customer.onboarding))}<br><strong>Billing:</strong> {html.escape(customer.billing.status.value.replace('_', ' ').title())}<br><strong>Paid at:</strong> {html.escape(paid)}</p><div class='actions'>{source_link}{project_links}</div></section><section><h2>Customer onboarding</h2><p class='muted'>A customer cannot become Active until all five required onboarding checks are complete.</p><form method='post' action='/agency/customers/{html.escape(customer_id, quote=True)}'><div class='row'><div><label for='status'>Customer status</label><select id='status' name='status'>{status_options}</select></div><div><label for='commercial_notes'>Commercial / onboarding notes</label><textarea id='commercial_notes' name='commercial_notes' maxlength='5000'>{html.escape(customer.commercial_notes)}</textarea></div></div>{checks}<h2>Invoice and payment</h2><p class='muted'>This tracks Webify client billing only. It does not charge the customer or change VERIDRA SaaS subscription billing.</p><div class='row'><div><label for='billing_status'>Billing status</label><select id='billing_status' name='billing_status'>{billing_options}</select></div><div><label for='invoice_reference'>Invoice reference</label><input id='invoice_reference' name='invoice_reference' maxlength='120' value='{html.escape(customer.billing.invoice_reference, quote=True)}'></div><div><label for='invoice_amount'>Invoice amount</label><input id='invoice_amount' name='invoice_amount' type='number' min='0' step='0.01' value='{html.escape(_money(customer.billing.invoice_amount), quote=True)}'></div><div><label for='billing_currency'>Currency</label><input id='billing_currency' name='billing_currency' minlength='3' maxlength='3' value='{html.escape(customer.billing.currency, quote=True)}'></div><div><label for='issued_on'>Issued on</label><input id='issued_on' name='issued_on' type='date' value='{html.escape(_date_value(customer.billing.issued_on), quote=True)}'></div><div><label for='due_on'>Due on</label><input id='due_on' name='due_on' type='date' value='{html.escape(_date_value(customer.billing.due_on), quote=True)}'></div></div><label for='billing_note'>Billing note</label><textarea id='billing_note' name='billing_note' maxlength='2000'>{html.escape(customer.billing.note)}</textarea><p><button type='submit'>Save customer</button></p></form></section>"""
     return _page(customer.business_name, body)
 
 
@@ -141,6 +161,7 @@ async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
     values = _values(await request.body())
     try:
         next_status = CustomerStatus(_one(values, "status"))
+        next_billing_status = CustomerBillingStatus(_one(values, "billing_status"))
         checklist = CustomerOnboardingChecklist(
             contact_confirmed=_checked(values, "contact_confirmed"),
             scope_confirmed=_checked(values, "scope_confirmed"),
@@ -151,11 +172,27 @@ async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
         activated_at = customer.activated_at
         if next_status is CustomerStatus.active and activated_at is None:
             activated_at = datetime.now(UTC)
+        paid_at = customer.billing.paid_at
+        if next_billing_status is CustomerBillingStatus.paid and paid_at is None:
+            paid_at = datetime.now(UTC)
+        elif next_billing_status is not CustomerBillingStatus.paid:
+            paid_at = None
+        billing = CustomerBillingState(
+            status=next_billing_status,
+            invoice_reference=_one(values, "invoice_reference"),
+            invoice_amount=_one(values, "invoice_amount") or None,
+            currency=(_one(values, "billing_currency") or "EUR").upper(),
+            issued_on=_one(values, "issued_on") or None,
+            due_on=_one(values, "due_on") or None,
+            paid_at=paid_at,
+            note=_one(values, "billing_note"),
+        )
         updated = CustomerRecord.model_validate(
             {
                 **customer.model_dump(mode="json"),
                 "status": next_status.value,
                 "onboarding": checklist.model_dump(mode="json"),
+                "billing": billing.model_dump(mode="json"),
                 "commercial_notes": _one(values, "commercial_notes"),
                 "updated_at": datetime.now(UTC),
                 "activated_at": activated_at,
@@ -165,6 +202,9 @@ async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
     except (ValueError, ValidationError, TenantCustomerStoreError) as exc:
         raise HTTPException(
             status_code=400,
-            detail="Customer update is invalid. Complete onboarding before activation.",
+            detail=(
+                "Customer update is invalid. Complete onboarding before activation and "
+                "provide valid invoice details for invoiced billing states."
+            ),
         ) from exc
     return RedirectResponse(f"/agency/customers/{customer_id}", status_code=303)

--- a/src/veridra/customer_lifecycle.py
+++ b/src/veridra/customer_lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from .customer_store import (
+    CustomerBillingState,
     CustomerOnboardingChecklist,
     CustomerRecord,
     CustomerSourceType,
@@ -63,6 +64,7 @@ def upsert_customer_from_lead(
         onboarding=(
             current.onboarding if current is not None else CustomerOnboardingChecklist()
         ),
+        billing=current.billing if current is not None else CustomerBillingState(),
         created_at=current.created_at if current is not None else datetime.now(UTC),
         updated_at=datetime.now(UTC),
         activated_at=current.activated_at if current is not None else None,
@@ -103,6 +105,7 @@ def upsert_customer_from_prospect(
         onboarding=(
             current.onboarding if current is not None else CustomerOnboardingChecklist()
         ),
+        billing=current.billing if current is not None else CustomerBillingState(),
         created_at=current.created_at if current is not None else datetime.now(UTC),
         updated_at=datetime.now(UTC),
         activated_at=current.activated_at if current is not None else None,

--- a/src/veridra/customer_store.py
+++ b/src/veridra/customer_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from enum import StrEnum
 from pathlib import Path
@@ -29,6 +29,15 @@ class CustomerStatus(StrEnum):
     closed = "closed"
 
 
+class CustomerBillingStatus(StrEnum):
+    unbilled = "unbilled"
+    invoice_prepared = "invoice_prepared"
+    invoice_sent = "invoice_sent"
+    paid = "paid"
+    overdue = "overdue"
+    cancelled = "cancelled"
+
+
 class CustomerOnboardingChecklist(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -51,6 +60,27 @@ class CustomerOnboardingChecklist(BaseModel):
         )
 
 
+class CustomerBillingState(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    status: CustomerBillingStatus = CustomerBillingStatus.unbilled
+    invoice_reference: str = Field(default="", max_length=120)
+    invoice_amount: Decimal | None = Field(default=None, ge=0, decimal_places=2)
+    currency: str = Field(default="EUR", min_length=3, max_length=3, pattern=r"^[A-Z]{3}$")
+    issued_on: date | None = None
+    due_on: date | None = None
+    paid_at: datetime | None = None
+    note: str = Field(default="", max_length=2000)
+
+    @model_validator(mode="after")
+    def validate_billing_state(self) -> CustomerBillingState:
+        if self.issued_on is not None and self.due_on is not None and self.due_on < self.issued_on:
+            raise ValueError("Invoice due date cannot be before the issue date.")
+        if self.status is CustomerBillingStatus.paid and self.paid_at is None:
+            raise ValueError("Paid billing state requires a payment timestamp.")
+        return self
+
+
 class CustomerRecord(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
 
@@ -68,6 +98,7 @@ class CustomerRecord(BaseModel):
     commercial_notes: str = Field(default="", max_length=5000)
     status: CustomerStatus = CustomerStatus.onboarding
     onboarding: CustomerOnboardingChecklist = Field(default_factory=CustomerOnboardingChecklist)
+    billing: CustomerBillingState = Field(default_factory=CustomerBillingState)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     activated_at: datetime | None = None

--- a/src/veridra/customer_store.py
+++ b/src/veridra/customer_store.py
@@ -76,6 +76,17 @@ class CustomerBillingState(BaseModel):
     def validate_billing_state(self) -> CustomerBillingState:
         if self.issued_on is not None and self.due_on is not None and self.due_on < self.issued_on:
             raise ValueError("Invoice due date cannot be before the issue date.")
+        invoiced_states = {
+            CustomerBillingStatus.invoice_prepared,
+            CustomerBillingStatus.invoice_sent,
+            CustomerBillingStatus.paid,
+            CustomerBillingStatus.overdue,
+        }
+        if self.status in invoiced_states:
+            if not self.invoice_reference:
+                raise ValueError("Invoiced billing states require an invoice reference.")
+            if self.invoice_amount is None:
+                raise ValueError("Invoiced billing states require an invoice amount.")
         if self.status is CustomerBillingStatus.paid and self.paid_at is None:
             raise ValueError("Paid billing state requires a payment timestamp.")
         return self

--- a/tests/test_customer_billing.py
+++ b/tests/test_customer_billing.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from veridra.customer_lifecycle import upsert_customer_from_prospect
+from veridra.customer_store import (
+    CustomerBillingState,
+    CustomerBillingStatus,
+    CustomerRecord,
+    CustomerSourceType,
+)
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.prospect import Prospect, ProspectStatus
+from veridra.tenant_customer_store import TenantCustomerStore
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id="b" * 24,
+        membership_role=TenantRole.owner,
+        session_id="c" * 24,
+        authenticated_at=datetime.now(UTC),
+    )
+
+
+def test_new_customer_defaults_to_unbilled() -> None:
+    customer = CustomerRecord(
+        business_name="Example Ltd",
+        source_type=CustomerSourceType.manual,
+        source_id="d" * 24,
+    )
+
+    assert customer.billing.status is CustomerBillingStatus.unbilled
+    assert customer.billing.invoice_reference == ""
+    assert customer.billing.invoice_amount is None
+    assert customer.billing.paid_at is None
+
+
+def test_invoiced_states_require_reference_and_amount() -> None:
+    with pytest.raises(ValidationError):
+        CustomerBillingState(status=CustomerBillingStatus.invoice_sent)
+
+    invoice = CustomerBillingState(
+        status=CustomerBillingStatus.invoice_sent,
+        invoice_reference="WEB-2026-001",
+        invoice_amount=Decimal("650.00"),
+        issued_on=date(2026, 8, 28),
+        due_on=date(2026, 9, 11),
+    )
+
+    assert invoice.invoice_reference == "WEB-2026-001"
+    assert invoice.invoice_amount == Decimal("650.00")
+
+
+def test_paid_state_requires_payment_timestamp() -> None:
+    with pytest.raises(ValidationError):
+        CustomerBillingState(
+            status=CustomerBillingStatus.paid,
+            invoice_reference="WEB-2026-001",
+            invoice_amount=Decimal("650.00"),
+        )
+
+    paid_at = datetime.now(UTC)
+    paid = CustomerBillingState(
+        status=CustomerBillingStatus.paid,
+        invoice_reference="WEB-2026-001",
+        invoice_amount=Decimal("650.00"),
+        paid_at=paid_at,
+    )
+    assert paid.paid_at == paid_at
+
+
+def test_due_date_cannot_precede_issue_date() -> None:
+    with pytest.raises(ValidationError):
+        CustomerBillingState(
+            status=CustomerBillingStatus.invoice_prepared,
+            invoice_reference="WEB-2026-001",
+            invoice_amount=Decimal("650.00"),
+            issued_on=date(2026, 8, 28),
+            due_on=date(2026, 8, 27),
+        )
+
+
+def test_prospect_refresh_preserves_existing_billing_state(tmp_path: Path) -> None:
+    identity = _identity()
+    store = TenantCustomerStore(tmp_path)
+    prospect = Prospect(
+        business_name="No Site Dental",
+        website=None,
+        status=ProspectStatus.customer,
+        outreach_offer="Website Improvement Sprint",
+    )
+    prospect_id = "e" * 24
+    customer_id = upsert_customer_from_prospect(
+        store,
+        identity,
+        prospect_id=prospect_id,
+        prospect=prospect,
+    )
+    customer = store.load(identity, store.ref(identity, customer_id))
+    billing = CustomerBillingState(
+        status=CustomerBillingStatus.invoice_sent,
+        invoice_reference="WEB-2026-001",
+        invoice_amount=Decimal("650.00"),
+        currency="EUR",
+        issued_on=date(2026, 8, 28),
+        due_on=date(2026, 9, 11),
+        note="Sent by email.",
+    )
+    store.replace(
+        identity,
+        store.ref(identity, customer_id),
+        customer.model_copy(update={"billing": billing}),
+    )
+
+    refreshed = prospect.model_copy(update={"commercial_note": "Customer replied."})
+    upsert_customer_from_prospect(
+        store,
+        identity,
+        prospect_id=prospect_id,
+        prospect=refreshed,
+    )
+    after = store.load(identity, store.ref(identity, customer_id))
+
+    assert after.billing == billing


### PR DESCRIPTION
Implements issue #254.

Changes:
- adds Webify customer billing lifecycle: unbilled, invoice_prepared, invoice_sent, paid, overdue, cancelled;
- tracks invoice reference, amount/currency, issue date, due date, paid timestamp and billing note;
- invoiced states require an invoice reference and amount;
- paid state requires a payment timestamp;
- customer source refreshes preserve billing state instead of resetting it;
- customer list/detail UI exposes billing state and invoice/payment controls;
- paid state automatically records paid_at in the browser workflow;
- tests cover defaults, invalid invoice states, paid timestamp, invalid due dates and billing preservation across outbound prospect refreshes;
- VERIDRA SaaS Stripe subscription billing is unchanged.

This is intentionally bookkeeping state only: no charging, tax engine, ledger, Stripe Connect or invoice PDF generation.