### PR TITLE
Make first-customer operator path commercially operable

### DIFF
--- a/VERIDRA_SMTP_CONFIG.bat
+++ b/VERIDRA_SMTP_CONFIG.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" smtp-config %*
+exit /b %ERRORLEVEL%

--- a/scripts/windows/veridra-local.ps1
+++ b/scripts/windows/veridra-local.ps1
@@ -1,10 +1,18 @@
 param(
     [Parameter(Position = 0, Mandatory = $true)]
-    [ValidateSet('setup','start','stop','restart','status','open','test','backup','restore','diagnostics','create-shortcut','remove-shortcut')]
+    [ValidateSet('setup','start','stop','restart','status','open','test','backup','restore','diagnostics','smtp-config','create-shortcut','remove-shortcut')]
     [string]$Command,
     [string]$BackupPath,
     [ValidateRange(1, 65535)]
     [int]$Port = 8010,
+    [string]$SmtpHost,
+    [ValidateRange(1, 65535)]
+    [int]$SmtpPort = 587,
+    [ValidateSet('starttls','implicit_tls')]
+    [string]$SmtpEncryption = 'starttls',
+    [string]$SmtpSender,
+    [string]$SmtpSenderName = 'Veridra',
+    [string]$SmtpUsername,
     [switch]$Apply
 )
 
@@ -14,11 +22,17 @@ $StateRoot = Join-Path $env:LOCALAPPDATA 'Veridra'
 $DataRoot = Join-Path $StateRoot 'data'
 $RuntimeRoot = Join-Path $StateRoot 'runtime'
 $BackupRoot = Join-Path $StateRoot 'backups'
+$ConfigRoot = Join-Path $StateRoot 'config'
+$SmtpConfigFile = Join-Path $ConfigRoot 'smtp.json'
+$SmtpSecretFile = Join-Path $ConfigRoot 'smtp-password.txt'
 $VenvRoot = Join-Path $RepoRoot '.venv'
 $PythonExe = Join-Path $VenvRoot 'Scripts\python.exe'
 $PidFile = Join-Path $RuntimeRoot 'veridra.pid'
+$MonitoringPidFile = Join-Path $RuntimeRoot 'veridra-monitoring.pid'
 $StdoutLogFile = Join-Path $RuntimeRoot 'veridra.stdout.log'
 $StderrLogFile = Join-Path $RuntimeRoot 'veridra.stderr.log'
