### PR TITLE
Stabilize local session rotation acceptance

### DIFF
--- a/VERIDRA_TEST.bat
+++ b/VERIDRA_TEST.bat
@@ -1,5 +1,7 @@
 @echo off
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" setup
 if errorlevel 1 exit /b %ERRORLEVEL%
+"%~dp0.venv\Scripts\python.exe" -m pip install --upgrade -e "%~dp0.[dev]"
+if errorlevel 1 exit /b %ERRORLEVEL%
 powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\windows\veridra-local.ps1" test %*
 exit /b %ERRORLEVEL%

--- a/tests/test_session_lifecycle_api.py
+++ b/tests/test_session_lifecycle_api.py
@@ -133,19 +133,19 @@ async def test_rotation_revokes_old_credential_and_activates_replacement(tmp_pat
 
     assert response.status_code == 200
     assert replacement is not None and replacement != CREDENTIAL
-    assert await store.load_by_credential(CREDENTIAL) is not None
     old_records = await store.load_by_credential(CREDENTIAL)
     assert old_records is not None and old_records.session.status.value == "revoked"
+    replacement_records = await store.load_by_credential(replacement)
+    assert replacement_records is not None
+    assert replacement_records.session.status.value == "active"
 
-    # Keep each credential check unambiguous across httpx/TestClient versions. The
-    # rotation response can leave a secure, host-scoped cookie in the jar while a
-    # manually inserted test cookie has a different scope.
-    client.cookies.clear()
-    client.cookies.set("veridra_session", CREDENTIAL)
-    assert client.get("/api/session/current").status_code == 401
-    client.cookies.clear()
-    client.cookies.set("veridra_session", replacement)
-    assert client.get("/api/session/current").status_code == 200
+    old_client = _client(store)
+    old_client.cookies.set("veridra_session", CREDENTIAL)
+    assert old_client.get("/api/session/current").status_code == 401
+
+    replacement_client = _client(store)
+    replacement_client.cookies.set("veridra_session", replacement)
+    assert replacement_client.get("/api/session/current").status_code == 200
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Continues #266 after the real Windows local suite reached 892 passing tests with one remaining failure in session rotation.

## Changes
- Force the local Windows test wrapper to upgrade already-installed dependencies in the reused `.venv`, matching the fresh dependency set used by CI more closely.
- Strengthen the rotation test by asserting the replacement credential is persisted as an active server-side session.
- Validate revoked and replacement credentials through fresh TestClient instances instead of reusing one cookie jar across rotation.

## Acceptance
Run the existing Ubuntu CI and Windows/Python 3.14 portability gate. After merge, rerun the targeted session test locally first; only if that passes should we run the full local suite again.

This does not close #266; real operator-path acceptance remains required.