### PR TITLE
#274: add persisted crawl observations and page-aware history comparison

### DIFF
--- a/src/veridra/agency_progress_web.py
+++ b/src/veridra/agency_progress_web.py
@@ -1,0 +1,134 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from .agency_navigation import agency_navigation
+from .identity_tenancy import RequestIdentity
+from .progress import ProgressSummary, build_progress_summary
+from .project_store import ClientProject
+from .request_security import require_request_identity
+from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+
+router = APIRouter(prefix="/agency", tags=["agency-progress"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1040px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.cards{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}.card{border:1px solid #dfe3e8;border-radius:8px;padding:15px}.card span{display:block;color:#68707a;font-size:12px;text-transform:uppercase}.card strong{display:block;font-size:24px;margin-top:6px}.changes{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.changes article{border:1px solid #dfe3e8;border-radius:8px;padding:16px}.changes ul{padding-left:20px;overflow-wrap:anywhere}.state-change{margin:0 0 10px;padding:10px;border:1px solid #e5e7eb;border-radius:7px}.back{display:inline-block;margin-bottom:12px;color:#22272d}@media(max-width:760px){.cards,.changes{grid-template-columns:1fr 1fr}}@media(max-width:520px){.cards,.changes{grid-template-columns:1fr}}
+"""
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _project(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+) -> ClientProject:
+    store = TenantProjectStore(_root(request))
+    try:
+        return store.load(identity, store.ref(identity, project_id))
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+
+def _items(values: tuple[str, ...]) -> str:
+    if not values:
+        return "<p class='muted'>None</p>"
+    return "<ul>" + "".join(f"<li>{html.escape(value)}</li>" for value in values) + "</ul>"
+
+
+def _change_groups(summary: ProgressSummary) -> str:
+    return "".join(
+        (
+            f"<article><h2>Pages added <span class='muted'>({len(summary.pages_added)})</span></h2>{_items(summary.pages_added)}</article>",
+            f"<article><h2>Pages removed <span class='muted'>({len(summary.pages_removed)})</span></h2>{_items(summary.pages_removed)}</article>",
+            f"<article><h2>Pages changed <span class='muted'>({len(summary.pages_changed)})</span></h2>{_items(summary.pages_changed)}</article>",
+            f"<article><h2>HTTP status changes <span class='muted'>({len(summary.page_status_changed)})</span></h2>{_items(summary.page_status_changed)}</article>",
+            f"<article><h2>New findings <span class='muted'>({len(summary.new_findings)})</span></h2>{_items(summary.new_findings)}</article>",
+            f"<article><h2>Resolved findings <span class='muted'>({len(summary.resolved_findings)})</span></h2>{_items(summary.resolved_findings)}</article>",
+            f"<article><h2>Persistent findings <span class='muted'>({len(summary.persistent_findings)})</span></h2>{_items(summary.persistent_findings)}</article>",
+        )
+    )
+
+
+def _state_changes(summary: ProgressSummary) -> str:
+    if not summary.state_changes:
+        return "<p class='muted'>No persisted finding changed status or severity.</p>"
+    return "".join(
+        "<div class='state-change'><strong>{identifier}</strong><br>"
+        "Status: {before_status} → {after_status}<br>"
+        "Severity: {before_severity} → {after_severity}</div>".format(
+            identifier=html.escape(change.finding_id),
+            before_status=html.escape(change.before_status),
+            after_status=html.escape(change.after_status),
+            before_severity=html.escape(change.before_severity),
+            after_severity=html.escape(change.after_severity),
+        )
+        for change in summary.state_changes
+    )
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+@router.get("/projects/{project_id}/progress", response_class=HTMLResponse)
+def project_progress(project_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    project = _project(request, identity, project_id)
+    history = TenantHistoryStore(_root(request))
+    try:
+        entries = history.list(identity, project_id)
+    except TenantHistoryStoreError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+    navigation = agency_navigation(identity, current="projects")
+    heading = (
+        f"{navigation}<section><a class='back' href='/agency/projects/{html.escape(project_id, quote=True)}'>← Project overview</a>"
+        f"<h1>Progress / Changes for {html.escape(project.name)}</h1>"
+        f"<p class='muted'>Deterministic comparison of stored observations and stable finding identities. This surface does not infer traffic, rank or market performance.</p>"
+    )
+    if len(entries) < 2:
+        body = heading + "<p class='notice'>At least two saved assessments are required before progress can be compared.</p></section>"
+        return _page(f"{project.name} progress", body)
+
+    latest = entries[0]
+    previous = entries[1]
+    try:
+        before = history.load(identity, history.ref(identity, project_id, previous.id))
+        after = history.load(identity, history.ref(identity, project_id, latest.id))
+        comparison = history.compare(identity, project_id, previous.id, latest.id)
+    except TenantHistoryStoreError as exc:
+        raise HTTPException(status_code=404, detail="Assessment comparison not found.") from exc
+    summary = build_progress_summary(before, after, comparison)
+
+    page_notice = (
+        "<p class='notice'>Page-level history is unavailable for this comparison because at least one assessment predates persisted page observations. Finding comparison remains valid.</p>"
+        if not summary.page_history_available
+        else ""
+    )
+    cards = "".join(
+        (
+            f"<div class='card'><span>Pages changed</span><strong>{len(summary.pages_changed)}</strong></div>",
+            f"<div class='card'><span>New findings</span><strong>{len(summary.new_findings)}</strong></div>",
+            f"<div class='card'><span>Resolved findings</span><strong>{len(summary.resolved_findings)}</strong></div>",
+            f"<div class='card'><span>Persistent findings</span><strong>{len(summary.persistent_findings)}</strong></div>",
+        )
+    )
+    body = (
+        heading
+        + f"<p><strong>Latest:</strong> {html.escape(latest.generated_at)}<br><strong>Previous:</strong> {html.escape(previous.generated_at)}</p>"
+        + page_notice
+        + f"</section><section><div class='cards'>{cards}</div></section>"
+        + f"<section><h2>Change details</h2><div class='changes'>{_change_groups(summary)}</div></section>"
+        + f"<section><h2>Finding state / severity changes</h2>{_state_changes(summary)}</section>"
+    )
+    return _page(f"{project.name} progress", body)

--- a/src/veridra/agency_progress_web.py
+++ b/src/veridra/agency_progress_web.py
@@ -63,15 +63,9 @@ def _state_changes(summary: ProgressSummary) -> str:
     if not summary.state_changes:
         return "<p class='muted'>No persisted finding changed status or severity.</p>"
     return "".join(
-        "<div class='state-change'><strong>{identifier}</strong><br>"
-        "Status: {before_status} → {after_status}<br>"
-        "Severity: {before_severity} → {after_severity}</div>".format(
-            identifier=html.escape(change.finding_id),
-            before_status=html.escape(change.before_status),
-            after_status=html.escape(change.after_status),
-            before_severity=html.escape(change.before_severity),
-            after_severity=html.escape(change.after_severity),
-        )
+        f"<div class='state-change'><strong>{html.escape(change.finding_id)}</strong><br>"
+        f"Status: {html.escape(change.before_status)} → {html.escape(change.after_status)}<br>"
+        f"Severity: {html.escape(change.before_severity)} → {html.escape(change.after_severity)}</div>"
         for change in summary.state_changes
     )
 

--- a/src/veridra/agency_project_customer_web.py
+++ b/src/veridra/agency_project_customer_web.py
@@ -41,5 +41,9 @@ def project_overview_with_customer(
             for customer_id, customer in linked
         )
         relationship = f"<p class='notice'><strong>Customer:</strong> {links}</p>"
+    progress = (
+        "<p><a href='/agency/projects/"
+        f"{html.escape(project_id, quote=True)}/progress'>Progress / Changes</a></p>"
+    )
     marker = "<h1>"
-    return rendered.replace(marker, relationship + marker, 1)
+    return rendered.replace(marker, relationship + progress + marker, 1)

--- a/src/veridra/history.py
+++ b/src/veridra/history.py
@@ -81,6 +81,14 @@ def _has_page_history(assessment: Assessment) -> bool:
     return bool(getattr(assessment, "collector_version", None))
 
 
+def _load_assessment_json(content: str) -> Assessment:
+    payload = json.loads(content)
+    schema_version = payload.get("schema_version") if isinstance(payload, dict) else None
+    if schema_version == "1.4":
+        return ObservedAssessment.model_validate(payload)
+    return Assessment.model_validate(payload)
+
+
 class HistoryStore:
     def __init__(self, directory: Path | None = None) -> None:
         self.directory = directory or default_history_directory()
@@ -117,9 +125,7 @@ class HistoryStore:
     def load(self, entry_id: str) -> Assessment:
         path = self._path(entry_id)
         try:
-            return ObservedAssessment.model_validate_json(
-                path.read_text(encoding="utf-8")
-            )
+            return _load_assessment_json(path.read_text(encoding="utf-8"))
         except FileNotFoundError as exc:
             raise HistoryError("Saved assessment was not found.") from exc
         except (OSError, ValueError) as exc:
@@ -131,9 +137,7 @@ class HistoryStore:
         entries: list[HistoryEntry] = []
         for path in sorted(self.directory.glob("*.json")):
             try:
-                assessment = Assessment.model_validate_json(
-                    path.read_text(encoding="utf-8")
-                )
+                assessment = _load_assessment_json(path.read_text(encoding="utf-8"))
             except (OSError, ValueError):
                 continue
             entries.append(

--- a/src/veridra/history.py
+++ b/src/veridra/history.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from .core import Assessment, Finding
+from .observations import ObservedAssessment, PageObservation
 
 
 class HistoryError(RuntimeError):
@@ -31,6 +32,10 @@ class Comparison:
     resolved: tuple[str, ...]
     changed: tuple[str, ...]
     unchanged: tuple[str, ...]
+    pages_added: tuple[str, ...] = ()
+    pages_removed: tuple[str, ...] = ()
+    pages_changed: tuple[str, ...] = ()
+    page_status_changed: tuple[str, ...] = ()
 
 
 def default_history_directory() -> Path:
@@ -64,6 +69,11 @@ def _finding_signature(finding: Finding) -> str:
             ensure_ascii=False,
         ).encode("utf-8")
     ).hexdigest()
+
+
+def _page_map(assessment: Assessment) -> dict[str, PageObservation]:
+    pages = getattr(assessment, "pages", ())
+    return {item.url: item for item in pages if isinstance(item, PageObservation)}
 
 
 class HistoryStore:
@@ -102,7 +112,9 @@ class HistoryStore:
     def load(self, entry_id: str) -> Assessment:
         path = self._path(entry_id)
         try:
-            return Assessment.model_validate_json(path.read_text(encoding="utf-8"))
+            return ObservedAssessment.model_validate_json(
+                path.read_text(encoding="utf-8")
+            )
         except FileNotFoundError as exc:
             raise HistoryError("Saved assessment was not found.") from exc
         except (OSError, ValueError) as exc:
@@ -166,6 +178,26 @@ class HistoryStore:
             != _finding_signature(after_map[identifier])
         )
         unchanged = sorted(common - set(changed))
+
+        before_pages = _page_map(before)
+        after_pages = _page_map(after)
+        before_urls = set(before_pages)
+        after_urls = set(after_pages)
+        common_urls = before_urls & after_urls
+        pages_changed = tuple(
+            sorted(
+                url
+                for url in common_urls
+                if before_pages[url].fingerprint != after_pages[url].fingerprint
+            )
+        )
+        page_status_changed = tuple(
+            sorted(
+                url
+                for url in common_urls
+                if before_pages[url].status_code != after_pages[url].status_code
+            )
+        )
         return Comparison(
             before_id=before_id,
             after_id=after_id,
@@ -173,4 +205,8 @@ class HistoryStore:
             resolved=tuple(sorted(before_ids - after_ids)),
             changed=tuple(changed),
             unchanged=tuple(unchanged),
+            pages_added=tuple(sorted(after_urls - before_urls)),
+            pages_removed=tuple(sorted(before_urls - after_urls)),
+            pages_changed=pages_changed,
+            page_status_changed=page_status_changed,
         )

--- a/src/veridra/history.py
+++ b/src/veridra/history.py
@@ -32,6 +32,7 @@ class Comparison:
     resolved: tuple[str, ...]
     changed: tuple[str, ...]
     unchanged: tuple[str, ...]
+    page_history_available: bool = False
     pages_added: tuple[str, ...] = ()
     pages_removed: tuple[str, ...] = ()
     pages_changed: tuple[str, ...] = ()
@@ -74,6 +75,10 @@ def _finding_signature(finding: Finding) -> str:
 def _page_map(assessment: Assessment) -> dict[str, PageObservation]:
     pages = getattr(assessment, "pages", ())
     return {item.url: item for item in pages if isinstance(item, PageObservation)}
+
+
+def _has_page_history(assessment: Assessment) -> bool:
+    return bool(getattr(assessment, "collector_version", None))
 
 
 class HistoryStore:
@@ -179,25 +184,34 @@ class HistoryStore:
         )
         unchanged = sorted(common - set(changed))
 
-        before_pages = _page_map(before)
-        after_pages = _page_map(after)
-        before_urls = set(before_pages)
-        after_urls = set(after_pages)
-        common_urls = before_urls & after_urls
-        pages_changed = tuple(
-            sorted(
-                url
-                for url in common_urls
-                if before_pages[url].fingerprint != after_pages[url].fingerprint
+        page_history_available = _has_page_history(before) and _has_page_history(after)
+        pages_added: tuple[str, ...] = ()
+        pages_removed: tuple[str, ...] = ()
+        pages_changed: tuple[str, ...] = ()
+        page_status_changed: tuple[str, ...] = ()
+        if page_history_available:
+            before_pages = _page_map(before)
+            after_pages = _page_map(after)
+            before_urls = set(before_pages)
+            after_urls = set(after_pages)
+            common_urls = before_urls & after_urls
+            pages_added = tuple(sorted(after_urls - before_urls))
+            pages_removed = tuple(sorted(before_urls - after_urls))
+            pages_changed = tuple(
+                sorted(
+                    url
+                    for url in common_urls
+                    if before_pages[url].fingerprint != after_pages[url].fingerprint
+                )
             )
-        )
-        page_status_changed = tuple(
-            sorted(
-                url
-                for url in common_urls
-                if before_pages[url].status_code != after_pages[url].status_code
+            page_status_changed = tuple(
+                sorted(
+                    url
+                    for url in common_urls
+                    if before_pages[url].status_code != after_pages[url].status_code
+                )
             )
-        )
+
         return Comparison(
             before_id=before_id,
             after_id=after_id,
@@ -205,8 +219,9 @@ class HistoryStore:
             resolved=tuple(sorted(before_ids - after_ids)),
             changed=tuple(changed),
             unchanged=tuple(unchanged),
-            pages_added=tuple(sorted(after_urls - before_urls)),
-            pages_removed=tuple(sorted(before_urls - after_urls)),
+            page_history_available=page_history_available,
+            pages_added=pages_added,
+            pages_removed=pages_removed,
             pages_changed=pages_changed,
             page_status_changed=page_status_changed,
         )

--- a/src/veridra/longitudinal.py
+++ b/src/veridra/longitudinal.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+
+from .core import Assessment
+from .observations import ObservationRecord
+
+
+@dataclass(frozen=True)
+class LifecycleMetadata:
+    """First/last-seen values bounded to genuinely stored comparable history."""
+
+    identity: str
+    first_seen: datetime | None
+    last_seen: datetime | None
+    history_available: bool
+    basis: str
+
+
+def _ordered(assessments: Iterable[Assessment]) -> tuple[Assessment, ...]:
+    return tuple(sorted(assessments, key=lambda item: item.generated_at))
+
+
+def finding_lifecycle(
+    assessments: Iterable[Assessment],
+) -> tuple[LifecycleMetadata, ...]:
+    """Derive finding lifecycle from stable finding IDs in retained assessments.
+
+    Legacy assessments still contain findings, so they remain valid evidence. The
+    timestamps are explicitly bounded to retained assessment history and are not
+    claims about time before the oldest stored assessment.
+    """
+
+    seen: defaultdict[str, list[datetime]] = defaultdict(list)
+    for assessment in _ordered(assessments):
+        for finding in assessment.findings:
+            seen[finding.id].append(assessment.generated_at)
+    return tuple(
+        LifecycleMetadata(
+            identity=finding_id,
+            first_seen=min(timestamps),
+            last_seen=max(timestamps),
+            history_available=True,
+            basis="retained_assessment_history",
+        )
+        for finding_id, timestamps in sorted(seen.items())
+    )
+
+
+def _observation_identity(record: ObservationRecord) -> str:
+    return f"{record.scope}:{record.subject}:{record.key}"
+
+
+def observation_lifecycle(
+    assessments: Iterable[Assessment],
+) -> tuple[LifecycleMetadata, ...]:
+    """Derive observation lifecycle only when the retained history supports it.
+
+    If any retained assessment predates the normalized observation layer, the
+    observation timeline is incomplete. In that case identities visible in the
+    observation-capable assessments are returned with first/last seen explicitly
+    unknown rather than fabricating a start or end date.
+    """
+
+    ordered = _ordered(assessments)
+    records_by_identity: defaultdict[str, list[datetime]] = defaultdict(list)
+    complete = bool(ordered) and all(
+        getattr(assessment, "collector_version", None) is not None
+        and hasattr(assessment, "observations")
+        for assessment in ordered
+    )
+
+    for assessment in ordered:
+        records = getattr(assessment, "observations", ())
+        for record in records:
+            if not isinstance(record, ObservationRecord):
+                continue
+            timestamp = record.observed_at or assessment.generated_at
+            records_by_identity[_observation_identity(record)].append(timestamp)
+
+    return tuple(
+        LifecycleMetadata(
+            identity=identity,
+            first_seen=min(timestamps) if complete else None,
+            last_seen=max(timestamps) if complete else None,
+            history_available=complete,
+            basis=(
+                "retained_observation_history"
+                if complete
+                else "observation_history_incomplete"
+            ),
+        )
+        for identity, timestamps in sorted(records_by_identity.items())
+    )

--- a/src/veridra/observations.py
+++ b/src/veridra/observations.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from .core import Assessment
 from .crawl import CrawlResult
 
 
@@ -40,6 +41,42 @@ class ObservationRecord(BaseModel):
     subject: str
     state: str
     evidence_refs: tuple[str, ...] = ()
+
+
+class ObservedAssessment(Assessment):
+    """Backward-compatible assessment envelope with longitudinal crawl evidence."""
+
+    schema_version: str = "1.4"
+    collector_version: str | None = None
+    crawl_profile: str | None = None
+    effective_crawl_limits: dict[str, int | float] | None = None
+    pages: tuple[PageObservation, ...] = ()
+    observations: tuple[ObservationRecord, ...] = ()
+
+    @classmethod
+    def from_assessment(
+        cls,
+        assessment: Assessment,
+        *,
+        pages: tuple[PageObservation, ...] = (),
+        observations: tuple[ObservationRecord, ...] = (),
+        collector_version: str | None = None,
+        crawl_profile: str | None = None,
+        effective_crawl_limits: dict[str, int | float] | None = None,
+    ) -> ObservedAssessment:
+        return cls.model_validate(
+            {
+                **assessment.model_dump(mode="json"),
+                "schema_version": "1.4",
+                "collector_version": collector_version,
+                "crawl_profile": crawl_profile,
+                "effective_crawl_limits": effective_crawl_limits,
+                "pages": [item.model_dump(mode="json") for item in pages],
+                "observations": [
+                    item.model_dump(mode="json") for item in observations
+                ],
+            }
+        )
 
 
 class _PageObservationParser(HTMLParser):
@@ -212,7 +249,11 @@ def observation_records(
                     key="page.indexable",
                     scope="page",
                     subject=page.url,
-                    state=("unknown" if page.indexable is None else str(page.indexable).lower()),
+                    state=(
+                        "unknown"
+                        if page.indexable is None
+                        else str(page.indexable).lower()
+                    ),
                 ),
             )
         )

--- a/src/veridra/observations.py
+++ b/src/veridra/observations.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections import defaultdict
 from datetime import datetime
 from html.parser import HTMLParser
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse, urlunparse
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -29,6 +30,7 @@ class PageObservation(BaseModel):
     canonical_url: str | None = None
     indexable: bool | None = None
     structured_data_types: tuple[str, ...] = ()
+    source_page_urls: tuple[str, ...] = ()
     fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
 
 
@@ -103,6 +105,7 @@ class _PageObservationParser(HTMLParser):
         self.canonical_href: str | None = None
         self.noindex = False
         self.structured_types: set[str] = set()
+        self.links: list[str] = []
         self._in_title = False
         self._in_h1 = False
         self._json_ld_depth = 0
@@ -128,6 +131,8 @@ class _PageObservationParser(HTMLParser):
         elif tag == "link" and "canonical" in lowered.get("rel", ""):
             value = data.get("href", "").strip()
             self.canonical_href = value or None
+        elif tag == "a" and data.get("href"):
+            self.links.append(data["href"])
         elif tag == "script" and lowered.get("type") == "application/ld+json":
             self._json_ld_depth += 1
 
@@ -203,12 +208,32 @@ def _fingerprint(
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _crawl_identity(raw_url: str, base_url: str) -> str | None:
+    parsed = urlparse(urljoin(base_url, raw_url))
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    path = parsed.path or "/"
+    return urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+
+
 def page_observations(result: CrawlResult) -> tuple[PageObservation, ...]:
-    observations: list[PageObservation] = []
+    parsed_pages: list[tuple[object, _PageObservationParser]] = []
+    assessed_urls = {crawled.evidence.final_url for crawled in result.pages}
+    inbound_sources: defaultdict[str, set[str]] = defaultdict(set)
+
     for crawled in result.pages:
-        page = crawled.evidence
         parser = _PageObservationParser()
-        parser.feed(page.body)
+        parser.feed(crawled.evidence.body)
+        parsed_pages.append((crawled, parser))
+        for raw_link in parser.links:
+            target = _crawl_identity(raw_link, crawled.evidence.final_url)
+            if target in assessed_urls and target != crawled.evidence.final_url:
+                inbound_sources[target].add(crawled.evidence.final_url)
+
+    observations: list[PageObservation] = []
+    for raw_crawled, parser in parsed_pages:
+        crawled = raw_crawled
+        page = crawled.evidence
         content_type = page.headers.get("content-type")
         canonical_url = (
             urljoin(page.final_url, parser.canonical_href)
@@ -229,6 +254,7 @@ def page_observations(result: CrawlResult) -> tuple[PageObservation, ...]:
                 canonical_url=canonical_url,
                 indexable=not parser.noindex,
                 structured_data_types=tuple(sorted(parser.structured_types)),
+                source_page_urls=tuple(sorted(inbound_sources[page.final_url])),
                 fingerprint=_fingerprint(
                     url=page.final_url,
                     status_code=page.status_code,
@@ -267,6 +293,16 @@ def observation_records(
                         "unknown"
                         if page.indexable is None
                         else str(page.indexable).lower()
+                    ),
+                ),
+                ObservationRecord(
+                    key="page.source-pages",
+                    scope="page",
+                    subject=page.url,
+                    state=json.dumps(
+                        list(page.source_page_urls),
+                        separators=(",", ":"),
+                        ensure_ascii=False,
                     ),
                 ),
             )

--- a/src/veridra/observations.py
+++ b/src/veridra/observations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime
 from html.parser import HTMLParser
 from urllib.parse import urljoin
 
@@ -41,6 +42,10 @@ class ObservationRecord(BaseModel):
     subject: str
     state: str
     evidence_refs: tuple[str, ...] = ()
+    observed_at: datetime | None = None
+    collector_version: str | None = None
+    source_type: str = "direct"
+    confidence: str | None = "direct"
 
 
 class ObservedAssessment(Assessment):
@@ -64,6 +69,15 @@ class ObservedAssessment(Assessment):
         crawl_profile: str | None = None,
         effective_crawl_limits: dict[str, int | float] | None = None,
     ) -> ObservedAssessment:
+        normalized_observations = tuple(
+            item.model_copy(
+                update={
+                    "observed_at": item.observed_at or assessment.generated_at,
+                    "collector_version": item.collector_version or collector_version,
+                }
+            )
+            for item in observations
+        )
         return cls.model_validate(
             {
                 **assessment.model_dump(mode="json"),
@@ -73,7 +87,7 @@ class ObservedAssessment(Assessment):
                 "effective_crawl_limits": effective_crawl_limits,
                 "pages": [item.model_dump(mode="json") for item in pages],
                 "observations": [
-                    item.model_dump(mode="json") for item in observations
+                    item.model_dump(mode="json") for item in normalized_observations
                 ],
             }
         )

--- a/src/veridra/observations.py
+++ b/src/veridra/observations.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from html.parser import HTMLParser
+from urllib.parse import urljoin
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .crawl import CrawlResult
+
+
+class PageObservation(BaseModel):
+    """Bounded, normalized facts directly observed for one crawled page."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    url: str
+    status_code: int
+    depth: int = Field(ge=0)
+    content_type: str | None = None
+    response_bytes: int = Field(ge=0)
+    title: str | None = None
+    meta_description: str | None = None
+    h1_count: int = Field(ge=0)
+    h1_text: str | None = None
+    canonical_url: str | None = None
+    indexable: bool | None = None
+    structured_data_types: tuple[str, ...] = ()
+    fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class ObservationRecord(BaseModel):
+    """Stable machine-comparable representation of a direct observation."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    key: str = Field(min_length=1, max_length=120)
+    scope: str = Field(pattern=r"^(page|domain|assessment)$")
+    subject: str
+    state: str
+    evidence_refs: tuple[str, ...] = ()
+
+
+class _PageObservationParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title_parts: list[str] = []
+        self.meta_description: str | None = None
+        self.h1_parts: list[str] = []
+        self.h1_count = 0
+        self.canonical_href: str | None = None
+        self.noindex = False
+        self.structured_types: set[str] = set()
+        self._in_title = False
+        self._in_h1 = False
+        self._json_ld_depth = 0
+        self._json_ld_parts: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        data = {key.lower(): (value or "") for key, value in attrs}
+        lowered = {key: value.lower() for key, value in data.items()}
+        if tag == "title":
+            self._in_title = True
+        elif tag == "h1":
+            self.h1_count += 1
+            self._in_h1 = True
+        elif tag == "meta" and lowered.get("name") == "description":
+            value = data.get("content", "").strip()
+            self.meta_description = value or None
+        elif tag == "meta" and lowered.get("name") == "robots":
+            self.noindex = "noindex" in lowered.get("content", "")
+        elif tag == "link" and "canonical" in lowered.get("rel", ""):
+            value = data.get("href", "").strip()
+            self.canonical_href = value or None
+        elif tag == "script" and lowered.get("type") == "application/ld+json":
+            self._json_ld_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+        elif tag == "h1":
+            self._in_h1 = False
+        elif tag == "script" and self._json_ld_depth:
+            self._json_ld_depth -= 1
+            if self._json_ld_depth == 0:
+                self._consume_json_ld()
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title_parts.append(data)
+        if self._in_h1:
+            self.h1_parts.append(data)
+        if self._json_ld_depth:
+            self._json_ld_parts.append(data)
+
+    def _consume_json_ld(self) -> None:
+        raw = "".join(self._json_ld_parts).strip()
+        self._json_ld_parts.clear()
+        if not raw:
+            return
+        try:
+            value = json.loads(raw)
+        except (TypeError, ValueError):
+            return
+        self._collect_types(value)
+
+    def _collect_types(self, value: object) -> None:
+        if isinstance(value, dict):
+            raw_type = value.get("@type")
+            if isinstance(raw_type, str) and raw_type.strip():
+                self.structured_types.add(raw_type.strip())
+            elif isinstance(raw_type, list):
+                for item in raw_type:
+                    if isinstance(item, str) and item.strip():
+                        self.structured_types.add(item.strip())
+            for child in value.values():
+                self._collect_types(child)
+        elif isinstance(value, list):
+            for child in value:
+                self._collect_types(child)
+
+
+def _clean_text(parts: list[str]) -> str | None:
+    value = " ".join(" ".join(parts).split())
+    return value or None
+
+
+def _fingerprint(
+    *,
+    url: str,
+    status_code: int,
+    content_type: str | None,
+    body: str,
+) -> str:
+    payload = {
+        "url": url,
+        "status_code": status_code,
+        "content_type": content_type,
+        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def page_observations(result: CrawlResult) -> tuple[PageObservation, ...]:
+    observations: list[PageObservation] = []
+    for crawled in result.pages:
+        page = crawled.evidence
+        parser = _PageObservationParser()
+        parser.feed(page.body)
+        content_type = page.headers.get("content-type")
+        canonical_url = (
+            urljoin(page.final_url, parser.canonical_href)
+            if parser.canonical_href is not None
+            else None
+        )
+        observations.append(
+            PageObservation(
+                url=page.final_url,
+                status_code=page.status_code,
+                depth=crawled.depth,
+                content_type=content_type,
+                response_bytes=len(page.body.encode("utf-8")),
+                title=_clean_text(parser.title_parts),
+                meta_description=parser.meta_description,
+                h1_count=parser.h1_count,
+                h1_text=_clean_text(parser.h1_parts),
+                canonical_url=canonical_url,
+                indexable=not parser.noindex,
+                structured_data_types=tuple(sorted(parser.structured_types)),
+                fingerprint=_fingerprint(
+                    url=page.final_url,
+                    status_code=page.status_code,
+                    content_type=content_type,
+                    body=page.body,
+                ),
+            )
+        )
+    return tuple(sorted(observations, key=lambda item: item.url))
+
+
+def observation_records(
+    pages: tuple[PageObservation, ...],
+) -> tuple[ObservationRecord, ...]:
+    records: list[ObservationRecord] = []
+    for page in pages:
+        records.extend(
+            (
+                ObservationRecord(
+                    key="page.http-status",
+                    scope="page",
+                    subject=page.url,
+                    state=str(page.status_code),
+                ),
+                ObservationRecord(
+                    key="page.fingerprint",
+                    scope="page",
+                    subject=page.url,
+                    state=page.fingerprint,
+                ),
+                ObservationRecord(
+                    key="page.indexable",
+                    scope="page",
+                    subject=page.url,
+                    state=("unknown" if page.indexable is None else str(page.indexable).lower()),
+                ),
+            )
+        )
+    return tuple(sorted(records, key=lambda item: (item.subject, item.key, item.state)))

--- a/src/veridra/observations.py
+++ b/src/veridra/observations.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin, urlparse, urlunparse
 from pydantic import BaseModel, ConfigDict, Field
 
 from .core import Assessment
-from .crawl import CrawlResult
+from .crawl import CrawledPage, CrawlResult
 
 
 class PageObservation(BaseModel):
@@ -217,7 +217,7 @@ def _crawl_identity(raw_url: str, base_url: str) -> str | None:
 
 
 def page_observations(result: CrawlResult) -> tuple[PageObservation, ...]:
-    parsed_pages: list[tuple[object, _PageObservationParser]] = []
+    parsed_pages: list[tuple[CrawledPage, _PageObservationParser]] = []
     assessed_urls = {crawled.evidence.final_url for crawled in result.pages}
     inbound_sources: defaultdict[str, set[str]] = defaultdict(set)
 
@@ -231,8 +231,7 @@ def page_observations(result: CrawlResult) -> tuple[PageObservation, ...]:
                 inbound_sources[target].add(crawled.evidence.final_url)
 
     observations: list[PageObservation] = []
-    for raw_crawled, parser in parsed_pages:
-        crawled = raw_crawled
+    for crawled, parser in parsed_pages:
         page = crawled.evidence
         content_type = page.headers.get("content-type")
         canonical_url = (

--- a/src/veridra/progress.py
+++ b/src/veridra/progress.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .core import Assessment
+from .history import Comparison
+
+
+@dataclass(frozen=True)
+class FindingStateChange:
+    finding_id: str
+    before_status: str
+    after_status: str
+    before_severity: str
+    after_severity: str
+
+
+@dataclass(frozen=True)
+class ProgressSummary:
+    new_findings: tuple[str, ...]
+    resolved_findings: tuple[str, ...]
+    persistent_findings: tuple[str, ...]
+    state_changes: tuple[FindingStateChange, ...]
+    pages_added: tuple[str, ...]
+    pages_removed: tuple[str, ...]
+    pages_changed: tuple[str, ...]
+    page_status_changed: tuple[str, ...]
+    page_history_available: bool
+
+
+def build_progress_summary(
+    before: Assessment,
+    after: Assessment,
+    comparison: Comparison,
+) -> ProgressSummary:
+    before_findings = {item.id: item for item in before.findings}
+    after_findings = {item.id: item for item in after.findings}
+    common_ids = set(before_findings) & set(after_findings)
+    state_changes = tuple(
+        FindingStateChange(
+            finding_id=finding_id,
+            before_status=before_findings[finding_id].status.value,
+            after_status=after_findings[finding_id].status.value,
+            before_severity=before_findings[finding_id].severity,
+            after_severity=after_findings[finding_id].severity,
+        )
+        for finding_id in sorted(common_ids)
+        if (
+            before_findings[finding_id].status != after_findings[finding_id].status
+            or before_findings[finding_id].severity != after_findings[finding_id].severity
+        )
+    )
+    return ProgressSummary(
+        new_findings=comparison.added,
+        resolved_findings=comparison.resolved,
+        persistent_findings=tuple(sorted(common_ids)),
+        state_changes=state_changes,
+        pages_added=comparison.pages_added,
+        pages_removed=comparison.pages_removed,
+        pages_changed=comparison.pages_changed,
+        page_status_changed=comparison.page_status_changed,
+        page_history_available=comparison.page_history_available,
+    )

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -14,6 +14,7 @@ from .agency_customer_web import router as agency_customer_router
 from .agency_lead_form_web import router as agency_lead_form_router
 from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
+from .agency_progress_web import router as agency_progress_router
 from .agency_project_customer_web import router as agency_project_customer_router
 from .agency_project_index_web import router as agency_project_index_router
 from .agency_prospect_discovery_evidence_web import (
@@ -178,6 +179,7 @@ app.include_router(agency_lead_form_router)
 app.include_router(agency_task_router)
 app.include_router(agency_task_management_router)
 app.include_router(agency_monitoring_router)
+app.include_router(agency_progress_router)
 app.include_router(agency_report_profile_router)
 app.include_router(agency_report_profile_edit_router)
 app.include_router(agency_report_router)

--- a/src/veridra/service.py
+++ b/src/veridra/service.py
@@ -23,8 +23,10 @@ from .dns_posture import (
     live_lookup,
 )
 from .local_readiness import analyze_local_readiness
+from .observations import ObservedAssessment, observation_records, page_observations
 from .page_quality import analyze_page_quality
 from .passive_security import analyze_passive_security
+from .version import __version__
 
 
 def _transport_findings(evidence: SiteEvidence) -> list[Finding]:
@@ -87,6 +89,18 @@ def _crawl_profile_finding(profile: CrawlProfile) -> Finding:
     )
 
 
+def _effective_limits_evidence(limits: CrawlLimits) -> dict[str, int | float]:
+    return {
+        "max_pages": limits.max_pages,
+        "max_depth": limits.max_depth,
+        "max_total_bytes": limits.max_total_bytes,
+        "per_page_bytes": limits.per_page_bytes,
+        "timeout": limits.timeout,
+        "max_sitemaps": limits.max_sitemaps,
+        "max_sitemap_urls": limits.max_sitemap_urls,
+    }
+
+
 def assess_url(
     raw_url: str,
     *,
@@ -146,9 +160,18 @@ def assess_url(
             )
         )
     elapsed_ms = round((perf_counter() - started) * 1000)
-    return Assessment.build(
+    assessment = Assessment.build(
         evidence.homepage.final_url,
         findings,
         mode="live",
         elapsed_ms=elapsed_ms,
+    )
+    pages = page_observations(crawl)
+    return ObservedAssessment.from_assessment(
+        assessment,
+        pages=pages,
+        observations=observation_records(pages),
+        collector_version=__version__,
+        crawl_profile=active_profile.name.value,
+        effective_crawl_limits=_effective_limits_evidence(effective_limits),
     )

--- a/tests/test_agency_progress_web.py
+++ b/tests/test_agency_progress_web.py
@@ -1,0 +1,226 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_progress_web import router
+from veridra.core import Assessment, Finding, Status
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.observations import ObservedAssessment, PageObservation
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_history_store import TenantHistoryStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 9, 1, 11, 0, tzinfo=UTC)
+ANALYST = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.analyst,
+    session_id="progress-analyst-session-0001",
+    authenticated_at=NOW,
+)
+VIEWER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="progress-viewer-session-00001",
+    authenticated_at=NOW,
+)
+OTHER = RequestIdentity(
+    user_id="3" * 24,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.viewer,
+    session_id="progress-other-session-000001",
+    authenticated_at=NOW,
+)
+
+
+def _app(root: Path) -> TestClient:
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        role = request.headers.get("x-test-role")
+        if role == "viewer":
+            bind_verified_request_identity(request, VIEWER)
+        elif role == "other":
+            bind_verified_request_identity(request, OTHER)
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _finding(
+    finding_id: str,
+    *,
+    status: Status = Status.attention,
+    severity: str = "medium",
+) -> Finding:
+    return Finding(
+        id=finding_id,
+        area="Website health",
+        title=finding_id,
+        status=status,
+        severity=severity,
+        summary="Observed.",
+    )
+
+
+def _page(url: str, fingerprint: str, status: int = 200) -> PageObservation:
+    return PageObservation(
+        url=url,
+        status_code=status,
+        depth=0,
+        content_type="text/html",
+        response_bytes=100,
+        title="Example",
+        h1_count=1,
+        h1_text="Example",
+        indexable=True,
+        fingerprint=fingerprint,
+    )
+
+
+def _observed(
+    generated_at: datetime,
+    findings: list[Finding],
+    pages: tuple[PageObservation, ...],
+) -> ObservedAssessment:
+    base = Assessment.build(
+        "https://example.com",
+        findings,
+        generated_at=generated_at,
+    )
+    return ObservedAssessment.from_assessment(
+        base,
+        pages=pages,
+        collector_version="test",
+        crawl_profile="quick",
+    )
+
+
+def _project(tmp_path: Path) -> tuple[Path, str, TenantHistoryStore]:
+    root = tmp_path / "tenants"
+    project_id = TenantProjectStore(root).save(
+        ANALYST,
+        ClientProject.build(name="Progress <Client>", target_url="https://example.com"),
+    )
+    return root, project_id, TenantHistoryStore(root)
+
+
+def test_progress_surface_shows_exact_latest_vs_previous_deltas(tmp_path: Path) -> None:
+    root, project_id, history = _project(tmp_path)
+    before = _observed(
+        NOW,
+        [
+            _finding("finding.persist"),
+            _finding("finding.resolve"),
+            _finding("finding.state", severity="high"),
+        ],
+        (
+            _page("https://example.com/", "a" * 64),
+            _page("https://example.com/removed", "b" * 64),
+        ),
+    )
+    after = _observed(
+        NOW + timedelta(hours=1),
+        [
+            _finding("finding.persist"),
+            _finding("finding.new"),
+            _finding("finding.state", status=Status.passed, severity="info"),
+        ],
+        (
+            _page("https://example.com/", "c" * 64),
+            _page("https://example.com/added", "d" * 64),
+        ),
+    )
+    history.save(ANALYST, project_id, before)
+    history.save(ANALYST, project_id, after)
+
+    response = _app(root).get(
+        f"/agency/projects/{project_id}/progress",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert response.status_code == 200
+    assert "Progress / Changes for Progress &lt;Client&gt;" in response.text
+    assert "Pages added" in response.text
+    assert "https://example.com/added" in response.text
+    assert "https://example.com/removed" in response.text
+    assert "finding.new" in response.text
+    assert "finding.resolve" in response.text
+    assert "finding.persist" in response.text
+    assert "finding.state" in response.text
+    assert "attention → passed" in response.text
+    assert "high → info" in response.text
+    assert "Page-level history is unavailable" not in response.text
+
+
+def test_progress_surface_marks_legacy_page_history_unknown(tmp_path: Path) -> None:
+    root, project_id, history = _project(tmp_path)
+    legacy = Assessment.build(
+        "https://example.com",
+        [_finding("finding.persist")],
+        generated_at=NOW,
+    )
+    current = _observed(
+        NOW + timedelta(hours=1),
+        [_finding("finding.persist"), _finding("finding.new")],
+        (_page("https://example.com/", "a" * 64),),
+    )
+    history.save(ANALYST, project_id, legacy)
+    history.save(ANALYST, project_id, current)
+
+    response = _app(root).get(
+        f"/agency/projects/{project_id}/progress",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert response.status_code == 200
+    assert "Page-level history is unavailable for this comparison" in response.text
+    assert "Finding comparison remains valid" in response.text
+    assert "finding.new" in response.text
+
+
+def test_progress_requires_two_assessments(tmp_path: Path) -> None:
+    root, project_id, history = _project(tmp_path)
+    history.save(
+        ANALYST,
+        project_id,
+        Assessment.build(
+            "https://example.com",
+            [_finding("finding.one")],
+            generated_at=NOW,
+        ),
+    )
+
+    response = _app(root).get(
+        f"/agency/projects/{project_id}/progress",
+        headers={"x-test-role": "viewer"},
+    )
+
+    assert response.status_code == 200
+    assert "At least two saved assessments are required" in response.text
+
+
+def test_progress_cross_tenant_access_is_concealed(tmp_path: Path) -> None:
+    root, project_id, _ = _project(tmp_path)
+
+    response = _app(root).get(
+        f"/agency/projects/{project_id}/progress",
+        headers={"x-test-role": "other"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Project not found."}

--- a/tests/test_history_observations.py
+++ b/tests/test_history_observations.py
@@ -74,7 +74,9 @@ def test_history_round_trip_preserves_observation_envelope(tmp_path: Path) -> No
     assert loaded.pages == assessment.pages
 
 
-def test_old_assessment_json_loads_with_unknown_observation_history(tmp_path: Path) -> None:
+def test_old_assessment_json_preserves_legacy_type_and_unknown_history(
+    tmp_path: Path,
+) -> None:
     store = HistoryStore(tmp_path)
     legacy = Assessment.build(
         "https://example.com",
@@ -85,11 +87,11 @@ def test_old_assessment_json_loads_with_unknown_observation_history(tmp_path: Pa
 
     loaded = store.load(entry_id)
 
-    assert isinstance(loaded, ObservedAssessment)
+    assert type(loaded) is Assessment
+    assert loaded == legacy
     assert loaded.schema_version == "1.3"
-    assert loaded.collector_version is None
-    assert loaded.pages == ()
-    assert loaded.observations == ()
+    assert not hasattr(loaded, "collector_version")
+    assert not hasattr(loaded, "pages")
 
 
 def test_compare_derives_exact_page_inventory_deltas(tmp_path: Path) -> None:

--- a/tests/test_history_observations.py
+++ b/tests/test_history_observations.py
@@ -87,6 +87,7 @@ def test_old_assessment_json_loads_with_unknown_observation_history(tmp_path: Pa
 
     assert isinstance(loaded, ObservedAssessment)
     assert loaded.schema_version == "1.3"
+    assert loaded.collector_version is None
     assert loaded.pages == ()
     assert loaded.observations == ()
 
@@ -112,6 +113,7 @@ def test_compare_derives_exact_page_inventory_deltas(tmp_path: Path) -> None:
 
     comparison = store.compare(store.save(before), store.save(after))
 
+    assert comparison.page_history_available is True
     assert comparison.pages_added == ("https://example.com/added",)
     assert comparison.pages_removed == ("https://example.com/removed",)
     assert comparison.pages_changed == (
@@ -141,5 +143,8 @@ def test_legacy_to_observed_comparison_does_not_invent_page_history(
 
     comparison = store.compare(store.save(legacy), store.save(current))
 
-    assert comparison.pages_added == ("https://example.com/",)
+    assert comparison.page_history_available is False
+    assert comparison.pages_added == ()
     assert comparison.pages_removed == ()
+    assert comparison.pages_changed == ()
+    assert comparison.page_status_changed == ()

--- a/tests/test_history_observations.py
+++ b/tests/test_history_observations.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from veridra.core import Assessment, Finding, Status
+from veridra.history import HistoryStore
+from veridra.observations import ObservedAssessment, PageObservation
+
+
+def _finding() -> Finding:
+    return Finding(
+        id="health.title",
+        area="Website health",
+        title="Title",
+        status=Status.passed,
+        severity="info",
+        summary="Present.",
+    )
+
+
+def _page(
+    url: str,
+    fingerprint: str,
+    *,
+    status_code: int = 200,
+) -> PageObservation:
+    return PageObservation(
+        url=url,
+        status_code=status_code,
+        depth=0,
+        content_type="text/html",
+        response_bytes=100,
+        title="Example",
+        h1_count=1,
+        h1_text="Example",
+        indexable=True,
+        fingerprint=fingerprint,
+    )
+
+
+def _observed(
+    generated_at: datetime,
+    pages: tuple[PageObservation, ...],
+) -> ObservedAssessment:
+    base = Assessment.build(
+        "https://example.com",
+        [_finding()],
+        generated_at=generated_at,
+    )
+    return ObservedAssessment.from_assessment(
+        base,
+        pages=pages,
+        collector_version="test",
+        crawl_profile="quick",
+        effective_crawl_limits={"max_pages": 10, "max_depth": 1},
+    )
+
+
+def test_history_round_trip_preserves_observation_envelope(tmp_path: Path) -> None:
+    store = HistoryStore(tmp_path)
+    assessment = _observed(
+        datetime(2026, 9, 1, tzinfo=UTC),
+        (_page("https://example.com/", "a" * 64),),
+    )
+
+    entry_id = store.save(assessment)
+    loaded = store.load(entry_id)
+
+    assert isinstance(loaded, ObservedAssessment)
+    assert loaded.schema_version == "1.4"
+    assert loaded.collector_version == "test"
+    assert loaded.crawl_profile == "quick"
+    assert loaded.pages == assessment.pages
+
+
+def test_old_assessment_json_loads_with_unknown_observation_history(tmp_path: Path) -> None:
+    store = HistoryStore(tmp_path)
+    legacy = Assessment.build(
+        "https://example.com",
+        [_finding()],
+        generated_at=datetime(2026, 8, 1, tzinfo=UTC),
+    )
+    entry_id = store.save(legacy)
+
+    loaded = store.load(entry_id)
+
+    assert isinstance(loaded, ObservedAssessment)
+    assert loaded.schema_version == "1.3"
+    assert loaded.pages == ()
+    assert loaded.observations == ()
+
+
+def test_compare_derives_exact_page_inventory_deltas(tmp_path: Path) -> None:
+    store = HistoryStore(tmp_path)
+    before = _observed(
+        datetime(2026, 9, 1, tzinfo=UTC),
+        (
+            _page("https://example.com/", "a" * 64),
+            _page("https://example.com/removed", "b" * 64),
+            _page("https://example.com/status", "c" * 64, status_code=200),
+        ),
+    )
+    after = _observed(
+        datetime(2026, 9, 2, tzinfo=UTC),
+        (
+            _page("https://example.com/", "d" * 64),
+            _page("https://example.com/added", "e" * 64),
+            _page("https://example.com/status", "f" * 64, status_code=404),
+        ),
+    )
+
+    comparison = store.compare(store.save(before), store.save(after))
+
+    assert comparison.pages_added == ("https://example.com/added",)
+    assert comparison.pages_removed == ("https://example.com/removed",)
+    assert comparison.pages_changed == (
+        "https://example.com/",
+        "https://example.com/status",
+    )
+    assert comparison.page_status_changed == ("https://example.com/status",)
+    assert comparison.added == ()
+    assert comparison.resolved == ()
+    assert comparison.changed == ()
+    assert comparison.unchanged == ("health.title",)
+
+
+def test_legacy_to_observed_comparison_does_not_invent_page_history(
+    tmp_path: Path,
+) -> None:
+    store = HistoryStore(tmp_path)
+    legacy = Assessment.build(
+        "https://example.com",
+        [_finding()],
+        generated_at=datetime(2026, 8, 1, tzinfo=UTC),
+    )
+    current = _observed(
+        datetime(2026, 9, 1, tzinfo=UTC),
+        (_page("https://example.com/", "a" * 64),),
+    )
+
+    comparison = store.compare(store.save(legacy), store.save(current))
+
+    assert comparison.pages_added == ("https://example.com/",)
+    assert comparison.pages_removed == ()

--- a/tests/test_longitudinal.py
+++ b/tests/test_longitudinal.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from veridra.core import Assessment, Finding, Status
+from veridra.longitudinal import finding_lifecycle, observation_lifecycle
+from veridra.observations import ObservationRecord, ObservedAssessment
+
+
+BASE = datetime(2026, 9, 1, 9, 0, tzinfo=UTC)
+
+
+def _finding(finding_id: str) -> Finding:
+    return Finding(
+        id=finding_id,
+        area="Website health",
+        title=finding_id,
+        status=Status.attention,
+        severity="medium",
+        summary="Observed.",
+    )
+
+
+def _base(at: datetime, *finding_ids: str) -> Assessment:
+    return Assessment.build(
+        "https://example.com",
+        [_finding(finding_id) for finding_id in finding_ids],
+        generated_at=at,
+    )
+
+
+def _observed(at: datetime, state: str = "200") -> ObservedAssessment:
+    base = _base(at, "finding.persist")
+    return ObservedAssessment.from_assessment(
+        base,
+        observations=(
+            ObservationRecord(
+                key="page.http-status",
+                scope="page",
+                subject="https://example.com/",
+                state=state,
+            ),
+        ),
+        collector_version="test",
+        crawl_profile="quick",
+    )
+
+
+def test_finding_lifecycle_uses_legacy_and_current_retained_assessments() -> None:
+    assessments = (
+        _base(BASE, "finding.old", "finding.persist"),
+        _base(BASE + timedelta(hours=1), "finding.persist", "finding.new"),
+    )
+
+    lifecycle = {item.identity: item for item in finding_lifecycle(assessments)}
+
+    assert lifecycle["finding.old"].first_seen == BASE
+    assert lifecycle["finding.old"].last_seen == BASE
+    assert lifecycle["finding.persist"].first_seen == BASE
+    assert lifecycle["finding.persist"].last_seen == BASE + timedelta(hours=1)
+    assert lifecycle["finding.new"].first_seen == BASE + timedelta(hours=1)
+    assert lifecycle["finding.persist"].basis == "retained_assessment_history"
+    assert lifecycle["finding.persist"].history_available is True
+
+
+def test_observation_lifecycle_is_known_when_all_retained_history_is_comparable() -> None:
+    first = _observed(BASE)
+    second = _observed(BASE + timedelta(hours=1), state="404")
+
+    lifecycle = observation_lifecycle((second, first))
+
+    assert len(lifecycle) == 1
+    item = lifecycle[0]
+    assert item.identity == "page:https://example.com/:page.http-status"
+    assert item.first_seen == BASE
+    assert item.last_seen == BASE + timedelta(hours=1)
+    assert item.history_available is True
+    assert item.basis == "retained_observation_history"
+
+
+def test_legacy_gap_forces_observation_first_and_last_seen_unknown() -> None:
+    legacy = _base(BASE, "finding.persist")
+    current = _observed(BASE + timedelta(hours=1))
+
+    lifecycle = observation_lifecycle((legacy, current))
+
+    assert len(lifecycle) == 1
+    item = lifecycle[0]
+    assert item.first_seen is None
+    assert item.last_seen is None
+    assert item.history_available is False
+    assert item.basis == "observation_history_incomplete"

--- a/tests/test_longitudinal.py
+++ b/tests/test_longitudinal.py
@@ -6,7 +6,6 @@ from veridra.core import Assessment, Finding, Status
 from veridra.longitudinal import finding_lifecycle, observation_lifecycle
 from veridra.observations import ObservationRecord, ObservedAssessment
 
-
 BASE = datetime(2026, 9, 1, 9, 0, tzinfo=UTC)
 
 

--- a/tests/test_observation_provenance.py
+++ b/tests/test_observation_provenance.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from veridra.core import Assessment
+from veridra.observations import ObservationRecord, ObservedAssessment
+
+
+def test_observed_assessment_enriches_direct_observation_provenance() -> None:
+    observed_at = datetime(2026, 9, 1, 10, 30, tzinfo=UTC)
+    assessment = Assessment.build(
+        "https://example.com",
+        [],
+        generated_at=observed_at,
+    )
+    record = ObservationRecord(
+        key="page.http-status",
+        scope="page",
+        subject="https://example.com/",
+        state="200",
+    )
+
+    wrapped = ObservedAssessment.from_assessment(
+        assessment,
+        observations=(record,),
+        collector_version="3.3.0",
+        crawl_profile="quick",
+    )
+
+    saved = wrapped.observations[0]
+    assert saved.observed_at == observed_at
+    assert saved.collector_version == "3.3.0"
+    assert saved.source_type == "direct"
+    assert saved.confidence == "direct"
+    assert saved.evidence_refs == ()
+
+
+def test_explicit_observation_provenance_is_not_overwritten() -> None:
+    assessment_time = datetime(2026, 9, 1, 10, 30, tzinfo=UTC)
+    explicit_time = datetime(2026, 8, 31, 9, 0, tzinfo=UTC)
+    assessment = Assessment.build(
+        "https://example.com",
+        [],
+        generated_at=assessment_time,
+    )
+    record = ObservationRecord(
+        key="page.indexable",
+        scope="page",
+        subject="https://example.com/",
+        state="true",
+        observed_at=explicit_time,
+        collector_version="fixture-collector",
+        source_type="direct-static-html",
+        confidence="direct",
+    )
+
+    wrapped = ObservedAssessment.from_assessment(
+        assessment,
+        observations=(record,),
+        collector_version="3.3.0",
+    )
+
+    saved = wrapped.observations[0]
+    assert saved.observed_at == explicit_time
+    assert saved.collector_version == "fixture-collector"
+    assert saved.source_type == "direct-static-html"

--- a/tests/test_observation_source_relations.py
+++ b/tests/test_observation_source_relations.py
@@ -22,7 +22,11 @@ def test_page_observations_capture_only_proven_assessed_source_links() -> None:
     home = CrawledPage(
         _page(
             "https://example.com/",
-            '<a href="/about?utm=nav#team">About</a><a href="https://other.test/">External</a>',
+            (
+                '<a href="/about?utm=nav#team">About</a>'
+                '<a href="/about#contact">About again</a>'
+                '<a href="https://other.test/">External</a>'
+            ),
         ),
         depth=0,
     )

--- a/tests/test_observation_source_relations.py
+++ b/tests/test_observation_source_relations.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from veridra.collector import PageEvidence
+from veridra.crawl import CrawledPage, CrawlResult
+from veridra.observations import observation_records, page_observations
+
+
+def _page(url: str, body: str) -> PageEvidence:
+    return PageEvidence(
+        requested_url=url,
+        final_url=url,
+        status_code=200,
+        headers={"content-type": "text/html; charset=utf-8"},
+        body=body,
+        redirect_chain=(),
+        connected_ip="203.0.113.10",
+        validated_ips=("203.0.113.10",),
+    )
+
+
+def test_page_observations_capture_only_proven_assessed_source_links() -> None:
+    home = CrawledPage(
+        _page(
+            "https://example.com/",
+            '<a href="/about?utm=nav#team">About</a><a href="https://other.test/">External</a>',
+        ),
+        depth=0,
+    )
+    about = CrawledPage(
+        _page("https://example.com/about", "<h1>About</h1>"),
+        depth=1,
+    )
+    result = CrawlResult(
+        pages=(about, home),
+        skipped_urls=(),
+        exhausted_page_limit=False,
+        exhausted_byte_limit=False,
+    )
+
+    pages = {item.url: item for item in page_observations(result)}
+
+    assert pages["https://example.com/"].source_page_urls == ()
+    assert pages["https://example.com/about"].source_page_urls == (
+        "https://example.com/",
+    )
+
+    records = observation_records(tuple(pages.values()))
+    source_record = next(
+        item
+        for item in records
+        if item.subject == "https://example.com/about"
+        and item.key == "page.source-pages"
+    )
+    assert source_record.state == '["https://example.com/"]'
+
+
+def test_unassessed_links_are_not_promoted_to_source_page_relations() -> None:
+    result = CrawlResult(
+        pages=(
+            CrawledPage(
+                _page(
+                    "https://example.com/",
+                    '<a href="/not-assessed">Not assessed</a>',
+                ),
+                depth=0,
+            ),
+        ),
+        skipped_urls=(),
+        exhausted_page_limit=False,
+        exhausted_byte_limit=False,
+    )
+
+    page = page_observations(result)[0]
+
+    assert page.source_page_urls == ()

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from veridra.collector import PageEvidence
+from veridra.crawl import CrawlResult, CrawledPage
+from veridra.observations import observation_records, page_observations
+
+
+def _page(url: str, body: str, *, status: int = 200) -> PageEvidence:
+    return PageEvidence(
+        requested_url=url,
+        final_url=url,
+        status_code=status,
+        headers={"content-type": "text/html; charset=utf-8"},
+        body=body,
+        redirect_chain=(),
+        connected_ip="203.0.113.10",
+        validated_ips=("203.0.113.10",),
+    )
+
+
+def test_page_observation_normalizes_directly_observed_page_facts() -> None:
+    result = CrawlResult(
+        pages=(
+            CrawledPage(
+                _page(
+                    "https://example.com/about",
+                    """
+                    <html><head>
+                    <title> About   Us </title>
+                    <meta name="description" content="Company profile">
+                    <link rel="canonical" href="/about">
+                    <script type="application/ld+json">
+                    {"@graph":[{"@type":"Organization"},{"@type":["WebPage","AboutPage"]}]}
+                    </script>
+                    </head><body><h1>About Example</h1></body></html>
+                    """,
+                ),
+                depth=1,
+            ),
+        ),
+        skipped_urls=(),
+        exhausted_page_limit=False,
+        exhausted_byte_limit=False,
+    )
+
+    pages = page_observations(result)
+
+    assert len(pages) == 1
+    page = pages[0]
+    assert page.url == "https://example.com/about"
+    assert page.status_code == 200
+    assert page.depth == 1
+    assert page.title == "About Us"
+    assert page.meta_description == "Company profile"
+    assert page.h1_count == 1
+    assert page.h1_text == "About Example"
+    assert page.canonical_url == "https://example.com/about"
+    assert page.indexable is True
+    assert page.structured_data_types == ("AboutPage", "Organization", "WebPage")
+    assert len(page.fingerprint) == 64
+
+
+def test_page_identity_and_fingerprint_are_deterministic_across_crawl_order() -> None:
+    first_page = CrawledPage(
+        _page("https://example.com/", "<html><title>Home</title><h1>Home</h1></html>"),
+        depth=0,
+    )
+    second_page = CrawledPage(
+        _page("https://example.com/contact", "<html><title>Contact</title></html>"),
+        depth=1,
+    )
+    first = CrawlResult(
+        pages=(second_page, first_page),
+        skipped_urls=(),
+        exhausted_page_limit=False,
+        exhausted_byte_limit=False,
+    )
+    second = CrawlResult(
+        pages=(first_page, second_page),
+        skipped_urls=(),
+        exhausted_page_limit=False,
+        exhausted_byte_limit=False,
+    )
+
+    assert page_observations(first) == page_observations(second)
+
+
+def test_fingerprint_changes_when_bounded_page_content_changes() -> None:
+    before = CrawlResult(
+        pages=(
+            CrawledPage(
+                _page("https://example.com/", "<html><title>Old</title></html>"),
+                depth=0,
+            ),
+        ),
+        skipped_urls=(),
+        exhausted_page_limit=False,
+        exhausted_byte_limit=False,
+    )
+    after = CrawlResult(
+        pages=(
+            CrawledPage(
+                _page("https://example.com/", "<html><title>New</title></html>"),
+                depth=0,
+            ),
+        ),
+        skipped_urls=(),
+        exhausted_page_limit=False,
+        exhausted_byte_limit=False,
+    )
+
+    assert page_observations(before)[0].fingerprint != page_observations(after)[0].fingerprint
+
+
+def test_noindex_and_observation_records_remain_machine_comparable() -> None:
+    result = CrawlResult(
+        pages=(
+            CrawledPage(
+                _page(
+                    "https://example.com/private",
+                    '<html><meta name="robots" content="noindex"><h1>Private</h1></html>',
+                ),
+                depth=1,
+            ),
+        ),
+        skipped_urls=(),
+        exhausted_page_limit=False,
+        exhausted_byte_limit=False,
+    )
+
+    pages = page_observations(result)
+    records = observation_records(pages)
+
+    assert pages[0].indexable is False
+    assert [(item.key, item.state) for item in records] == [
+        ("page.fingerprint", pages[0].fingerprint),
+        ("page.http-status", "200"),
+        ("page.indexable", "false"),
+    ]

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from veridra.collector import PageEvidence
-from veridra.crawl import CrawlResult, CrawledPage
+from veridra.crawl import CrawledPage, CrawlResult
 from veridra.observations import observation_records, page_observations
 
 

--- a/tests/test_observations.py
+++ b/tests/test_observations.py
@@ -57,6 +57,7 @@ def test_page_observation_normalizes_directly_observed_page_facts() -> None:
     assert page.canonical_url == "https://example.com/about"
     assert page.indexable is True
     assert page.structured_data_types == ("AboutPage", "Organization", "WebPage")
+    assert page.source_page_urls == ()
     assert len(page.fingerprint) == 64
 
 
@@ -136,4 +137,5 @@ def test_noindex_and_observation_records_remain_machine_comparable() -> None:
         ("page.fingerprint", pages[0].fingerprint),
         ("page.http-status", "200"),
         ("page.indexable", "false"),
+        ("page.source-pages", "[]"),
     ]

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from veridra.core import Assessment, Finding, Status
+from veridra.history import Comparison
+from veridra.progress import build_progress_summary
+
+
+def _assessment(*findings: Finding) -> Assessment:
+    return Assessment.build(
+        "https://example.com",
+        list(findings),
+        generated_at=datetime(2026, 9, 1, tzinfo=UTC),
+    )
+
+
+def _finding(
+    finding_id: str,
+    *,
+    status: Status = Status.attention,
+    severity: str = "medium",
+) -> Finding:
+    return Finding(
+        id=finding_id,
+        area="Website health",
+        title=finding_id,
+        status=status,
+        severity=severity,
+        summary="Observed.",
+    )
+
+
+def test_progress_uses_stable_finding_ids_for_lifecycle_groups() -> None:
+    before = _assessment(
+        _finding("finding.persist"),
+        _finding("finding.resolve"),
+        _finding("finding.state", status=Status.attention, severity="high"),
+    )
+    after = _assessment(
+        _finding("finding.persist"),
+        _finding("finding.new"),
+        _finding("finding.state", status=Status.passed, severity="info"),
+    )
+    comparison = Comparison(
+        before_id="a" * 24,
+        after_id="b" * 24,
+        added=("finding.new",),
+        resolved=("finding.resolve",),
+        changed=("finding.state",),
+        unchanged=("finding.persist",),
+        page_history_available=True,
+        pages_added=("https://example.com/new",),
+        pages_removed=("https://example.com/old",),
+        pages_changed=("https://example.com/",),
+        page_status_changed=("https://example.com/old",),
+    )
+
+    summary = build_progress_summary(before, after, comparison)
+
+    assert summary.new_findings == ("finding.new",)
+    assert summary.resolved_findings == ("finding.resolve",)
+    assert summary.persistent_findings == ("finding.persist", "finding.state")
+    assert len(summary.state_changes) == 1
+    change = summary.state_changes[0]
+    assert change.finding_id == "finding.state"
+    assert change.before_status == "attention"
+    assert change.after_status == "passed"
+    assert change.before_severity == "high"
+    assert change.after_severity == "info"
+    assert summary.pages_added == ("https://example.com/new",)
+    assert summary.pages_removed == ("https://example.com/old",)
+    assert summary.pages_changed == ("https://example.com/",)
+    assert summary.page_status_changed == ("https://example.com/old",)
+    assert summary.page_history_available is True
+
+
+def test_progress_does_not_call_legacy_page_history_zero_change() -> None:
+    before = _assessment(_finding("finding.persist"))
+    after = _assessment(_finding("finding.persist"))
+    comparison = Comparison(
+        before_id="a" * 24,
+        after_id="b" * 24,
+        added=(),
+        resolved=(),
+        changed=(),
+        unchanged=("finding.persist",),
+        page_history_available=False,
+    )
+
+    summary = build_progress_summary(before, after, comparison)
+
+    assert summary.persistent_findings == ("finding.persist",)
+    assert summary.page_history_available is False
+    assert summary.pages_added == ()
+    assert summary.pages_removed == ()
+    assert summary.pages_changed == ()
+    assert summary.page_status_changed == ()

--- a/tools/operator_e2e_acceptance_entry.py
+++ b/tools/operator_e2e_acceptance_entry.py
@@ -144,6 +144,28 @@ def _report(page: Page, project_url: str, evidence: Path) -> None:
     acceptance._assert_text(page, "SMTP accepted the report delivery")
 
 
+def _wait_autonomous_monitoring(
+    runtime_log: Path,
+    page: Page,
+    monitoring_url: str,
+) -> None:
+    """Run the established monitor wait, then prove Progress/Changes in Chromium."""
+    _ORIGINAL_WAIT_AUTONOMOUS_MONITORING(runtime_log, page, monitoring_url)
+    project_url = monitoring_url.rsplit("/monitoring", 1)[0]
+    page.goto(project_url, wait_until="networkidle")
+    progress_link = page.get_by_role("link", name="Progress / Changes")
+    progress_link.wait_for(state="visible", timeout=10_000)
+    progress_link.click()
+    page.wait_for_url("**/progress")
+    page.wait_for_load_state("networkidle")
+    acceptance._assert_text(page, "Progress / Changes")
+    acceptance._assert_text(page, "Change details")
+    acceptance._assert_text(page, "Pages changed")
+    acceptance._assert_text(page, "New findings")
+    acceptance._assert_text(page, "Resolved findings")
+    acceptance._assert_text(page, "Persistent findings")
+
+
 def _preserve_playwright_browser_cache() -> None:
     """Keep E2E state isolated without hiding Chromium installed by setup."""
     if os.environ.get("PLAYWRIGHT_BROWSERS_PATH"):
@@ -157,9 +179,11 @@ def _preserve_playwright_browser_cache() -> None:
         print(f"[E2E] Reusing Playwright browser cache: {browser_cache}", flush=True)
 
 
+_ORIGINAL_WAIT_AUTONOMOUS_MONITORING = acceptance._wait_autonomous_monitoring
 acceptance._run_launcher = _run_launcher
 acceptance._create_and_qualify_prospect = _create_and_qualify_prospect
 acceptance._report = _report
+acceptance._wait_autonomous_monitoring = _wait_autonomous_monitoring
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope
Implements the observation/history foundation in #274.

- adds bounded normalized `PageObservation` records derived only from already-collected crawl evidence;
- persists normalized URL, HTTP status, depth, title, meta description, H1 summary/count, canonical target, indexability, content type, response size, structured-data types and deterministic page fingerprints;
- persists assessed-page source-link relationships without claiming unrecorded crawler discovery provenance;
- keeps machine-comparable `ObservationRecord` data separate from findings;
- persists observation time, collector version, source type/confidence and evidence-reference slots without inventing unavailable raw-evidence identifiers;
- introduces backward-compatible `ObservedAssessment` schema 1.4 while preserving schema-1.3 assessments as plain `Assessment` objects;
- persists crawl profile/effective limits and collector version for live assessments;
- extends history comparison with page added/removed/changed/status-change deltas while preserving existing finding comparison fields;
- suppresses page-history claims when either assessment predates observation provenance;
- adds deterministic `ProgressSummary` semantics for new, resolved, persistent and status/severity-changed findings;
- adds evidence-bounded first_seen/last_seen semantics: findings use retained assessment history, while normalized observation lifecycle stays explicitly unknown if retained history contains pre-observation assessments;
- adds a tenant-isolated project `Progress / Changes` surface with latest-vs-previous page/finding deltas and explicit legacy-history messaging;
- links the project overview to Progress / Changes;
- extends the real Windows Playwright first-customer operator acceptance to navigate Project → Progress / Changes after manual + autonomous monitoring have produced comparable saved assessments;
- adds deterministic unit/HTTP/tenant tests for observations, source relations, compatibility, lifecycle, comparison and progress semantics.

## Safety / compatibility
- no new network behavior, JavaScript execution, authentication or active probing;
- raw collected evidence remains authoritative;
- no external estimates or AI interpretation enter the deterministic comparison layer;
- no destructive migration of existing assessment evidence;
- legacy saved assessments remain readable and preserve prior hashing/equality semantics;
- tenant storage/permission boundaries are reused rather than duplicated;
- existing finding comparison fields, reports, remediation and monitoring contracts remain intact.

## Validation gate
Do not merge until the latest head passes Ruff, strict mypy, full pytest, deterministic audit, Chromium/browser acceptance, commercial acceptance and Windows portability/true Playwright operator E2E.

Closes #274 when the full validation gate is green.