### PR TITLE
P0 unified commercial dashboard

### DIFF
--- a/src/veridra/agency_commercial_dashboard_web.py
+++ b/src/veridra/agency_commercial_dashboard_web.py
@@ -1,0 +1,87 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from decimal import Decimal
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from .agency_navigation import agency_navigation
+from .commercial_dashboard import build_commercial_snapshot
+from .customer_store import CustomerBillingStatus, CustomerStatus
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .lead_store import LeadStatus
+from .prospect import ProspectStatus
+from .request_security import require_request_identity
+from .tenant_customer_store import TenantCustomerStore
+from .tenant_lead_store import TenantLeadStore
+from .tenant_prospect_store import TenantProspectStore
+
+router = APIRouter(prefix="/agency/commercial", tags=["agency-commercial-dashboard"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1180px;margin:36px auto;padding:0 20px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:14px}.card{background:#fff;border:1px solid #dfe3e8;border-radius:9px;padding:18px}.metric{font-size:28px;font-weight:700;margin:6px 0}.muted{color:#68707a}.money{font-size:18px;font-weight:700;margin:5px 0}.actions{display:flex;gap:8px;flex-wrap:wrap}.button{display:inline-block;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none}.secondary{background:#59636e}.queue{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px}@media(max-width:900px){.grid{grid-template-columns:1fr 1fr}.queue{grid-template-columns:1fr}}@media(max-width:600px){.grid{grid-template-columns:1fr}}
+"""
+
+
+def _page(body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>Commercial dashboard · Veridra</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.view_data)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _money(values: dict[str, Decimal]) -> str:
+    if not values:
+        return "—"
+    return " · ".join(
+        f"{html.escape(currency)} {html.escape(f'{amount:.2f}')}"
+        for currency, amount in sorted(values.items())
+    )
+
+
+@router.get("", response_class=HTMLResponse)
+def commercial_dashboard(request: Request) -> str:
+    identity = _identity(request)
+    root = _root(request)
+    prospects = [prospect for _, prospect in TenantProspectStore(root).list(identity)]
+    leads = [lead for _, lead in TenantLeadStore(root).list(identity)]
+    customers = [customer for _, customer in TenantCustomerStore(root).list(identity)]
+    snapshot = build_commercial_snapshot(prospects, leads, customers)
+
+    active_pipeline = sum(
+        snapshot.prospect_counts.get(status, 0)
+        for status in (
+            ProspectStatus.contacted,
+            ProspectStatus.responded,
+            ProspectStatus.conversation,
+            ProspectStatus.proposal,
+        )
+    )
+    open_inbound = sum(
+        snapshot.lead_counts.get(status, 0)
+        for status in (LeadStatus.new, LeadStatus.contacted, LeadStatus.qualified)
+    )
+    active_customers = snapshot.customer_counts.get(CustomerStatus.active, 0)
+    paid_customers = snapshot.billing_counts.get(CustomerBillingStatus.paid, 0)
+
+    body = f"""{agency_navigation(identity, current='commercial')}<section><h1>Commercial dashboard</h1><p class='muted'>Tenant-scoped view from prospecting through customer onboarding and cash collection. Currency totals are kept separate; no FX conversion or accounting treatment is applied.</p><div class='actions'><a class='button' href='/agency/prospects'>Prospects</a><a class='button secondary' href='/agency/leads'>Inbound leads</a><a class='button secondary' href='/agency/customers'>Customers</a></div></section><section><div class='grid'><article class='card'><span class='muted'>Outbound sales in motion</span><div class='metric'>{active_pipeline}</div><span>contacted → proposal</span></article><article class='card'><span class='muted'>Open inbound leads</span><div class='metric'>{open_inbound}</div><span>new / contacted / qualified</span></article><article class='card'><span class='muted'>Active customers</span><div class='metric'>{active_customers}</div><span>onboarding completed</span></article><article class='card'><span class='muted'>Paid customers</span><div class='metric'>{paid_customers}</div><span>current billing record paid</span></article></div></section><section><h2>Pipeline value</h2><div class='grid'><article class='card'><span class='muted'>Inbound quoted pipeline</span><div class='money'>{_money(snapshot.quoted_pipeline)}</div></article><article class='card'><span class='muted'>Inbound expected pipeline</span><div class='money'>{_money(snapshot.expected_pipeline)}</div></article><article class='card'><span class='muted'>Client invoices tracked</span><div class='money'>{_money(snapshot.invoiced_total)}</div></article><article class='card'><span class='muted'>Paid</span><div class='money'>{_money(snapshot.paid_total)}</div></article></div></section><section><h2>Action queues</h2><div class='queue'><article class='card'><span class='muted'>Proposals awaiting outcome</span><div class='metric'>{snapshot.proposals}</div><a href='/agency/prospects'>Open prospects →</a></article><article class='card'><span class='muted'>Customers still onboarding</span><div class='metric'>{snapshot.customers_onboarding}</div><a href='/agency/customers'>Open customers →</a></article><article class='card'><span class='muted'>Overdue invoices</span><div class='metric'>{snapshot.overdue_invoices}</div><div class='money'>{_money(snapshot.overdue_total)}</div><a href='/agency/customers'>Review billing →</a></article></div></section><section><h2>Stage detail</h2><div class='grid'><article class='card'><strong>Outbound prospects</strong><p>Contacted: {snapshot.prospect_counts.get(ProspectStatus.contacted, 0)}<br>Responded: {snapshot.prospect_counts.get(ProspectStatus.responded, 0)}<br>Conversation: {snapshot.prospect_counts.get(ProspectStatus.conversation, 0)}<br>Proposal: {snapshot.prospect_counts.get(ProspectStatus.proposal, 0)}<br>Customer: {snapshot.prospect_counts.get(ProspectStatus.customer, 0)}<br>Lost: {snapshot.prospect_counts.get(ProspectStatus.lost, 0)}</p></article><article class='card'><strong>Inbound leads</strong><p>New: {snapshot.lead_counts.get(LeadStatus.new, 0)}<br>Contacted: {snapshot.lead_counts.get(LeadStatus.contacted, 0)}<br>Qualified: {snapshot.lead_counts.get(LeadStatus.qualified, 0)}<br>Won: {snapshot.lead_counts.get(LeadStatus.won, 0)}<br>Lost: {snapshot.lead_counts.get(LeadStatus.lost, 0)}</p></article><article class='card'><strong>Customers</strong><p>Onboarding: {snapshot.customer_counts.get(CustomerStatus.onboarding, 0)}<br>Active: {snapshot.customer_counts.get(CustomerStatus.active, 0)}<br>Paused: {snapshot.customer_counts.get(CustomerStatus.paused, 0)}<br>Closed: {snapshot.customer_counts.get(CustomerStatus.closed, 0)}</p></article><article class='card'><strong>Billing</strong><p>Unbilled: {snapshot.billing_counts.get(CustomerBillingStatus.unbilled, 0)}<br>Prepared: {snapshot.billing_counts.get(CustomerBillingStatus.invoice_prepared, 0)}<br>Sent: {snapshot.billing_counts.get(CustomerBillingStatus.invoice_sent, 0)}<br>Paid: {snapshot.billing_counts.get(CustomerBillingStatus.paid, 0)}<br>Overdue: {snapshot.billing_counts.get(CustomerBillingStatus.overdue, 0)}<br>Cancelled: {snapshot.billing_counts.get(CustomerBillingStatus.cancelled, 0)}</p></article></div></section>"""
+    return _page(body)

--- a/src/veridra/agency_navigation.py
+++ b/src/veridra/agency_navigation.py
@@ -9,6 +9,7 @@ def agency_navigation(identity: RequestIdentity, *, current: str | None = None) 
     capabilities = TENANT_ROLE_CAPABILITIES[identity.membership_role]
     destinations: list[tuple[str, str, str]] = [
         ("home", "/agency", "Agency home"),
+        ("commercial", "/agency/commercial", "Commercial"),
         ("customers", "/agency/customers", "Customers"),
         ("projects", "/agency/projects", "Client projects"),
     ]

--- a/src/veridra/commercial_dashboard.py
+++ b/src/veridra/commercial_dashboard.py
@@ -37,8 +37,8 @@ class CommercialSnapshot:
         return self.billing_counts.get(CustomerBillingStatus.overdue, 0)
 
 
-def _count(values: Iterable[T], enum_type: type[T]) -> dict[T, int]:
-    counts = {item: 0 for item in enum_type}
+def _count(values: Iterable[T], members: Iterable[T]) -> dict[T, int]:
+    counts = {item: 0 for item in members}
     for value in values:
         counts[value] = counts.get(value, 0) + 1
     return counts
@@ -87,7 +87,10 @@ def build_commercial_snapshot(
         prospect_counts=_count((item.status for item in prospect_list), ProspectStatus),
         lead_counts=_count((item.status for item in lead_list), LeadStatus),
         customer_counts=_count((item.status for item in customer_list), CustomerStatus),
-        billing_counts=_count((item.billing.status for item in customer_list), CustomerBillingStatus),
+        billing_counts=_count(
+            (item.billing.status for item in customer_list),
+            CustomerBillingStatus,
+        ),
         quoted_pipeline=quoted_pipeline,
         expected_pipeline=expected_pipeline,
         invoiced_total=invoiced_total,

--- a/src/veridra/commercial_dashboard.py
+++ b/src/veridra/commercial_dashboard.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from decimal import Decimal
+
+from .customer_store import CustomerBillingStatus, CustomerRecord, CustomerStatus
+from .lead_store import AuditLead, LeadStatus
+from .prospect import Prospect, ProspectStatus
+
+
+@dataclass(frozen=True, slots=True)
+class CommercialSnapshot:
+    prospect_counts: dict[ProspectStatus, int]
+    lead_counts: dict[LeadStatus, int]
+    customer_counts: dict[CustomerStatus, int]
+    billing_counts: dict[CustomerBillingStatus, int]
+    quoted_pipeline: dict[str, Decimal]
+    expected_pipeline: dict[str, Decimal]
+    invoiced_total: dict[str, Decimal]
+    paid_total: dict[str, Decimal]
+    overdue_total: dict[str, Decimal]
+
+    @property
+    def proposals(self) -> int:
+        return self.prospect_counts.get(ProspectStatus.proposal, 0)
+
+    @property
+    def customers_onboarding(self) -> int:
+        return self.customer_counts.get(CustomerStatus.onboarding, 0)
+
+    @property
+    def overdue_invoices(self) -> int:
+        return self.billing_counts.get(CustomerBillingStatus.overdue, 0)
+
+
+def _count[T](values: Iterable[T], enum_type: type[T]) -> dict[T, int]:
+    counts = {item: 0 for item in enum_type}
+    for value in values:
+        counts[value] = counts.get(value, 0) + 1
+    return counts
+
+
+def _add_money(target: dict[str, Decimal], currency: str, amount: Decimal | None) -> None:
+    if amount is None:
+        return
+    target[currency] = target.get(currency, Decimal("0.00")) + amount
+
+
+def build_commercial_snapshot(
+    prospects: Iterable[Prospect],
+    leads: Iterable[AuditLead],
+    customers: Iterable[CustomerRecord],
+) -> CommercialSnapshot:
+    prospect_list = list(prospects)
+    lead_list = list(leads)
+    customer_list = list(customers)
+
+    quoted_pipeline: dict[str, Decimal] = {}
+    expected_pipeline: dict[str, Decimal] = {}
+    for lead in lead_list:
+        if lead.status not in {LeadStatus.won, LeadStatus.lost, LeadStatus.deleted_pending}:
+            _add_money(quoted_pipeline, lead.currency, lead.quoted_value)
+            _add_money(expected_pipeline, lead.currency, lead.expected_value)
+
+    invoiced_total: dict[str, Decimal] = {}
+    paid_total: dict[str, Decimal] = {}
+    overdue_total: dict[str, Decimal] = {}
+    for customer in customer_list:
+        billing = customer.billing
+        if billing.status in {
+            CustomerBillingStatus.invoice_prepared,
+            CustomerBillingStatus.invoice_sent,
+            CustomerBillingStatus.paid,
+            CustomerBillingStatus.overdue,
+        }:
+            _add_money(invoiced_total, billing.currency, billing.invoice_amount)
+        if billing.status is CustomerBillingStatus.paid:
+            _add_money(paid_total, billing.currency, billing.invoice_amount)
+        if billing.status is CustomerBillingStatus.overdue:
+            _add_money(overdue_total, billing.currency, billing.invoice_amount)
+
+    return CommercialSnapshot(
+        prospect_counts=_count((item.status for item in prospect_list), ProspectStatus),
+        lead_counts=_count((item.status for item in lead_list), LeadStatus),
+        customer_counts=_count((item.status for item in customer_list), CustomerStatus),
+        billing_counts=_count((item.billing.status for item in customer_list), CustomerBillingStatus),
+        quoted_pipeline=quoted_pipeline,
+        expected_pipeline=expected_pipeline,
+        invoiced_total=invoiced_total,
+        paid_total=paid_total,
+        overdue_total=overdue_total,
+    )

--- a/src/veridra/commercial_dashboard.py
+++ b/src/veridra/commercial_dashboard.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import TypeVar
 
 from .customer_store import CustomerBillingStatus, CustomerRecord, CustomerStatus
 from .lead_store import AuditLead, LeadStatus
 from .prospect import Prospect, ProspectStatus
+
+T = TypeVar("T")
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,7 +37,7 @@ class CommercialSnapshot:
         return self.billing_counts.get(CustomerBillingStatus.overdue, 0)
 
 
-def _count[T](values: Iterable[T], enum_type: type[T]) -> dict[T, int]:
+def _count(values: Iterable[T], enum_type: type[T]) -> dict[T, int]:
     counts = {item: 0 for item in enum_type}
     for value in values:
         counts[value] = counts.get(value, 0) + 1

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -6,6 +6,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from . import app as app_module
 from . import public_web
 from .access_logging import StructuredAccessLogMiddleware, configure_access_logger
+from .agency_commercial_dashboard_web import router as agency_commercial_dashboard_router
 from .agency_conversion_web import router as agency_conversion_router
 from .agency_crawl_profile_web import router as agency_crawl_profile_router
 from .agency_customer_web import router as agency_customer_router
@@ -157,6 +158,7 @@ app.include_router(tenant_team_router)
 app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)
+app.include_router(agency_commercial_dashboard_router)
 app.include_router(agency_customer_router)
 app.include_router(agency_project_index_router)
 app.include_router(agency_conversion_router)

--- a/tests/test_commercial_dashboard.py
+++ b/tests/test_commercial_dashboard.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from veridra.commercial_dashboard import build_commercial_snapshot
+from veridra.customer_store import (
+    CustomerBillingState,
+    CustomerBillingStatus,
+    CustomerRecord,
+    CustomerSourceType,
+    CustomerStatus,
+)
+from veridra.lead_store import AuditLead, LeadStatus
+from veridra.prospect import Prospect, ProspectStatus
+
+
+def _lead(
+    *,
+    status: LeadStatus,
+    currency: str,
+    quoted: Decimal | None,
+    expected: Decimal | None,
+) -> AuditLead:
+    return AuditLead(
+        form_id="a" * 24,
+        website="https://example.com",
+        name="Example Lead",
+        email="lead@example.com",
+        consent_text="I agree",
+        consented_at=datetime.now(UTC),
+        assessment_id="b" * 24,
+        status=status,
+        quoted_value=quoted,
+        expected_value=expected,
+        currency=currency,
+    )
+
+
+def _customer(
+    source_id: str,
+    *,
+    status: CustomerStatus,
+    billing_status: CustomerBillingStatus,
+    amount: Decimal | None,
+    currency: str,
+) -> CustomerRecord:
+    paid_at = datetime.now(UTC) if billing_status is CustomerBillingStatus.paid else None
+    reference = "WEB-001" if billing_status not in {
+        CustomerBillingStatus.unbilled,
+        CustomerBillingStatus.cancelled,
+    } else ""
+    return CustomerRecord(
+        business_name=f"Customer {source_id[0]}",
+        source_type=CustomerSourceType.manual,
+        source_id=source_id,
+        status=status,
+        billing=CustomerBillingState(
+            status=billing_status,
+            invoice_reference=reference,
+            invoice_amount=amount,
+            currency=currency,
+            paid_at=paid_at,
+        ),
+    )
+
+
+def test_empty_commercial_snapshot_is_safe() -> None:
+    snapshot = build_commercial_snapshot([], [], [])
+
+    assert snapshot.proposals == 0
+    assert snapshot.customers_onboarding == 0
+    assert snapshot.overdue_invoices == 0
+    assert snapshot.quoted_pipeline == {}
+    assert snapshot.paid_total == {}
+
+
+def test_pipeline_and_cash_totals_keep_currencies_separate() -> None:
+    leads = [
+        _lead(
+            status=LeadStatus.qualified,
+            currency="EUR",
+            quoted=Decimal("650.00"),
+            expected=Decimal("500.00"),
+        ),
+        _lead(
+            status=LeadStatus.contacted,
+            currency="GBP",
+            quoted=Decimal("400.00"),
+            expected=Decimal("200.00"),
+        ),
+        _lead(
+            status=LeadStatus.won,
+            currency="EUR",
+            quoted=Decimal("900.00"),
+            expected=Decimal("900.00"),
+        ),
+    ]
+    customers = [
+        _customer(
+            "c" * 24,
+            status=CustomerStatus.active,
+            billing_status=CustomerBillingStatus.paid,
+            amount=Decimal("650.00"),
+            currency="EUR",
+        ),
+        _customer(
+            "d" * 24,
+            status=CustomerStatus.onboarding,
+            billing_status=CustomerBillingStatus.overdue,
+            amount=Decimal("300.00"),
+            currency="EUR",
+        ),
+        _customer(
+            "e" * 24,
+            status=CustomerStatus.active,
+            billing_status=CustomerBillingStatus.invoice_sent,
+            amount=Decimal("450.00"),
+            currency="GBP",
+        ),
+    ]
+    prospects = [
+        Prospect(business_name="Proposal", status=ProspectStatus.proposal),
+        Prospect(business_name="Conversation", status=ProspectStatus.conversation),
+    ]
+
+    snapshot = build_commercial_snapshot(prospects, leads, customers)
+
+    assert snapshot.proposals == 1
+    assert snapshot.customers_onboarding == 1
+    assert snapshot.overdue_invoices == 1
+    assert snapshot.quoted_pipeline == {
+        "EUR": Decimal("650.00"),
+        "GBP": Decimal("400.00"),
+    }
+    assert snapshot.expected_pipeline == {
+        "EUR": Decimal("500.00"),
+        "GBP": Decimal("200.00"),
+    }
+    assert snapshot.invoiced_total == {
+        "EUR": Decimal("950.00"),
+        "GBP": Decimal("450.00"),
+    }
+    assert snapshot.paid_total == {"EUR": Decimal("650.00")}
+    assert snapshot.overdue_total == {"EUR": Decimal("300.00")}

--- a/tests/test_commercial_dashboard.py
+++ b/tests/test_commercial_dashboard.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 
+from pydantic import HttpUrl
+
 from veridra.commercial_dashboard import build_commercial_snapshot
 from veridra.customer_store import (
     CustomerBillingState,
@@ -24,7 +26,7 @@ def _lead(
 ) -> AuditLead:
     return AuditLead(
         form_id="a" * 24,
-        website="https://example.com",
+        website=HttpUrl("https://example.com"),
         name="Example Lead",
         email="lead@example.com",
         consent_text="I agree",

--- a/tests/test_commercial_dashboard.py
+++ b/tests/test_commercial_dashboard.py
@@ -9,6 +9,7 @@ from veridra.commercial_dashboard import build_commercial_snapshot
 from veridra.customer_store import (
     CustomerBillingState,
     CustomerBillingStatus,
+    CustomerOnboardingChecklist,
     CustomerRecord,
     CustomerSourceType,
     CustomerStatus,
@@ -52,11 +53,23 @@ def _customer(
         CustomerBillingStatus.unbilled,
         CustomerBillingStatus.cancelled,
     } else ""
+    onboarding = (
+        CustomerOnboardingChecklist(
+            contact_confirmed=True,
+            scope_confirmed=True,
+            commercial_terms_confirmed=True,
+            access_requirements_confirmed=True,
+            kickoff_completed=True,
+        )
+        if status is CustomerStatus.active
+        else CustomerOnboardingChecklist()
+    )
     return CustomerRecord(
         business_name=f"Customer {source_id[0]}",
         source_type=CustomerSourceType.manual,
         source_id=source_id,
         status=status,
+        onboarding=onboarding,
         billing=CustomerBillingState(
             status=billing_status,
             invoice_reference=reference,


### PR DESCRIPTION
Implements issue #256.

Changes:
- adds a tenant-scoped Commercial dashboard at `/agency/commercial`;
- aggregates outbound prospect funnel counts, inbound lead stages, customer lifecycle and billing state;
- separates quoted/expected pipeline, invoiced, paid and overdue totals by currency with no FX conversion;
- surfaces action queues for proposals, customers still onboarding and overdue invoices;
- links directly to Prospects, Inbound Leads and Customers;
- adds Commercial to shared agency navigation;
- pure aggregation tests cover empty state, stage counts, paid/overdue totals and strict currency separation.

Read-only operational reporting only; no accounting treatment, forecasting, collections or external frontend dependencies.