### PR TITLE
Fix full-suite session clock drift on Windows

### DIFF
--- a/tests/test_session_lifecycle_api.py
+++ b/tests/test_session_lifecycle_api.py
@@ -57,7 +57,7 @@ def _client(store: SQLiteIdentityRecordStore) -> TestClient:
         adapter=ServerSideSessionIdentityAdapter(
             extractor=SecureSessionCookieExtractor(),
             store=store,
-            clock=lambda: NOW + timedelta(minutes=1),
+            clock=lambda: datetime.now(UTC) + timedelta(minutes=1),
         ),
     )
     app.include_router(session_router)


### PR DESCRIPTION
Fixes the remaining Phase 0 local-suite failure under #266.

Root cause: `tests/test_session_lifecycle_api.py` froze the middleware validation clock at module-import time (`NOW + 1 minute`), while `/api/session/rotate` issues replacement sessions using real current UTC time. The isolated test passed because it ran quickly, but the full suite reached it several minutes later, making the replacement appear to be issued in the future and causing a false 401.

This change makes the test client validation clock advance with real UTC time while preserving the one-minute skew allowance. No production session logic is changed.

Expected effect: the test behaves the same in isolated and full-suite runs, including slower Windows/Python 3.14 environments.