### PR TITLE
P0 outbound prospect activity and follow-up history

### DIFF
--- a/src/veridra/agency_prospect_web.py
+++ b/src/veridra/agency_prospect_web.py
@@ -27,6 +27,7 @@ from .prospect import (
     StageAQualification,
     prospect_identifier,
 )
+from .prospect_activity import ProspectActivityError, TenantProspectActivityStore
 from .request_security import require_request_identity
 from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
 from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
@@ -34,7 +35,7 @@ from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
 router = APIRouter(prefix="/agency/prospects", tags=["agency-prospects"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1180px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.warning{border-left-color:#b7791f;background:#fff8e6}.actions{display:flex;gap:8px;flex-wrap:wrap}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:100px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.score-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}@media(max-width:760px){.row,.score-grid{grid-template-columns:1fr}table{display:block;overflow:auto}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1180px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.warning{border-left-color:#b7791f;background:#fff8e6}.actions{display:flex;gap:8px;flex-wrap:wrap}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:100px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.score-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}.timeline{list-style:none;padding:0;margin:0}.timeline li{padding:12px 0;border-bottom:1px solid #e5e7eb}.timeline time{display:block;color:#68707a;font-size:12px;margin-bottom:4px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}@media(max-width:760px){.row,.score-grid{grid-template-columns:1fr}table{display:block;overflow:auto}}
 """
 
 _COMMERCIAL_STATUSES = (
@@ -60,6 +61,10 @@ def _page(title: str, body: str) -> str:
 def _root(request: Request) -> Path | None:
     value = getattr(request.app.state, "veridra_tenant_data_root", None)
     return value if isinstance(value, Path) else None
+
+
+def _activity_root(request: Request) -> Path:
+    return _root(request) or Path.home() / ".veridra" / "tenants"
 
 
 def _store(request: Request) -> TenantProspectStore:
@@ -91,6 +96,12 @@ def _values(body: bytes) -> dict[str, list[str]]:
 
 def _one(values: dict[str, list[str]], name: str) -> str:
     return values.get(name, [""])[0].strip()
+
+
+def _datetime_local(value: datetime | None) -> str:
+    if value is None:
+        return ""
+    return value.isoformat(timespec="minutes").replace("+00:00", "")
 
 
 def _load(request: Request, identity: RequestIdentity, prospect_id: str) -> Prospect:
@@ -142,18 +153,20 @@ def prospect_index(request: Request) -> str:
             if audit_url and prospect.status not in _TERMINAL_QUALIFICATION_STATUSES
             else ""
         )
+        follow_up = prospect.next_follow_up_at.isoformat() if prospect.next_follow_up_at else "—"
         rows.append(
             "<tr>"
             f"<td><strong>{html.escape(prospect.business_name)}</strong><br><span class='muted'>{html.escape(prospect.sector or 'Unclassified')}</span></td>"
             f"<td>{html.escape(prospect.locality or '—')}<br><span class='muted'>{html.escape(prospect.administrative_area or '')}</span></td>"
             f"<td>{html.escape(website)}</td>"
             f"<td><span class='badge'>{html.escape(prospect.status.value)}</span></td>"
+            f"<td>{html.escape(follow_up)}<br><span class='muted'>{html.escape(prospect.next_action or 'No action')}</span></td>"
             f"<td>{html.escape(_decision(prospect))}</td>"
             f"<td><div class='actions'><a class='button' href='/agency/prospects/{html.escape(prospect_id, quote=True)}'>Review</a>{audit_action}</div></td>"
             "</tr>"
         )
     table = (
-        "<table><thead><tr><th>Business</th><th>Territory</th><th>Website</th><th>Status</th><th>Stage A</th><th>Actions</th></tr></thead><tbody>"
+        "<table><thead><tr><th>Business</th><th>Territory</th><th>Website</th><th>Status</th><th>Follow-up</th><th>Stage A</th><th>Actions</th></tr></thead><tbody>"
         + "".join(rows)
         + "</tbody></table>"
         if rows
@@ -226,6 +239,14 @@ def prospect_detail(prospect_id: str, request: Request) -> str:
     website = str(prospect.website) if prospect.website is not None else "—"
     audit_url = _audit_url(prospect)
     audit_action = f"<a class='button' href='{html.escape(audit_url, quote=True)}'>Start website audit</a>" if audit_url else "<span class='muted'>Add a website before auditing.</span>"
+    try:
+        events = TenantProspectActivityStore(_activity_root(request)).list(identity, prospect_id)
+    except ProspectActivityError as exc:
+        raise HTTPException(status_code=404, detail="Prospect activity could not be read.") from exc
+    timeline = "".join(
+        f"<li><time>{html.escape(event.occurred_at.isoformat())}</time><strong>{html.escape(event.event_type.value.replace('_', ' ').title())}</strong><div>{html.escape(event.summary)}</div></li>"
+        for event in reversed(events)
+    ) or "<li class='muted'>No activity recorded yet.</li>"
     qualification = prospect.qualification
     values = {
         "active_real_business": qualification.active_real_business if qualification else 0,
@@ -260,8 +281,8 @@ def prospect_detail(prospect_id: str, request: Request) -> str:
     if prospect.status in _TERMINAL_QUALIFICATION_STATUSES:
         commercial_section = "<section><h2>Commercial funnel</h2><p class='notice warning'>This prospect is terminally rejected/archived at qualification stage. Re-open qualification before recording outreach.</p></section>"
     else:
-        commercial_section = f"<section><h2>Commercial funnel</h2><p class='muted'>Record what actually happened after qualification. This is sales evidence, not an automated outreach action.</p><form method='post' action='/agency/prospects/{html.escape(prospect_id, quote=True)}/commercial'><div class='row'><div><label for='commercial_status'>Funnel stage</label><select id='commercial_status' name='status'>{_commercial_status_options(prospect)}</select></div><div><label for='commercial_loss_reason'>Loss reason</label><select id='commercial_loss_reason' name='commercial_loss_reason'>{_commercial_loss_options(prospect)}</select></div></div><div class='row'><div><label for='outreach_offer'>Offer used</label><input id='outreach_offer' name='outreach_offer' maxlength='240' value='{html.escape(prospect.outreach_offer, quote=True)}' placeholder='e.g. Website Improvement Sprint'></div><div><label for='message_variant'>Message variant / cohort</label><input id='message_variant' name='message_variant' maxlength='120' value='{html.escape(prospect.message_variant, quote=True)}' placeholder='e.g. dental-vigo-v1'></div></div><label for='commercial_note'>Commercial note</label><textarea id='commercial_note' name='commercial_note' maxlength='2000' placeholder='Channel, reply context, objection, proposal note or other useful evidence.'>{html.escape(prospect.commercial_note)}</textarea><p class='notice'>A prospect marked <strong>lost</strong> requires a loss reason. For every other stage the loss reason is cleared automatically.</p><button type='submit'>Save commercial progress</button></form></section>"
-    body = f"{navigation}<section><p><a href='/agency/prospects'>← Prospects</a></p><h1>{html.escape(prospect.business_name)}</h1><p><span class='badge'>{html.escape(prospect.status.value)}</span> · Stage A: {html.escape(_decision(prospect))}</p><p><strong>Website:</strong> {html.escape(website)}<br><strong>Sector:</strong> {html.escape(prospect.sector or '—')}<br><strong>Territory:</strong> {html.escape(prospect.locality or '—')}, {html.escape(prospect.administrative_area or '—')}<br><strong>Contact:</strong> {html.escape(prospect.contact_email or prospect.phone or '—')}</p><p class='notice'>{html.escape(prospect.evidence_summary or 'No discovery evidence recorded yet.')}</p><div class='actions'>{audit_action}</div></section>{qualification_section}{commercial_section}"
+        commercial_section = f"<section><h2>Commercial funnel</h2><p class='muted'>Record what actually happened after qualification. This is sales evidence, not an automated outreach action.</p><form method='post' action='/agency/prospects/{html.escape(prospect_id, quote=True)}/commercial'><div class='row'><div><label for='commercial_status'>Funnel stage</label><select id='commercial_status' name='status'>{_commercial_status_options(prospect)}</select></div><div><label for='commercial_loss_reason'>Loss reason</label><select id='commercial_loss_reason' name='commercial_loss_reason'>{_commercial_loss_options(prospect)}</select></div></div><div class='row'><div><label for='outreach_offer'>Offer used</label><input id='outreach_offer' name='outreach_offer' maxlength='240' value='{html.escape(prospect.outreach_offer, quote=True)}' placeholder='e.g. Website Improvement Sprint'></div><div><label for='message_variant'>Message variant / cohort</label><input id='message_variant' name='message_variant' maxlength='120' value='{html.escape(prospect.message_variant, quote=True)}' placeholder='e.g. dental-dublin-v1'></div><div><label for='last_contacted_at'>Last contacted</label><input id='last_contacted_at' name='last_contacted_at' type='datetime-local' value='{html.escape(_datetime_local(prospect.last_contacted_at), quote=True)}'></div><div><label for='next_follow_up_at'>Next follow-up</label><input id='next_follow_up_at' name='next_follow_up_at' type='datetime-local' value='{html.escape(_datetime_local(prospect.next_follow_up_at), quote=True)}'></div></div><label for='next_action'>Next action</label><input id='next_action' name='next_action' maxlength='500' value='{html.escape(prospect.next_action, quote=True)}' placeholder='e.g. Follow up by phone on Monday'><label for='commercial_note'>Commercial note</label><textarea id='commercial_note' name='commercial_note' maxlength='2000' placeholder='Channel, reply context, objection, proposal note or other useful evidence.'>{html.escape(prospect.commercial_note)}</textarea><p class='notice'>A prospect marked <strong>lost</strong> requires a loss reason. For every other stage the loss reason is cleared automatically.</p><button type='submit'>Save commercial progress</button></form></section>"
+    body = f"{navigation}<section><p><a href='/agency/prospects'>← Prospects</a></p><h1>{html.escape(prospect.business_name)}</h1><p><span class='badge'>{html.escape(prospect.status.value)}</span> · Stage A: {html.escape(_decision(prospect))}</p><p><strong>Website:</strong> {html.escape(website)}<br><strong>Sector:</strong> {html.escape(prospect.sector or '—')}<br><strong>Territory:</strong> {html.escape(prospect.locality or '—')}, {html.escape(prospect.administrative_area or '—')}<br><strong>Contact:</strong> {html.escape(prospect.contact_email or prospect.phone or '—')}<br><strong>Next action:</strong> {html.escape(prospect.next_action or '—')}</p><p class='notice'>{html.escape(prospect.evidence_summary or 'No discovery evidence recorded yet.')}</p><div class='actions'>{audit_action}</div></section>{qualification_section}{commercial_section}<section><h2>Activity history</h2><p class='muted'>Append-only record of meaningful outbound CRM changes.</p><ul class='timeline'>{timeline}</ul></section>"
     return _page(prospect.business_name, body)
 
 
@@ -346,6 +367,9 @@ async def update_commercial_progress(prospect_id: str, request: Request) -> Redi
                     loss_reason.value if loss_reason is not None else None
                 ),
                 "commercial_note": _one(values, "commercial_note"),
+                "last_contacted_at": _one(values, "last_contacted_at") or None,
+                "next_follow_up_at": _one(values, "next_follow_up_at") or None,
+                "next_action": _one(values, "next_action"),
                 "human_verified": True,
                 "updated_at": datetime.now(UTC),
             }

--- a/src/veridra/customer_lifecycle.py
+++ b/src/veridra/customer_lifecycle.py
@@ -110,7 +110,7 @@ def upsert_customer_from_prospect(
         updated_at=datetime.now(UTC),
         activated_at=current.activated_at if current is not None else None,
     )
-    saved_id = store.upsert(identity, customer)
+    saved_id = store.upsert_from_prospect_conversion(identity, customer)
     if saved_id != customer_id:
         raise TenantCustomerStoreError("Customer identity changed unexpectedly.")
     return saved_id

--- a/src/veridra/prospect.py
+++ b/src/veridra/prospect.py
@@ -132,6 +132,9 @@ class Prospect(BaseModel):
     message_variant: str = Field(default="", max_length=120)
     commercial_loss_reason: ProspectCommercialLossReason | None = None
     commercial_note: str = Field(default="", max_length=2000)
+    last_contacted_at: datetime | None = None
+    next_follow_up_at: datetime | None = None
+    next_action: str = Field(default="", max_length=500)
     human_verified: bool = False
     rejection_reason: ProspectRejectionReason | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/src/veridra/prospect_activity.py
+++ b/src/veridra/prospect_activity.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .identity_tenancy import RequestIdentity, TenantCapability, require_tenant_capability
+
+
+class ProspectActivityError(RuntimeError):
+    pass
+
+
+class ProspectActivityType(StrEnum):
+    created = "created"
+    stage_changed = "stage_changed"
+    contact_recorded = "contact_recorded"
+    follow_up_changed = "follow_up_changed"
+    commercial_changed = "commercial_changed"
+    note_changed = "note_changed"
+    customer_converted = "customer_converted"
+
+
+class ProspectActivityEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    occurred_at: datetime
+    event_type: ProspectActivityType
+    summary: str = Field(min_length=1, max_length=500)
+    actor: str = Field(default="", max_length=160)
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+
+def _valid_identifier(value: str) -> bool:
+    return len(value) == 24 and all(char in "0123456789abcdef" for char in value)
+
+
+class TenantProspectActivityStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def _path(self, tenant_id: str, prospect_id: str) -> Path:
+        if not _valid_identifier(tenant_id):
+            raise ProspectActivityError("Tenant identifier is invalid.")
+        if not _valid_identifier(prospect_id):
+            raise ProspectActivityError("Prospect identifier is invalid.")
+        return self.root / tenant_id / "prospect-activity" / f"{prospect_id}.jsonl"
+
+    @staticmethod
+    def _event_bytes(event: ProspectActivityEvent) -> bytes:
+        payload = json.dumps(
+            event.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        return (payload + "\n").encode("utf-8")
+
+    def append(
+        self,
+        identity: RequestIdentity,
+        prospect_id: str,
+        event_type: ProspectActivityType,
+        summary: str,
+        *,
+        metadata: dict[str, str] | None = None,
+    ) -> ProspectActivityEvent:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+        event = ProspectActivityEvent(
+            occurred_at=datetime.now(UTC),
+            event_type=event_type,
+            summary=summary,
+            actor=identity.user_id,
+            metadata=metadata or {},
+        )
+        destination = self._path(identity.tenant_id, prospect_id)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with destination.open("ab") as handle:
+                handle.write(self._event_bytes(event))
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError as exc:
+            raise ProspectActivityError("Prospect activity could not be appended safely.") from exc
+        return event
+
+    def ensure_created(self, identity: RequestIdentity, prospect_id: str) -> None:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+        destination = self._path(identity.tenant_id, prospect_id)
+        if destination.exists() and destination.stat().st_size > 0:
+            return
+        self.append(
+            identity,
+            prospect_id,
+            ProspectActivityType.created,
+            "Prospect record created",
+        )
+
+    def list(self, identity: RequestIdentity, prospect_id: str) -> list[ProspectActivityEvent]:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        source = self._path(identity.tenant_id, prospect_id)
+        if not source.exists():
+            return []
+        events: list[ProspectActivityEvent] = []
+        try:
+            for line in source.read_text(encoding="utf-8").splitlines():
+                if line.strip():
+                    events.append(ProspectActivityEvent.model_validate_json(line))
+        except (OSError, ValueError) as exc:
+            raise ProspectActivityError("Prospect activity could not be read safely.") from exc
+        return sorted(events, key=lambda event: event.occurred_at)

--- a/src/veridra/tenant_customer_store.py
+++ b/src/veridra/tenant_customer_store.py
@@ -39,6 +39,18 @@ class TenantCustomerStore:
         except CustomerStoreError as exc:
             raise TenantCustomerStoreError("Customer record could not be saved.") from exc
 
+    def upsert_from_prospect_conversion(
+        self,
+        identity: RequestIdentity,
+        customer: CustomerRecord,
+    ) -> str:
+        """Allow the sales workflow to create/update its prospect-backed customer record only."""
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+        try:
+            return self._store(identity).upsert(customer)
+        except CustomerStoreError as exc:
+            raise TenantCustomerStoreError("Customer record could not be saved.") from exc
+
     def load(self, identity: RequestIdentity, target: TenantObjectRef) -> CustomerRecord:
         require_tenant_scope(identity, target)
         if target.object_type != "customer":

--- a/src/veridra/tenant_prospect_store.py
+++ b/src/veridra/tenant_prospect_store.py
@@ -11,6 +11,11 @@ from .identity_tenancy import (
     require_tenant_scope,
 )
 from .prospect import Prospect, ProspectStatus, ProspectStore, ProspectStoreError
+from .prospect_activity import (
+    ProspectActivityError,
+    ProspectActivityType,
+    TenantProspectActivityStore,
+)
 from .tenant_customer_store import TenantCustomerStore, TenantCustomerStoreError
 from .tenant_project_store import default_tenant_data_directory
 
@@ -26,6 +31,9 @@ class TenantProspectStore:
     def _store(self, identity: RequestIdentity) -> ProspectStore:
         return ProspectStore(self.root / identity.tenant_id / "prospects")
 
+    def _activity(self) -> TenantProspectActivityStore:
+        return TenantProspectActivityStore(self.root)
+
     @staticmethod
     def ref(identity: RequestIdentity, prospect_id: str) -> TenantObjectRef:
         return TenantObjectRef(
@@ -36,7 +44,12 @@ class TenantProspectStore:
 
     def save(self, identity: RequestIdentity, prospect: Prospect) -> str:
         require_tenant_capability(identity, TenantCapability.manage_leads)
-        return self._store(identity).save(prospect)
+        prospect_id = self._store(identity).save(prospect)
+        try:
+            self._activity().ensure_created(identity, prospect_id)
+        except ProspectActivityError as exc:
+            raise TenantProspectStoreError("Prospect activity could not be recorded.") from exc
+        return prospect_id
 
     def load(self, identity: RequestIdentity, target: TenantObjectRef) -> Prospect:
         require_tenant_scope(identity, target)
@@ -67,7 +80,63 @@ class TenantProspectStore:
         if target.object_type != "prospect":
             raise TenantProspectStoreError("Tenant object is not a prospect reference.")
         try:
+            previous = self._store(identity).load(target.object_id)
             self._store(identity).replace(target.object_id, prospect)
+            activity = self._activity()
+            activity.ensure_created(identity, target.object_id)
+            if previous.status is not prospect.status:
+                activity.append(
+                    identity,
+                    target.object_id,
+                    ProspectActivityType.stage_changed,
+                    f"Stage changed from {previous.status.value} to {prospect.status.value}",
+                    metadata={
+                        "from": previous.status.value,
+                        "to": prospect.status.value,
+                    },
+                )
+                if prospect.status is ProspectStatus.customer:
+                    activity.append(
+                        identity,
+                        target.object_id,
+                        ProspectActivityType.customer_converted,
+                        "Prospect converted to customer",
+                    )
+            if previous.last_contacted_at != prospect.last_contacted_at:
+                activity.append(
+                    identity,
+                    target.object_id,
+                    ProspectActivityType.contact_recorded,
+                    "Contact timestamp updated",
+                )
+            if (
+                previous.next_follow_up_at != prospect.next_follow_up_at
+                or previous.next_action != prospect.next_action
+            ):
+                activity.append(
+                    identity,
+                    target.object_id,
+                    ProspectActivityType.follow_up_changed,
+                    "Follow-up plan updated",
+                )
+            if (
+                previous.outreach_offer != prospect.outreach_offer
+                or previous.message_variant != prospect.message_variant
+                or previous.commercial_loss_reason != prospect.commercial_loss_reason
+            ):
+                activity.append(
+                    identity,
+                    target.object_id,
+                    ProspectActivityType.commercial_changed,
+                    "Commercial details updated",
+                )
+            if previous.commercial_note != prospect.commercial_note:
+                activity.append(
+                    identity,
+                    target.object_id,
+                    ProspectActivityType.note_changed,
+                    "Commercial note updated",
+                )
             if prospect.status is ProspectStatus.customer:
                 upsert_customer_from_prospect(
                     TenantCustomerStore(self.root),
@@ -75,8 +144,8 @@ class TenantProspectStore:
                     prospect_id=target.object_id,
                     prospect=prospect,
                 )
-        except ProspectStoreError as exc:
-            raise TenantProspectStoreError("Saved prospect was not found.") from exc
+        except (ProspectStoreError, ProspectActivityError) as exc:
+            raise TenantProspectStoreError("Saved prospect could not be updated safely.") from exc
         except TenantCustomerStoreError as exc:
             raise TenantProspectStoreError(
                 "Customer onboarding record could not be saved."

--- a/tests/test_prospect_activity_followup.py
+++ b/tests/test_prospect_activity_followup.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi import Response as FastAPIResponse
+from fastapi.testclient import TestClient
+
+from veridra.agency_prospect_web import router as agency_prospect_router
+from veridra.customer_store import CustomerSourceType
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.prospect import Prospect, ProspectStatus
+from veridra.prospect_activity import ProspectActivityType, TenantProspectActivityStore
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_customer_store import TenantCustomerStore
+from veridra.tenant_prospect_store import TenantProspectStore
+
+ORIGIN = "http://testserver"
+NOW = datetime(2026, 8, 28, 9, 0, tzinfo=UTC)
+
+
+def _identity(*, tenant: str = "b") -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id=tenant * 24,
+        membership_role=TenantRole.sales,
+        session_id="prospect-activity-session-001",
+        authenticated_at=NOW,
+    )
+
+
+def _prospect() -> Prospect:
+    return Prospect(
+        business_name="No Site Dental",
+        sector="Dental clinic",
+        locality="Dublin",
+        country_code="IE",
+        phone="+35310000000",
+        contact_email="hello@nositedental.example",
+        status=ProspectStatus.approved_for_outreach,
+        human_verified=True,
+    )
+
+
+def test_legacy_prospect_without_follow_up_fields_loads_with_safe_defaults() -> None:
+    legacy = Prospect.model_validate(
+        {
+            "business_name": "Legacy Dental",
+            "sector": "Dental clinic",
+            "locality": "Dublin",
+            "country_code": "IE",
+            "status": "contacted",
+        }
+    )
+
+    assert legacy.last_contacted_at is None
+    assert legacy.next_follow_up_at is None
+    assert legacy.next_action == ""
+
+
+def test_activity_log_is_append_only_and_records_meaningful_changes(tmp_path: Path) -> None:
+    identity = _identity()
+    store = TenantProspectStore(tmp_path)
+    prospect = _prospect()
+    prospect_id = store.save(identity, prospect)
+    activity = TenantProspectActivityStore(tmp_path)
+    path = tmp_path / identity.tenant_id / "prospect-activity" / f"{prospect_id}.jsonl"
+
+    original_bytes = path.read_bytes()
+    original_events = activity.list(identity, prospect_id)
+    assert [event.event_type for event in original_events] == [ProspectActivityType.created]
+
+    contacted = prospect.model_copy(
+        update={
+            "status": ProspectStatus.contacted,
+            "last_contacted_at": datetime(2026, 8, 28, 9, 30, tzinfo=UTC),
+            "next_follow_up_at": datetime(2026, 8, 31, 10, 0, tzinfo=UTC),
+            "next_action": "Call the clinic manager",
+            "outreach_offer": "Website Improvement Sprint",
+            "message_variant": "dublin-dental-v1",
+            "commercial_note": "Personalised email sent.",
+        }
+    )
+    store.replace(identity, store.ref(identity, prospect_id), contacted)
+
+    updated_bytes = path.read_bytes()
+    events = activity.list(identity, prospect_id)
+    event_types = [event.event_type for event in events]
+
+    assert updated_bytes.startswith(original_bytes)
+    assert event_types == [
+        ProspectActivityType.created,
+        ProspectActivityType.stage_changed,
+        ProspectActivityType.contact_recorded,
+        ProspectActivityType.follow_up_changed,
+        ProspectActivityType.commercial_changed,
+        ProspectActivityType.note_changed,
+    ]
+    assert events[1].metadata == {"from": "approved_for_outreach", "to": "contacted"}
+
+
+def test_follow_up_fields_persist_tenant_scoped(tmp_path: Path) -> None:
+    identity = _identity()
+    other_identity = _identity(tenant="c")
+    store = TenantProspectStore(tmp_path)
+    prospect_id = store.save(identity, _prospect())
+    saved = store.load(identity, store.ref(identity, prospect_id))
+    updated = saved.model_copy(
+        update={
+            "last_contacted_at": datetime(2026, 8, 28, 9, 30, tzinfo=UTC),
+            "next_follow_up_at": datetime(2026, 8, 31, 10, 0, tzinfo=UTC),
+            "next_action": "Follow up by phone",
+        }
+    )
+    store.replace(identity, store.ref(identity, prospect_id), updated)
+
+    reloaded = store.load(identity, store.ref(identity, prospect_id))
+    assert reloaded.last_contacted_at == datetime(2026, 8, 28, 9, 30, tzinfo=UTC)
+    assert reloaded.next_follow_up_at == datetime(2026, 8, 31, 10, 0, tzinfo=UTC)
+    assert reloaded.next_action == "Follow up by phone"
+    assert store.list(other_identity) == []
+
+
+def test_sales_user_can_convert_prospect_to_customer_and_history_is_preserved(
+    tmp_path: Path,
+) -> None:
+    identity = _identity()
+    store = TenantProspectStore(tmp_path)
+    prospect = _prospect()
+    prospect_id = store.save(identity, prospect)
+    before = TenantProspectActivityStore(tmp_path).list(identity, prospect_id)
+
+    customer_prospect = prospect.model_copy(
+        update={
+            "status": ProspectStatus.customer,
+            "outreach_offer": "Website Improvement Sprint",
+            "commercial_note": "Client accepted the sprint.",
+        }
+    )
+    store.replace(identity, store.ref(identity, prospect_id), customer_prospect)
+
+    customers = TenantCustomerStore(tmp_path).list(identity)
+    events = TenantProspectActivityStore(tmp_path).list(identity, prospect_id)
+
+    assert len(customers) == 1
+    _, customer = customers[0]
+    assert customer.source_type is CustomerSourceType.prospect
+    assert customer.source_id == prospect_id
+    assert customer.business_name == "No Site Dental"
+    assert customer.website is None
+    assert events[: len(before)] == before
+    assert ProspectActivityType.customer_converted in [event.event_type for event in events]
+
+
+def _client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient, RequestIdentity]:
+    identity = _identity()
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path
+
+    @app.middleware("http")
+    async def bind_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[FastAPIResponse]],
+    ) -> FastAPIResponse:
+        bind_verified_request_identity(request, identity)
+        return await call_next(request)
+
+    app.include_router(agency_prospect_router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    return TestClient(app), identity
+
+
+def test_prospect_ui_saves_follow_up_and_renders_activity_history(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity = _client(tmp_path, monkeypatch)
+    store = TenantProspectStore(tmp_path)
+    prospect_id = store.save(identity, _prospect())
+
+    response = client.post(
+        f"/agency/prospects/{prospect_id}/commercial",
+        headers={"Origin": ORIGIN},
+        data={
+            "status": "contacted",
+            "outreach_offer": "Website Improvement Sprint",
+            "message_variant": "dublin-dental-v1",
+            "commercial_loss_reason": "",
+            "commercial_note": "Email sent to clinic.",
+            "last_contacted_at": "2026-08-28T09:30",
+            "next_follow_up_at": "2026-08-31T10:00",
+            "next_action": "Call the clinic manager",
+        },
+        follow_redirects=False,
+    )
+    detail = client.get(f"/agency/prospects/{prospect_id}")
+    index = client.get("/agency/prospects")
+    saved = store.load(identity, store.ref(identity, prospect_id))
+
+    assert response.status_code == 303
+    assert saved.status is ProspectStatus.contacted
+    assert saved.next_action == "Call the clinic manager"
+    assert saved.last_contacted_at is not None
+    assert saved.next_follow_up_at is not None
+    assert detail.status_code == 200
+    assert "Activity history" in detail.text
+    assert "Stage Changed" in detail.text
+    assert "Follow Up Changed" in detail.text
+    assert "Call the clinic manager" in detail.text
+    assert index.status_code == 200
+    assert "Follow-up" in index.text
+    assert "Call the clinic manager" in index.text


### PR DESCRIPTION
Implements issue #260.

Changes:
- adds backward-compatible outbound prospect fields for last contact, next follow-up and next action;
- adds append-only tenant-scoped prospect activity events for creation, stage, contact, follow-up, commercial, note and customer-conversion changes;
- records events at the TenantProspectStore boundary so UI and programmatic updates share the same history;
- renders prospect activity history and follow-up controls in the agency Prospect UI;
- exposes follow-up state on the prospect list;
- keeps legacy prospect JSON loadable with safe defaults;
- adds focused regression coverage for append-only history, tenant isolation, persistence and no-website prospect conversion;
- fixes the sales-role conversion edge case narrowly by allowing customer upsert only through the prospect-conversion path while keeping normal customer/project mutation permissions unchanged.

No automated outreach, email sending, marketing sequences or external CRM integration.