+$MonitoringStdoutLogFile = Join-Path $RuntimeRoot 'veridra-monitoring.stdout.log'
+$MonitoringStderrLogFile = Join-Path $RuntimeRoot 'veridra-monitoring.stderr.log'
 if ($env:VERIDRA_LOCAL_PORT) {
     $configuredPort = 0
     if (-not [int]::TryParse($env:VERIDRA_LOCAL_PORT, [ref]$configuredPort) -or $configuredPort -lt 1 -or $configuredPort -gt 65535) {
@@ -30,7 +44,7 @@ $Url = "http://127.0.0.1:$Port/"
 
 function Write-Step([string]$Message) { Write-Host "[Veridra] $Message" }
 function Ensure-Directories {
-    foreach ($path in @($StateRoot,$DataRoot,$RuntimeRoot,$BackupRoot)) {
+    foreach ($path in @($StateRoot,$DataRoot,$RuntimeRoot,$BackupRoot,$ConfigRoot)) {
         New-Item -ItemType Directory -Force -Path $path | Out-Null
     }
 }
@@ -47,6 +61,29 @@ function Assert-PythonVersion([string]$PythonCommand) {
     & $PythonCommand -c "import sys; raise SystemExit(0 if sys.version_info >= (3,11) else 1)"
     if ($LASTEXITCODE -ne 0) { throw 'Veridra requires Python 3.11 or newer.' }
 }
+function Import-SmtpEnvironment {
+    Remove-Item Env:VERIDRA_SMTP_HOST -ErrorAction SilentlyContinue
+    Remove-Item Env:VERIDRA_SMTP_PORT -ErrorAction SilentlyContinue
+    Remove-Item Env:VERIDRA_SMTP_ENCRYPTION -ErrorAction SilentlyContinue
+    Remove-Item Env:VERIDRA_SMTP_SENDER -ErrorAction SilentlyContinue
+    Remove-Item Env:VERIDRA_SMTP_SENDER_NAME -ErrorAction SilentlyContinue
+    Remove-Item Env:VERIDRA_SMTP_USERNAME -ErrorAction SilentlyContinue
+    Remove-Item Env:VERIDRA_SMTP_PASSWORD -ErrorAction SilentlyContinue
+    if (-not (Test-Path $SmtpConfigFile)) { return }
+    $config = Get-Content $SmtpConfigFile -Raw | ConvertFrom-Json
+    $env:VERIDRA_SMTP_HOST = [string]$config.host
+    $env:VERIDRA_SMTP_PORT = [string]$config.port
+    $env:VERIDRA_SMTP_ENCRYPTION = [string]$config.encryption
+    $env:VERIDRA_SMTP_SENDER = [string]$config.sender
+    $env:VERIDRA_SMTP_SENDER_NAME = [string]$config.sender_name
+    if ($config.username) {
+        $env:VERIDRA_SMTP_USERNAME = [string]$config.username
+        if (-not (Test-Path $SmtpSecretFile)) { throw 'SMTP username is configured but the encrypted password file is missing.' }
+        $secure = Get-Content $SmtpSecretFile -Raw | ConvertTo-SecureString
+        $credential = New-Object System.Management.Automation.PSCredential('smtp', $secure)
+        $env:VERIDRA_SMTP_PASSWORD = $credential.GetNetworkCredential().Password
+    }
+}
 function Set-LocalEnvironment {
     $env:VERIDRA_ENV = 'development'
     $env:VERIDRA_BIND_HOST = '127.0.0.1'
@@ -55,15 +92,18 @@ function Set-LocalEnvironment {
     $env:VERIDRA_TRUSTED_ORIGIN = $Url.TrimEnd('/')
     $env:VERIDRA_IDENTITY_DB = Join-Path $DataRoot 'identity\veridra.sqlite3'
     $env:VERIDRA_TENANT_DATA_ROOT = Join-Path $DataRoot 'tenants'
+    Import-SmtpEnvironment
 }
-function Get-VeridraProcess {
-    if (-not (Test-Path $PidFile)) { return $null }
-    $pidText = (Get-Content $PidFile -Raw).Trim()
-    if ($pidText -notmatch '^\d+$') { Remove-Item $PidFile -Force; return $null }
+function Get-ManagedProcess([string]$Path) {
+    if (-not (Test-Path $Path)) { return $null }
+    $pidText = (Get-Content $Path -Raw).Trim()
+    if ($pidText -notmatch '^\d+$') { Remove-Item $Path -Force; return $null }
     $process = Get-Process -Id ([int]$pidText) -ErrorAction SilentlyContinue
-    if (-not $process) { Remove-Item $PidFile -Force; return $null }
+    if (-not $process) { Remove-Item $Path -Force; return $null }
     return $process
 }
+function Get-VeridraProcess { return Get-ManagedProcess $PidFile }
+function Get-MonitoringProcess { return Get-ManagedProcess $MonitoringPidFile }
 function Wait-Ready([int]$Seconds = 30) {
     $deadline = (Get-Date).AddSeconds($Seconds)
     do {
@@ -92,31 +132,52 @@ function Invoke-Setup {
     if ($LASTEXITCODE -ne 0) { throw 'Chromium installation failed.' }
     Write-Step "Setup complete. Local data root: $DataRoot"
 }
+function Start-MonitoringService {
+    if (Get-MonitoringProcess) { return }
+    Set-LocalEnvironment
+    Write-Step 'Starting recurring monitoring service...'
+    $arguments = @('-m','veridra.monitoring_service','--interval','30')
+    $process = Start-Process -FilePath $PythonExe -ArgumentList $arguments -WorkingDirectory $RepoRoot -RedirectStandardOutput $MonitoringStdoutLogFile -RedirectStandardError $MonitoringStderrLogFile -PassThru -WindowStyle Hidden
+    Set-Content -Path $MonitoringPidFile -Value $process.Id -Encoding ascii
+    Start-Sleep -Milliseconds 500
+    if (-not (Get-MonitoringProcess)) { throw "Monitoring service stopped unexpectedly. Review $MonitoringStderrLogFile" }
+}
 function Invoke-Start {
     Ensure-Directories
-    if (Get-VeridraProcess) { Write-Step "Already running at $Url"; return }
     if (-not (Test-Path $PythonExe)) { Invoke-Setup }
     Set-LocalEnvironment
-    $connection = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
-    if ($connection) { throw "Port $Port is already occupied by another process." }
-    Write-Step "Starting local server on port $Port..."
-    $arguments = @('-m','veridra.runtime')
-    $process = Start-Process -FilePath $PythonExe -ArgumentList $arguments -WorkingDirectory $RepoRoot -RedirectStandardOutput $StdoutLogFile -RedirectStandardError $StderrLogFile -PassThru -WindowStyle Hidden
-    Set-Content -Path $PidFile -Value $process.Id -Encoding ascii
-    Wait-Ready
+    $web = Get-VeridraProcess
+    if (-not $web) {
+        $connection = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+        if ($connection) { throw "Port $Port is already occupied by another process." }
+        Write-Step "Starting local server on port $Port..."
+        $arguments = @('-m','veridra.runtime')
+        $process = Start-Process -FilePath $PythonExe -ArgumentList $arguments -WorkingDirectory $RepoRoot -RedirectStandardOutput $StdoutLogFile -RedirectStandardError $StderrLogFile -PassThru -WindowStyle Hidden
+        Set-Content -Path $PidFile -Value $process.Id -Encoding ascii
+        Wait-Ready
+    }
+    Start-MonitoringService
     Write-Step "Ready at $Url"
 }
-function Invoke-Stop {
-    $process = Get-VeridraProcess
-    if (-not $process) { Write-Step 'Not running.'; return }
-    Write-Step "Stopping process $($process.Id)..."
+function Stop-Managed([string]$Name, [string]$Path) {
+    $process = Get-ManagedProcess $Path
+    if (-not $process) { return }
+    Write-Step "Stopping $Name process $($process.Id)..."
     Stop-Process -Id $process.Id -Force
-    Remove-Item $PidFile -Force -ErrorAction SilentlyContinue
+    Remove-Item $Path -Force -ErrorAction SilentlyContinue
+}
+function Invoke-Stop {
+    Stop-Managed 'monitoring' $MonitoringPidFile
+    Stop-Managed 'web' $PidFile
+    Write-Step 'Stopped.'
 }
 function Invoke-Status {
-    $process = Get-VeridraProcess
-    if ($process) { Write-Step "Running (PID $($process.Id)) at $Url"; exit 0 }
-    Write-Step 'Stopped.'
+    $web = Get-VeridraProcess
+    $monitoring = Get-MonitoringProcess
+    Write-Step ("Web: " + $(if ($web) { "running PID $($web.Id) at $Url" } else { 'stopped' }))
+    Write-Step ("Monitoring: " + $(if ($monitoring) { "running PID $($monitoring.Id)" } else { 'stopped' }))
+    Write-Step ("SMTP: " + $(if (Test-Path $SmtpConfigFile) { 'configured' } else { 'not configured' }))
+    if ($web -and $monitoring) { exit 0 }
     exit 1
 }
 function Invoke-Open { Invoke-Start; Start-Process $Url }
@@ -131,6 +192,29 @@ function Invoke-Test {
         & $PythonExe -m pytest
         if ($LASTEXITCODE -ne 0) { throw 'pytest failed.' }
     } finally { Pop-Location }
+}
+function Invoke-SmtpConfig {
+    Ensure-Directories
+    if (-not $SmtpHost) { $SmtpHost = Read-Host 'SMTP host' }
+    if (-not $SmtpSender) { $SmtpSender = Read-Host 'Sender email' }
+    if (-not $SmtpHost -or -not $SmtpSender) { throw 'SMTP host and sender email are required.' }
+    $record = [ordered]@{
+        host = $SmtpHost
+        port = $SmtpPort
+        encryption = $SmtpEncryption
+        sender = $SmtpSender
+        sender_name = $SmtpSenderName
+        username = $SmtpUsername
+    }
+    $record | ConvertTo-Json | Set-Content -Path $SmtpConfigFile -Encoding utf8
+    if ($SmtpUsername) {
+        $secure = Read-Host 'SMTP password (stored encrypted for this Windows user)' -AsSecureString
+        $secure | ConvertFrom-SecureString | Set-Content -Path $SmtpSecretFile -Encoding ascii
+    } else {
+        Remove-Item $SmtpSecretFile -Force -ErrorAction SilentlyContinue
+    }
+    Write-Step "SMTP configuration saved outside the repository: $SmtpConfigFile"
+    Write-Step 'Restart Veridra to apply the new mail configuration.'
 }
 function Invoke-Backup {
     Ensure-Directories
@@ -158,6 +242,8 @@ function Invoke-Restore {
 function Invoke-Diagnostics {
     Ensure-Directories
     $output = Join-Path $RuntimeRoot ("VERIDRA_DIAGNOSTICS_" + (Get-Date -Format 'yyyyMMdd_HHmmss') + '.txt')
+    $web = Get-VeridraProcess
+    $monitoring = Get-MonitoringProcess
     $lines = @(
         "Generated: $(Get-Date -Format o)",
         "Repository: $RepoRoot",
@@ -167,9 +253,13 @@ function Invoke-Diagnostics {
         "Python exists: $(Test-Path $PythonExe)",
         "Port: $Port",
         "URL: $Url",
-        "Process: $((Get-VeridraProcess | ForEach-Object { $_.Id }) -join '')",
+        "Web process: $($web.Id)",
+        "Monitoring process: $($monitoring.Id)",
+        "SMTP configured: $(Test-Path $SmtpConfigFile)",
         "Stdout log: $StdoutLogFile",
-        "Stderr log: $StderrLogFile"
+        "Stderr log: $StderrLogFile",
+        "Monitoring stdout: $MonitoringStdoutLogFile",
+        "Monitoring stderr: $MonitoringStderrLogFile"
     )
     $lines | Set-Content -Path $output -Encoding utf8
     Write-Step "Diagnostics written: $output"
@@ -203,6 +293,7 @@ switch ($Command) {
     'backup' { Invoke-Backup }
     'restore' { Invoke-Restore }
     'diagnostics' { Invoke-Diagnostics }
+    'smtp-config' { Invoke-SmtpConfig }
     'create-shortcut' { Invoke-CreateShortcut }
     'remove-shortcut' { Invoke-RemoveShortcut }
 }

--- a/src/veridra/agency_customer_project_web.py
+++ b/src/veridra/agency_customer_project_web.py
@@ -21,7 +21,9 @@ from .identity_tenancy import (
 from .project_store import ClientProject
 from .request_security import require_request_identity
 from .tenant_customer_store import TenantCustomerStore, TenantCustomerStoreError
+from .tenant_entitlements import require_tenant_project_capacity
 from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+from .tenant_workspace_policy import TenantWorkspacePolicy
 
 router = APIRouter(prefix="/agency/customers", tags=["agency-customer-projects"])
 
@@ -135,7 +137,13 @@ async def create_customer_project(customer_id: str, request: Request) -> Redirec
     body = await request.body()
     project_name = _one(body, "project_name")
     target_url = _one(body, "target_url")
-    projects = TenantProjectStore(_root(request))
+    root = _root(request)
+    projects = TenantProjectStore(root)
+    require_tenant_project_capacity(
+        TenantWorkspacePolicy(root),
+        identity,
+        len(projects.list(identity)),
+    )
     before = {entry.id for entry in projects.list(identity)}
     try:
         project = ClientProject.build(

--- a/src/veridra/agency_customer_project_web.py
+++ b/src/veridra/agency_customer_project_web.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E501
 from __future__ import annotations
 
 import html
@@ -147,7 +148,7 @@ async def create_customer_project(customer_id: str, request: Request) -> Redirec
         project_id = projects.save(identity, project)
         _replace_customer(request, identity, customer_id, customer, project_id)
     except (ValueError, ValidationError, TenantProjectStoreError, TenantCustomerStoreError) as exc:
-        if 'project_id' in locals() and project_id not in before:
+        if "project_id" in locals() and project_id not in before:
             try:
                 projects.delete(identity, projects.ref(identity, project_id))
             except Exception:

--- a/src/veridra/agency_customer_project_web.py
+++ b/src/veridra/agency_customer_project_web.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import html
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .agency_customer_web import customer_detail as base_customer_detail
+from .customer_store import CustomerRecord
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .project_store import ClientProject
+from .request_security import require_request_identity
+from .tenant_customer_store import TenantCustomerStore, TenantCustomerStoreError
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+
+router = APIRouter(prefix="/agency/customers", tags=["agency-customer-projects"])
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _one(body: bytes, name: str) -> str:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True).get(name, [""])[0].strip()
+
+
+def _manage_identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _load_customer(request: Request, identity: RequestIdentity, customer_id: str) -> CustomerRecord:
+    store = TenantCustomerStore(_root(request))
+    try:
+        return store.load(identity, store.ref(identity, customer_id))
+    except TenantCustomerStoreError as exc:
+        raise HTTPException(status_code=404, detail="Customer not found.") from exc
+
+
+def _replace_customer(
+    request: Request,
+    identity: RequestIdentity,
+    customer_id: str,
+    customer: CustomerRecord,
+    project_id: str,
+) -> None:
+    if project_id in customer.project_ids:
+        return
+    replacement = CustomerRecord.model_validate(
+        {
+            **customer.model_dump(mode="json"),
+            "project_ids": [*customer.project_ids, project_id],
+            "updated_at": datetime.now(UTC),
+        }
+    )
+    store = TenantCustomerStore(_root(request))
+    store.replace(identity, store.ref(identity, customer_id), replacement)
+
+
+def _project_section(request: Request, identity: RequestIdentity, customer_id: str, customer: CustomerRecord) -> str:
+    projects = TenantProjectStore(_root(request)).list(identity)
+    linked = set(customer.project_ids)
+    available = [entry for entry in projects if entry.id not in linked]
+    linked_rows = "".join(
+        f"<li><a href='/agency/projects/{html.escape(entry.id, quote=True)}'>{html.escape(entry.name)}</a> — {html.escape(entry.target_url)}</li>"
+        for entry in projects
+        if entry.id in linked
+    ) or "<li>No linked delivery projects yet.</li>"
+    options = "".join(
+        f"<option value='{html.escape(entry.id, quote=True)}'>{html.escape(entry.name)} — {html.escape(entry.target_url)}</option>"
+        for entry in available
+    )
+    link_form = (
+        f"<form method='post' action='/agency/customers/{html.escape(customer_id, quote=True)}/projects/link'>"
+        f"<label for='project_id'>Existing project</label><select id='project_id' name='project_id' required>{options}</select>"
+        "<p><button type='submit'>Link existing project</button></p></form>"
+        if options
+        else "<p class='muted'>No other existing projects are available to link.</p>"
+    )
+    website = html.escape(str(customer.website) if customer.website is not None else "", quote=True)
+    default_name = html.escape(f"{customer.business_name} — Digital Presence", quote=True)
+    create_form = f"""
+    <form method='post' action='/agency/customers/{html.escape(customer_id, quote=True)}/projects/create'>
+      <label for='project_name'>Project name</label>
+      <input id='project_name' name='project_name' maxlength='120' value='{default_name}' required>
+      <label for='target_url'>Delivery target URL</label>
+      <input id='target_url' name='target_url' maxlength='2048' value='{website}' placeholder='https://client.example or staging URL' required>
+      <p class='muted'>For a customer with no public website yet, use the controlled staging or future production URL that Webify will assess and manage.</p>
+      <p><button type='submit'>Create and link project</button></p>
+    </form>
+    """
+    return f"""
+    <section>
+      <h2>Delivery projects</h2>
+      <p class='muted'>Customer/project linkage is persisted explicitly. Creating or linking here is the supported operator path.</p>
+      <ul>{linked_rows}</ul>
+      <div class='row'><div><h3>Create project</h3>{create_form}</div><div><h3>Link existing project</h3>{link_form}</div></div>
+    </section>
+    """
+
+
+@router.get("/{customer_id}", response_class=HTMLResponse)
+def customer_detail_with_projects(customer_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.view_data)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    customer = _load_customer(request, identity, customer_id)
+    rendered = base_customer_detail(customer_id, request)
+    section = _project_section(request, identity, customer_id, customer)
+    marker = "</main></body></html>"
+    return rendered.replace(marker, section + marker, 1)
+
+
+@router.post("/{customer_id}/projects/create")
+async def create_customer_project(customer_id: str, request: Request) -> RedirectResponse:
+    identity = _manage_identity(request)
+    customer = _load_customer(request, identity, customer_id)
+    body = await request.body()
+    project_name = _one(body, "project_name")
+    target_url = _one(body, "target_url")
+    projects = TenantProjectStore(_root(request))
+    before = {entry.id for entry in projects.list(identity)}
+    try:
+        project = ClientProject.build(
+            name=project_name,
+            target_url=target_url,
+            client_label=customer.business_name,
+            contact_label=customer.contact_name or None,
+            monitoring_email=customer.contact_email or None,
+        )
+        project_id = projects.save(identity, project)
+        _replace_customer(request, identity, customer_id, customer, project_id)
+    except (ValueError, ValidationError, TenantProjectStoreError, TenantCustomerStoreError) as exc:
+        if 'project_id' in locals() and project_id not in before:
+            try:
+                projects.delete(identity, projects.ref(identity, project_id))
+            except Exception:
+                pass
+        raise HTTPException(status_code=400, detail="Customer project could not be created and linked.") from exc
+    return RedirectResponse(f"/agency/customers/{customer_id}", status_code=303)
+
+
+@router.post("/{customer_id}/projects/link")
+async def link_customer_project(customer_id: str, request: Request) -> RedirectResponse:
+    identity = _manage_identity(request)
+    customer = _load_customer(request, identity, customer_id)
+    project_id = _one(await request.body(), "project_id")
+    projects = TenantProjectStore(_root(request))
+    try:
+        projects.load(identity, projects.ref(identity, project_id))
+        _replace_customer(request, identity, customer_id, customer, project_id)
+    except (TenantProjectStoreError, TenantCustomerStoreError, ValidationError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="Existing project could not be linked to this customer.") from exc
+    return RedirectResponse(f"/agency/customers/{customer_id}", status_code=303)

--- a/src/veridra/agency_project_customer_web.py
+++ b/src/veridra/agency_project_customer_web.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E501
 from __future__ import annotations
 
 import html

--- a/src/veridra/agency_project_customer_web.py
+++ b/src/veridra/agency_project_customer_web.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import html
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+
+from .agency_conversion_web import tenant_project_next_actions as base_project_overview
+from .request_security import require_request_identity
+from .tenant_customer_store import TenantCustomerStore
+
+router = APIRouter(prefix="/agency", tags=["agency-project-customer"])
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+@router.get("/projects/{project_id}", response_class=HTMLResponse)
+def project_overview_with_customer(
+    project_id: str,
+    request: Request,
+    task_created: str | None = None,
+) -> str:
+    identity = require_request_identity(request)
+    rendered = base_project_overview(project_id, request, task_created)
+    customers = TenantCustomerStore(_root(request)).list(identity)
+    linked = [
+        (customer_id, customer)
+        for customer_id, customer in customers
+        if project_id in customer.project_ids
+    ]
+    if not linked:
+        relationship = "<p class='notice'><strong>Customer relationship:</strong> Not linked. Link this project from the customer record before treating it as customer delivery work.</p>"
+    else:
+        links = " · ".join(
+            f"<a href='/agency/customers/{html.escape(customer_id, quote=True)}'>{html.escape(customer.business_name)}</a>"
+            for customer_id, customer in linked
+        )
+        relationship = f"<p class='notice'><strong>Customer:</strong> {links}</p>"
+    marker = "<h1>"
+    return rendered.replace(marker, relationship + marker, 1)

--- a/src/veridra/monitoring_service.py
+++ b/src/veridra/monitoring_service.py
@@ -65,13 +65,22 @@ def enqueue_due_projects(root: Path, *, now: datetime | None = None) -> tuple[in
                 run_window=run_window,
                 now=current,
             )
-            after = len([job for job in jobs.list_for_tenant(tenant_id) if job.project_id == entry.id])
-            if after > before:
+            current_project_jobs = [
+                job
+                for job in jobs.list_for_tenant(tenant_id)
+                if job.project_id == entry.id
+            ]
+            if len(current_project_jobs) > before:
                 jobs_enqueued += 1
     return projects_seen, jobs_enqueued
 
 
-def run_service_tick(root: Path, *, now: datetime | None = None, limit: int = 10) -> MonitoringServiceTick:
+def run_service_tick(
+    root: Path,
+    *,
+    now: datetime | None = None,
+    limit: int = 10,
+) -> MonitoringServiceTick:
     projects_seen, jobs_enqueued = enqueue_due_projects(root, now=now)
     worker = MonitoringWorker(root=root).run_once(limit=limit)
     return MonitoringServiceTick(
@@ -105,15 +114,9 @@ def main() -> None:
     while True:
         tick = run_service_tick(root, limit=args.limit)
         print(
-            "projects_seen={projects} jobs_enqueued={enqueued} leased={leased} "
-            "succeeded={succeeded} retried={retried} failed={failed}".format(
-                projects=tick.projects_seen,
-                enqueued=tick.jobs_enqueued,
-                leased=tick.worker.leased,
-                succeeded=tick.worker.succeeded,
-                retried=tick.worker.retried,
-                failed=tick.worker.failed,
-            ),
+            f"projects_seen={tick.projects_seen} jobs_enqueued={tick.jobs_enqueued} "
+            f"leased={tick.worker.leased} succeeded={tick.worker.succeeded} "
+            f"retried={tick.worker.retried} failed={tick.worker.failed}",
             flush=True,
         )
         if args.once:

--- a/src/veridra/monitoring_service.py
+++ b/src/veridra/monitoring_service.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .monitoring_jobs import MonitoringJobState, SQLiteMonitoringJobStore
+from .monitoring_worker import MonitoringWorker, MonitoringWorkerResult
+from .project_store import ProjectStore, ProjectStoreError
+
+
+@dataclass(frozen=True)
+class MonitoringServiceTick:
+    projects_seen: int
+    jobs_enqueued: int
+    worker: MonitoringWorkerResult
+
+
+def _valid_id(value: str) -> bool:
+    return len(value) == 24 and all(char in "0123456789abcdef" for char in value)
+
+
+def enqueue_due_projects(root: Path, *, now: datetime | None = None) -> tuple[int, int]:
+    current = (now or datetime.now(UTC)).astimezone(UTC)
+    jobs = SQLiteMonitoringJobStore(root / "monitoring-jobs.sqlite3")
+    projects_seen = 0
+    jobs_enqueued = 0
+    if not root.exists():
+        return projects_seen, jobs_enqueued
+
+    for tenant_directory in sorted(root.iterdir()):
+        if not tenant_directory.is_dir() or not _valid_id(tenant_directory.name):
+            continue
+        tenant_id = tenant_directory.name
+        project_store = ProjectStore(tenant_directory / "projects")
+        existing_jobs = jobs.list_for_tenant(tenant_id)
+        for entry in project_store.list():
+            projects_seen += 1
+            try:
+                project = project_store.load(entry.id)
+            except ProjectStoreError:
+                continue
+            schedule = project.monitoring_schedule
+            if schedule.cadence.value == "manual":
+                continue
+
+            project_jobs = [job for job in existing_jobs if job.project_id == entry.id]
+            if project_jobs and project_jobs[0].state in {
+                MonitoringJobState.queued,
+                MonitoringJobState.leased,
+            }:
+                continue
+            anchor = project_jobs[0].updated_at if project_jobs else None
+            due = schedule.next_due(anchor, now=current)
+            if due is None or due > current:
+                continue
+            run_window = due.astimezone(UTC).replace(second=0, microsecond=0).isoformat()
+            before = len(project_jobs)
+            jobs.enqueue(
+                tenant_id=tenant_id,
+                project_id=entry.id,
+                run_window=run_window,
+                now=current,
+            )
+            after = len([job for job in jobs.list_for_tenant(tenant_id) if job.project_id == entry.id])
+            if after > before:
+                jobs_enqueued += 1
+    return projects_seen, jobs_enqueued
+
+
+def run_service_tick(root: Path, *, now: datetime | None = None, limit: int = 10) -> MonitoringServiceTick:
+    projects_seen, jobs_enqueued = enqueue_due_projects(root, now=now)
+    worker = MonitoringWorker(root=root).run_once(limit=limit)
+    return MonitoringServiceTick(
+        projects_seen=projects_seen,
+        jobs_enqueued=jobs_enqueued,
+        worker=worker,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Schedule due project monitoring runs and execute durable monitoring jobs."
+    )
+    parser.add_argument("--tenant-data-root", type=Path, default=None)
+    parser.add_argument("--interval", type=int, default=30)
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument("--once", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    configured = args.tenant_data_root or os.environ.get("VERIDRA_TENANT_DATA_ROOT")
+    if configured is None:
+        raise SystemExit(
+            "Tenant data root is required via --tenant-data-root or VERIDRA_TENANT_DATA_ROOT."
+        )
+    if args.interval < 5 or args.interval > 3600:
+        raise SystemExit("--interval must be between 5 and 3600 seconds.")
+    root = Path(configured).expanduser().resolve()
+    while True:
+        tick = run_service_tick(root, limit=args.limit)
+        print(
+            "projects_seen={projects} jobs_enqueued={enqueued} leased={leased} "
+            "succeeded={succeeded} retried={retried} failed={failed}".format(
+                projects=tick.projects_seen,
+                enqueued=tick.jobs_enqueued,
+                leased=tick.worker.leased,
+                succeeded=tick.worker.succeeded,
+                retried=tick.worker.retried,
+                failed=tick.worker.failed,
+            ),
+            flush=True,
+        )
+        if args.once:
+            return
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -14,10 +14,9 @@ from .agency_customer_web import router as agency_customer_router
 from .agency_lead_form_web import router as agency_lead_form_router
 from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
+from .agency_project_customer_web import router as agency_project_customer_router
 from .agency_project_index_web import router as agency_project_index_router
-from .agency_prospect_discovery_evidence_web import (
-    router as agency_prospect_discovery_evidence_router,
-)
+from .agency_prospect_discovery_evidence_web import router as agency_prospect_discovery_evidence_router
 from .agency_prospect_discovery_web import router as agency_prospect_discovery_router
 from .agency_prospect_import_web import router as agency_prospect_import_router
 from .agency_prospect_web import router as agency_prospect_router
@@ -47,8 +46,7 @@ from .operations_api import router as operations_router
 from .password_recovery_api import router as password_recovery_router
 from .pdf_web import router as pdf_router
 from .plans_web import router as plans_router
-from .public_web import ToolDefinition
-from .public_web import router as public_router
+from .public_web import ToolDefinition, router as public_router
 from .runtime_billing import configure_runtime_billing
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig, RuntimeEnvironment
@@ -76,7 +74,6 @@ from .workspace_members_web import router as workspace_members_router
 from .workspace_web import router as workspace_router
 
 app = FastAPI(title="Veridra", version=__version__)
-
 runtime_config = RuntimeConfig.from_environment()
 runtime_config.configure_directories()
 app.state.veridra_runtime_config = runtime_config
@@ -85,113 +82,26 @@ if runtime_config.tenant_data_root is not None:
 configure_runtime_legal(app, runtime_config)
 configure_runtime_email(app, runtime_config)
 configure_runtime_billing(app, runtime_config)
-app.add_middleware(
-    RuntimeBoundaryMiddleware,
-    max_body_bytes=runtime_config.max_request_body_bytes,
-    trusted_proxy_ips=runtime_config.trusted_proxy_ips,
-    hide_schema_routes=(runtime_config.environment is RuntimeEnvironment.production),
-)
+app.add_middleware(RuntimeBoundaryMiddleware,max_body_bytes=runtime_config.max_request_body_bytes,trusted_proxy_ips=runtime_config.trusted_proxy_ips,hide_schema_routes=(runtime_config.environment is RuntimeEnvironment.production))
 if runtime_config.allowed_hosts:
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(runtime_config.allowed_hosts))
-app.add_middleware(
-    SecurityHeadersMiddleware,
-    environment=runtime_config.environment,
-)
+app.add_middleware(SecurityHeadersMiddleware, environment=runtime_config.environment)
 configure_access_logger()
 app.add_middleware(StructuredAccessLogMiddleware)
-
 if "Accessibility" not in app_module._AREAS:
     vars(app_module)["_AREAS"] = (*app_module._AREAS, "Accessibility")
-
-_ACCESSIBILITY_TOOL = ToolDefinition(
-    slug="accessibility",
-    title="Accessibility Readiness",
-    description=(
-        "Check static language, labels, names, heading structure, IDs and image-alt signals."
-    ),
-    areas=("Accessibility",),
-    limitation=(
-        "Static HTML heuristics only. This is not WCAG conformance, browser-rendered "
-        "testing or assistive-technology validation."
-    ),
-)
+_ACCESSIBILITY_TOOL = ToolDefinition(slug="accessibility",title="Accessibility Readiness",description="Check static language, labels, names, heading structure, IDs and image-alt signals.",areas=("Accessibility",),limitation="Static HTML heuristics only. This is not WCAG conformance, browser-rendered testing or assistive-technology validation.")
 if _ACCESSIBILITY_TOOL.slug not in public_web._TOOL_BY_SLUG:
     vars(public_web)["TOOLS"] = (*public_web.TOOLS, _ACCESSIBILITY_TOOL)
     public_web._TOOL_BY_SLUG[_ACCESSIBILITY_TOOL.slug] = _ACCESSIBILITY_TOOL
-
 app.middleware("http")(enforce_workspace_policy)
 configure_identity_middleware(app)
-app.include_router(health_router)
-app.include_router(landing_router)
-app.include_router(public_router)
-app.include_router(plans_router)
-app.include_router(onboarding_router)
-app.include_router(signup_router)
-app.include_router(browser_auth_router)
-app.include_router(invitation_web_router)
-app.include_router(stripe_billing_router)
-app.include_router(tenant_assessment_router)
-app.include_router(operations_router)
-app.include_router(auth_router)
-app.include_router(password_recovery_router)
-app.include_router(session_router)
-app.include_router(invitation_router)
-app.include_router(existing_user_invitation_router)
-app.include_router(tenant_project_router)
-app.include_router(assessment_project_conversion_router)
-app.include_router(tenant_history_router)
-app.include_router(tenant_report_router)
-app.include_router(tenant_lead_router)
-app.include_router(tenant_prospect_router)
-app.include_router(lead_project_conversion_router)
-app.include_router(tenant_lead_form_router)
-app.include_router(tenant_task_router)
-app.include_router(finding_task_router)
-app.include_router(tenant_monitoring_router)
-app.include_router(monitoring_job_router)
-app.include_router(tenant_profile_router)
-app.include_router(lead_form_tenant_binding_router)
-app.include_router(tenant_bound_lead_capture_router)
-app.include_router(pdf_router)
-app.include_router(crawl_profile_router)
-app.include_router(workspace_router)
-app.include_router(tenant_team_router)
-app.include_router(workspace_members_router)
-app.include_router(member_assignments_router)
-app.include_router(agency_workflow_router)
-app.include_router(agency_commercial_dashboard_router)
-# This router intentionally precedes agency_customer_router so its customer-detail
-# wrapper can add the supported create/link-project operator workflow.
-app.include_router(agency_customer_project_router)
-app.include_router(agency_customer_router)
-app.include_router(agency_project_index_router)
-app.include_router(agency_conversion_router)
-app.include_router(agency_crawl_profile_router)
-app.include_router(agency_prospect_import_router)
-app.include_router(agency_prospect_discovery_router)
-app.include_router(agency_prospect_discovery_evidence_router)
-app.include_router(agency_prospect_router)
-app.include_router(agency_lead_router)
-app.include_router(agency_lead_form_router)
-app.include_router(agency_task_router)
-app.include_router(agency_task_management_router)
-app.include_router(agency_monitoring_router)
-app.include_router(agency_report_profile_router)
-app.include_router(agency_report_profile_edit_router)
-app.include_router(agency_report_router)
-
+for included in (health_router,landing_router,public_router,plans_router,onboarding_router,signup_router,browser_auth_router,invitation_web_router,stripe_billing_router,tenant_assessment_router,operations_router,auth_router,password_recovery_router,session_router,invitation_router,existing_user_invitation_router,tenant_project_router,assessment_project_conversion_router,tenant_history_router,tenant_report_router,tenant_lead_router,tenant_prospect_router,lead_project_conversion_router,tenant_lead_form_router,tenant_task_router,finding_task_router,tenant_monitoring_router,monitoring_job_router,tenant_profile_router,lead_form_tenant_binding_router,tenant_bound_lead_capture_router,pdf_router,crawl_profile_router,workspace_router,tenant_team_router,workspace_members_router,member_assignments_router,agency_workflow_router,agency_commercial_dashboard_router,agency_customer_project_router,agency_customer_router,agency_project_index_router,agency_project_customer_router,agency_conversion_router,agency_crawl_profile_router,agency_prospect_import_router,agency_prospect_discovery_router,agency_prospect_discovery_evidence_router,agency_prospect_router,agency_lead_router,agency_lead_form_router,agency_task_router,agency_task_management_router,agency_monitoring_router,agency_report_profile_router,agency_report_profile_edit_router,agency_report_router):
+    app.include_router(included)
 
 def main() -> None:
     import uvicorn
-
-    uvicorn.run(
-        app,
-        host=runtime_config.bind_host,
-        port=runtime_config.bind_port,
-        proxy_headers=False,
-        access_log=False,
-    )
-
+    uvicorn.run(app, host=runtime_config.bind_host, port=runtime_config.bind_port, proxy_headers=False, access_log=False)
 
 if __name__ == "__main__":
     main()

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -9,6 +9,7 @@ from .access_logging import StructuredAccessLogMiddleware, configure_access_logg
 from .agency_commercial_dashboard_web import router as agency_commercial_dashboard_router
 from .agency_conversion_web import router as agency_conversion_router
 from .agency_crawl_profile_web import router as agency_crawl_profile_router
+from .agency_customer_project_web import router as agency_customer_project_router
 from .agency_customer_web import router as agency_customer_router
 from .agency_lead_form_web import router as agency_lead_form_router
 from .agency_lead_web import router as agency_lead_router
@@ -159,6 +160,9 @@ app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)
 app.include_router(agency_commercial_dashboard_router)
+# This router intentionally precedes agency_customer_router so its customer-detail
+# wrapper can add the supported create/link-project operator workflow.
+app.include_router(agency_customer_project_router)
 app.include_router(agency_customer_router)
 app.include_router(agency_project_index_router)
 app.include_router(agency_conversion_router)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -16,7 +16,9 @@ from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
 from .agency_project_customer_web import router as agency_project_customer_router
 from .agency_project_index_web import router as agency_project_index_router
-from .agency_prospect_discovery_evidence_web import router as agency_prospect_discovery_evidence_router
+from .agency_prospect_discovery_evidence_web import (
+    router as agency_prospect_discovery_evidence_router,
+)
 from .agency_prospect_discovery_web import router as agency_prospect_discovery_router
 from .agency_prospect_import_web import router as agency_prospect_import_router
 from .agency_prospect_web import router as agency_prospect_router
@@ -46,7 +48,8 @@ from .operations_api import router as operations_router
 from .password_recovery_api import router as password_recovery_router
 from .pdf_web import router as pdf_router
 from .plans_web import router as plans_router
-from .public_web import ToolDefinition, router as public_router
+from .public_web import ToolDefinition
+from .public_web import router as public_router
 from .runtime_billing import configure_runtime_billing
 from .runtime_boundary import RuntimeBoundaryMiddleware
 from .runtime_config import RuntimeConfig, RuntimeEnvironment
@@ -74,6 +77,7 @@ from .workspace_members_web import router as workspace_members_router
 from .workspace_web import router as workspace_router
 
 app = FastAPI(title="Veridra", version=__version__)
+
 runtime_config = RuntimeConfig.from_environment()
 runtime_config.configure_directories()
 app.state.veridra_runtime_config = runtime_config
@@ -82,26 +86,114 @@ if runtime_config.tenant_data_root is not None:
 configure_runtime_legal(app, runtime_config)
 configure_runtime_email(app, runtime_config)
 configure_runtime_billing(app, runtime_config)
-app.add_middleware(RuntimeBoundaryMiddleware,max_body_bytes=runtime_config.max_request_body_bytes,trusted_proxy_ips=runtime_config.trusted_proxy_ips,hide_schema_routes=(runtime_config.environment is RuntimeEnvironment.production))
+app.add_middleware(
+    RuntimeBoundaryMiddleware,
+    max_body_bytes=runtime_config.max_request_body_bytes,
+    trusted_proxy_ips=runtime_config.trusted_proxy_ips,
+    hide_schema_routes=(runtime_config.environment is RuntimeEnvironment.production),
+)
 if runtime_config.allowed_hosts:
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=list(runtime_config.allowed_hosts))
-app.add_middleware(SecurityHeadersMiddleware, environment=runtime_config.environment)
+app.add_middleware(
+    SecurityHeadersMiddleware,
+    environment=runtime_config.environment,
+)
 configure_access_logger()
 app.add_middleware(StructuredAccessLogMiddleware)
+
 if "Accessibility" not in app_module._AREAS:
     vars(app_module)["_AREAS"] = (*app_module._AREAS, "Accessibility")
-_ACCESSIBILITY_TOOL = ToolDefinition(slug="accessibility",title="Accessibility Readiness",description="Check static language, labels, names, heading structure, IDs and image-alt signals.",areas=("Accessibility",),limitation="Static HTML heuristics only. This is not WCAG conformance, browser-rendered testing or assistive-technology validation.")
+
+_ACCESSIBILITY_TOOL = ToolDefinition(
+    slug="accessibility",
+    title="Accessibility Readiness",
+    description=(
+        "Check static language, labels, names, heading structure, IDs and image-alt signals."
+    ),
+    areas=("Accessibility",),
+    limitation=(
+        "Static HTML heuristics only. This is not WCAG conformance, browser-rendered "
+        "testing or assistive-technology validation."
+    ),
+)
 if _ACCESSIBILITY_TOOL.slug not in public_web._TOOL_BY_SLUG:
     vars(public_web)["TOOLS"] = (*public_web.TOOLS, _ACCESSIBILITY_TOOL)
     public_web._TOOL_BY_SLUG[_ACCESSIBILITY_TOOL.slug] = _ACCESSIBILITY_TOOL
+
 app.middleware("http")(enforce_workspace_policy)
 configure_identity_middleware(app)
-for included in (health_router,landing_router,public_router,plans_router,onboarding_router,signup_router,browser_auth_router,invitation_web_router,stripe_billing_router,tenant_assessment_router,operations_router,auth_router,password_recovery_router,session_router,invitation_router,existing_user_invitation_router,tenant_project_router,assessment_project_conversion_router,tenant_history_router,tenant_report_router,tenant_lead_router,tenant_prospect_router,lead_project_conversion_router,tenant_lead_form_router,tenant_task_router,finding_task_router,tenant_monitoring_router,monitoring_job_router,tenant_profile_router,lead_form_tenant_binding_router,tenant_bound_lead_capture_router,pdf_router,crawl_profile_router,workspace_router,tenant_team_router,workspace_members_router,member_assignments_router,agency_workflow_router,agency_commercial_dashboard_router,agency_customer_project_router,agency_customer_router,agency_project_index_router,agency_project_customer_router,agency_conversion_router,agency_crawl_profile_router,agency_prospect_import_router,agency_prospect_discovery_router,agency_prospect_discovery_evidence_router,agency_prospect_router,agency_lead_router,agency_lead_form_router,agency_task_router,agency_task_management_router,agency_monitoring_router,agency_report_profile_router,agency_report_profile_edit_router,agency_report_router):
-    app.include_router(included)
+app.include_router(health_router)
+app.include_router(landing_router)
+app.include_router(public_router)
+app.include_router(plans_router)
+app.include_router(onboarding_router)
+app.include_router(signup_router)
+app.include_router(browser_auth_router)
+app.include_router(invitation_web_router)
+app.include_router(stripe_billing_router)
+app.include_router(tenant_assessment_router)
+app.include_router(operations_router)
+app.include_router(auth_router)
+app.include_router(password_recovery_router)
+app.include_router(session_router)
+app.include_router(invitation_router)
+app.include_router(existing_user_invitation_router)
+app.include_router(tenant_project_router)
+app.include_router(assessment_project_conversion_router)
+app.include_router(tenant_history_router)
+app.include_router(tenant_report_router)
+app.include_router(tenant_lead_router)
+app.include_router(tenant_prospect_router)
+app.include_router(lead_project_conversion_router)
+app.include_router(tenant_lead_form_router)
+app.include_router(tenant_task_router)
+app.include_router(finding_task_router)
+app.include_router(tenant_monitoring_router)
+app.include_router(monitoring_job_router)
+app.include_router(tenant_profile_router)
+app.include_router(lead_form_tenant_binding_router)
+app.include_router(tenant_bound_lead_capture_router)
+app.include_router(pdf_router)
+app.include_router(crawl_profile_router)
+app.include_router(workspace_router)
+app.include_router(tenant_team_router)
+app.include_router(workspace_members_router)
+app.include_router(member_assignments_router)
+app.include_router(agency_workflow_router)
+app.include_router(agency_commercial_dashboard_router)
+# The wrapper routers precede their base routers so they can add customer/project
+# relationship actions without duplicating the established operator pages.
+app.include_router(agency_customer_project_router)
+app.include_router(agency_customer_router)
+app.include_router(agency_project_index_router)
+app.include_router(agency_project_customer_router)
+app.include_router(agency_conversion_router)
+app.include_router(agency_crawl_profile_router)
+app.include_router(agency_prospect_import_router)
+app.include_router(agency_prospect_discovery_router)
+app.include_router(agency_prospect_discovery_evidence_router)
+app.include_router(agency_prospect_router)
+app.include_router(agency_lead_router)
+app.include_router(agency_lead_form_router)
+app.include_router(agency_task_router)
+app.include_router(agency_task_management_router)
+app.include_router(agency_monitoring_router)
+app.include_router(agency_report_profile_router)
+app.include_router(agency_report_profile_edit_router)
+app.include_router(agency_report_router)
+
 
 def main() -> None:
     import uvicorn
-    uvicorn.run(app, host=runtime_config.bind_host, port=runtime_config.bind_port, proxy_headers=False, access_log=False)
+
+    uvicorn.run(
+        app,
+        host=runtime_config.bind_host,
+        port=runtime_config.bind_port,
+        proxy_headers=False,
+        access_log=False,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_monitoring_service.py
+++ b/tests/test_monitoring_service.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from veridra.monitoring_jobs import SQLiteMonitoringJobStore
+from veridra.monitoring_schedule import MonitoringCadence, MonitoringSchedule
+from veridra.monitoring_service import enqueue_due_projects
+from veridra.project_store import ClientProject, ProjectStore
+
+TENANT_ID = "a" * 24
+NOW = datetime(2026, 8, 28, 16, 0, tzinfo=UTC)
+
+
+def _scheduled_project(root: Path) -> tuple[Path, str]:
+    tenant_root = root / TENANT_ID
+    store = ProjectStore(tenant_root / "projects")
+    project = ClientProject.build(
+        name="Scheduled client",
+        target_url="https://example.com",
+    ).model_copy(
+        update={
+            "monitoring_schedule": MonitoringSchedule(
+                cadence=MonitoringCadence.weekly,
+                timezone="Europe/Madrid",
+                hour=9,
+                minute=0,
+                weekday=0,
+            )
+        }
+    )
+    project_id = store.save(project)
+    return tenant_root, project_id
+
+
+def test_due_schedule_enqueues_one_idempotent_job(tmp_path: Path) -> None:
+    root = tmp_path / "tenants"
+    _, project_id = _scheduled_project(root)
+
+    first = enqueue_due_projects(root, now=NOW)
+    second = enqueue_due_projects(root, now=NOW)
+
+    assert first == (1, 1)
+    assert second == (1, 0)
+    jobs = SQLiteMonitoringJobStore(root / "monitoring-jobs.sqlite3").list_for_tenant(TENANT_ID)
+    assert len(jobs) == 1
+    assert jobs[0].project_id == project_id
+    assert jobs[0].run_window == NOW.replace(second=0, microsecond=0).isoformat()
+
+
+def test_manual_project_does_not_enqueue(tmp_path: Path) -> None:
+    root = tmp_path / "tenants"
+    tenant_root = root / TENANT_ID
+    ProjectStore(tenant_root / "projects").save(
+        ClientProject.build(name="Manual client", target_url="https://example.com")
+    )
+
+    result = enqueue_due_projects(root, now=NOW)
+
+    assert result == (1, 0)
+    jobs = SQLiteMonitoringJobStore(root / "monitoring-jobs.sqlite3").list_for_tenant(TENANT_ID)
+    assert jobs == ()


### PR DESCRIPTION
Closes the implementation blockers tracked in #266 without closing the final manual acceptance gate.

## P0-1 Customer -> project operator path
- Add supported customer-page actions to create+link a delivery project or link an existing project.
- Persist `CustomerRecord.project_ids` through the normal tenant stores.
- Show reverse customer relationship on project overview.
- Roll back a newly-created project if customer linkage fails.

## P0-2 Autonomous local recurring monitoring
- Add a recurring monitoring service that scans due project schedules, idempotently enqueues run windows in the existing durable SQLite job store, and executes jobs through the existing leased/retry-capable worker.
- Local START/OPEN now start both web and monitoring processes.
- STOP/RESTART/STATUS/DIAGNOSTICS manage and expose both processes.

## P0-3 Supported persistent local SMTP configuration
- Add `VERIDRA_SMTP_CONFIG.bat`.
- Persist non-secret SMTP settings under `%LOCALAPPDATA%\Veridra\config`.
- Store SMTP password encrypted with Windows DPAPI for the current Windows user; no secret is committed to Git.
- START/RESTART imports the local SMTP configuration for report and monitoring delivery.

## Tests
- Add scheduler/idempotency coverage for recurring monitoring.

## Acceptance rule
This PR does not claim first-customer readiness by itself. After merge, #266 remains open until the complete workflow is exercised through the real browser UI and supported Windows commands, including SMTP delivery, automatic monitoring execution, restart persistence, and backup/mutate/restore.