### PR TITLE
#273: standard JSON AI review exchange

### DIFF
--- a/docs/ai-review-chatgpt-prompt.md
+++ b/docs/ai-review-chatgpt-prompt.md
@@ -1,0 +1,76 @@
+# VERIDRA Standard AI Review Prompt
+
+Use this prompt with one `VERIDRA_AI_REVIEW_*.json` export.
+
+---
+
+You are the reasoning layer in a VERIDRA review exchange.
+
+VERIDRA owns the evidence, deterministic scores, workflow and state. Your job is to interpret only the supplied review bundle and return one structured JSON result. Do not invent evidence, traffic, rankings, audience data, conversion impact, revenue impact, customer intent, outreach events or facts that are not present in the bundle.
+
+## Required procedure
+
+1. Read the attached JSON and verify that `exchange_type` is `veridra_ai_review_bundle` and `schema_version` is `1.0`.
+2. Treat `evidence`, `deterministic_scores`, `context` and `provenance` as the complete authoritative input for this review.
+3. Distinguish direct evidence from inference. State uncertainty explicitly.
+4. Cite only `evidence_id` values that actually exist in the bundle.
+5. Do not recommend or claim that outreach has occurred. Suggested messaging is advisory copy/positioning only.
+6. Use only these structured safe action values when justified: `flag_for_follow_up`, `request_human_review`, `create_remediation_review`.
+7. Return exactly one JSON object and no prose outside it.
+
+## Required result shape
+
+```json
+{
+  "schema_version": "1.0",
+  "exchange_type": "veridra_ai_review_result",
+  "review_id": "a unique review identifier",
+  "source_bundle_id": "copy bundle_id exactly",
+  "source_bundle_hash_sha256": "copy bundle_hash_sha256 exactly",
+  "generated_at": "current ISO-8601 timestamp with timezone",
+  "model_provenance": "model name/version if known, otherwise null",
+  "tool_provenance": "brief description of tools used, otherwise null",
+  "interpretation": "bounded evidence-grounded interpretation",
+  "strengths": ["..."],
+  "weaknesses_gaps": ["..."],
+  "opportunity_assessment": "...",
+  "confidence": "high | medium | low | unknown",
+  "uncertainty": ["..."],
+  "recommended_next_action": "...",
+  "suggested_messaging_positioning": ["..."],
+  "evidence_refs": ["existing evidence_id values only"],
+  "safe_actions": [
+    {
+      "action": "request_human_review",
+      "reason": "...",
+      "evidence_refs": ["existing evidence_id values only"]
+    }
+  ],
+  "result_hash_sha256": "SHA-256 described below"
+}
+```
+
+## Integrity hash
+
+Before returning the JSON:
+
+1. Build the complete result object except `result_hash_sha256`.
+2. Normalize `generated_at` to UTC ISO-8601 using `Z`.
+3. Serialize that object as UTF-8 JSON with keys sorted, no insignificant whitespace, and Unicode preserved (`ensure_ascii=false`; separators `,` and `:`).
+4. Compute SHA-256 of those bytes.
+5. Put the lowercase 64-character hexadecimal digest in `result_hash_sha256`.
+
+If your current environment cannot reliably compute SHA-256, say so instead of inventing a digest. A VERIDRA import with a fabricated or incorrect digest will be rejected.
+
+## Reasoning hardlines
+
+- A missing fact remains missing.
+- Correlation is not causation.
+- Do not turn a bounded review sample into population-wide statistics.
+- Do not convert technical observations into quantified business loss without direct evidence.
+- Suggested messaging must remain consistent with cited evidence.
+- Structured safe actions are recommendations only; VERIDRA does not execute them automatically.
+
+---
+
+The returned file should be saved as a `.json` file and imported through Project → AI review exchange → Import reviewed result.

--- a/src/veridra/agency_ai_review_web.py
+++ b/src/veridra/agency_ai_review_web.py
@@ -4,18 +4,24 @@ from __future__ import annotations
 import html
 import json
 from pathlib import Path
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlencode
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from .agency_navigation import agency_navigation
 from .ai_review_exchange import (
+    AIReviewBundle,
     AIReviewExchangeError,
     ReviewContextType,
     parse_and_validate_result,
 )
-from .identity_tenancy import IdentityBoundaryError, RequestIdentity, TenantCapability, require_tenant_capability
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
 from .project_ai_review import build_project_review_bundle
 from .project_store import ClientProject
 from .request_security import require_request_identity
@@ -39,7 +45,11 @@ def _root(request: Request) -> Path | None:
     return value if isinstance(value, Path) else None
 
 
-def _project(request: Request, identity: RequestIdentity, project_id: str) -> ClientProject:
+def _project(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+) -> ClientProject:
     store = TenantProjectStore(_root(request))
     try:
         return store.load(identity, store.ref(identity, project_id))
@@ -55,7 +65,11 @@ def _can_manage(identity: RequestIdentity) -> bool:
     return True
 
 
-def _latest_bundle(request: Request, identity: RequestIdentity, project_id: str):
+def _latest_bundle(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+) -> AIReviewBundle:
     project = _project(request, identity, project_id)
     history = TenantHistoryStore(_root(request))
     try:
@@ -63,10 +77,16 @@ def _latest_bundle(request: Request, identity: RequestIdentity, project_id: str)
     except TenantHistoryStoreError as exc:
         raise HTTPException(status_code=404, detail="Project history not found.") from exc
     if not entries:
-        raise HTTPException(status_code=409, detail="Run and save an assessment before exporting an AI review bundle.")
+        raise HTTPException(
+            status_code=409,
+            detail="Run and save an assessment before exporting an AI review bundle.",
+        )
     latest = entries[0]
     try:
-        assessment = history.load(identity, history.ref(identity, project_id, latest.id))
+        assessment = history.load(
+            identity,
+            history.ref(identity, project_id, latest.id),
+        )
     except TenantHistoryStoreError as exc:
         raise HTTPException(status_code=404, detail="Latest assessment not found.") from exc
     return build_project_review_bundle(
@@ -80,11 +100,17 @@ def _latest_bundle(request: Request, identity: RequestIdentity, project_id: str)
 def _list(values: tuple[str, ...]) -> str:
     if not values:
         return "<p class='muted'>None recorded.</p>"
-    return "<ul>" + "".join(f"<li>{html.escape(value)}</li>" for value in values) + "</ul>"
+    return "<ul>" + "".join(
+        f"<li>{html.escape(value)}</li>" for value in values
+    ) + "</ul>"
 
 
 @router.get("/projects/{project_id}/ai-review", response_class=HTMLResponse)
-def project_ai_review(project_id: str, request: Request, imported: bool = False) -> str:
+def project_ai_review(
+    project_id: str,
+    request: Request,
+    imported: bool = False,
+) -> str:
     identity = require_request_identity(request)
     project = _project(request, identity, project_id)
     store = TenantAIReviewStore(_root(request))
@@ -106,7 +132,11 @@ def project_ai_review(project_id: str, request: Request, imported: bool = False)
         "</tr>"
         for item in history
     ) or "<tr><td colspan='4' class='muted'>No reviewed result has been imported yet.</td></tr>"
-    imported_notice = "<p class='notice ai'><strong>Reviewed result imported.</strong> AI reasoning is stored as a separate provenance layer; deterministic VERIDRA evidence was not changed.</p>" if imported else ""
+    imported_notice = (
+        "<p class='notice ai'><strong>Reviewed result imported.</strong> AI reasoning is stored as a separate provenance layer; deterministic VERIDRA evidence was not changed.</p>"
+        if imported
+        else ""
+    )
     navigation = agency_navigation(identity, current="projects")
     body = f"""{navigation}<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>← Project overview</a></p><h1>AI review exchange — {html.escape(project.name)}</h1>{imported_notice}<p class='notice ai'><strong>Separation rule:</strong> VERIDRA owns observed evidence and deterministic state. Imported AI reasoning is advisory and visibly separate.</p><div class='actions'>{''.join(actions)}</div><p class='muted'>Normal workflow: export one JSON → attach it to ChatGPT with the standard prompt → import the returned JSON → inspect the reviewed result.</p></section><section><h2>Review history / provenance</h2><table class='history'><thead><tr><th>Review</th><th>Generated</th><th>Source bundle</th><th>Model provenance</th></tr></thead><tbody>{rows}</tbody></table></section>"""
     return _page(f"{project.name} AI review", body)
@@ -118,7 +148,12 @@ def export_project_ai_review(project_id: str, request: Request) -> Response:
     require_tenant_capability(identity, TenantCapability.manage_reports)
     bundle = _latest_bundle(request, identity, project_id)
     TenantAIReviewStore(_root(request)).save_bundle(identity, bundle)
-    content = json.dumps(bundle.model_dump(mode="json"), indent=2, ensure_ascii=False, sort_keys=True)
+    content = json.dumps(
+        bundle.model_dump(mode="json"),
+        indent=2,
+        ensure_ascii=False,
+        sort_keys=True,
+    )
     filename = f"VERIDRA_AI_REVIEW_{project_id}_{bundle.bundle_id}.json"
     return Response(
         content=content,
@@ -128,18 +163,27 @@ def export_project_ai_review(project_id: str, request: Request) -> Response:
 
 
 @router.get("/projects/{project_id}/ai-review/import", response_class=HTMLResponse)
-def import_project_ai_review_form(project_id: str, request: Request, error: str | None = None) -> str:
+def import_project_ai_review_form(
+    project_id: str,
+    request: Request,
+    error: str | None = None,
+) -> str:
     identity = require_request_identity(request)
     require_tenant_capability(identity, TenantCapability.manage_reports)
     project = _project(request, identity, project_id)
-    error_panel = f"<p class='notice error'>{html.escape(error)}</p>" if error else ""
+    error_panel = (
+        f"<p class='notice error'>{html.escape(error)}</p>" if error else ""
+    )
     navigation = agency_navigation(identity, current="projects")
     body = f"""{navigation}<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}/ai-review'>← AI review exchange</a></p><h1>Import reviewed result</h1>{error_panel}<p>Paste the complete <code>veridra_ai_review_result</code> JSON returned for this project. VERIDRA validates schema, source bundle id/hash, chronology, result integrity and evidence references before storing it.</p><form method='post'><label for='result_json'><strong>Reviewed result JSON</strong></label><textarea id='result_json' name='result_json' required spellcheck='false'></textarea><p><button type='submit'>Validate and import</button></p></form><p class='muted'>Import is append-only. It cannot overwrite assessments, findings, deterministic scores, customer records, prospects or outreach state.</p></section>"""
     return _page(f"Import AI review — {project.name}", body)
 
 
 @router.post("/projects/{project_id}/ai-review/import")
-async def import_project_ai_review(project_id: str, request: Request) -> RedirectResponse:
+async def import_project_ai_review(
+    project_id: str,
+    request: Request,
+) -> RedirectResponse:
     identity = require_request_identity(request)
     require_tenant_capability(identity, TenantCapability.manage_reports)
     _project(request, identity, project_id)
@@ -148,33 +192,60 @@ async def import_project_ai_review(project_id: str, request: Request) -> Redirec
     try:
         preview = json.loads(raw)
         if not isinstance(preview, dict):
-            raise ValueError
+            raise ValueError("Reviewed result must be a JSON object.")
         bundle_id = str(preview.get("source_bundle_id", ""))
         if not bundle_id:
-            raise ValueError
+            raise ValueError("Reviewed result has no source bundle id.")
         store = TenantAIReviewStore(_root(request))
-        bundle = store.load_bundle(identity, ReviewContextType.project, project_id, bundle_id)
+        bundle = store.load_bundle(
+            identity,
+            ReviewContextType.project,
+            project_id,
+            bundle_id,
+        )
         result = parse_and_validate_result(raw, source_bundle=bundle)
         store.save_result(identity, bundle=bundle, result=result)
     except (ValueError, AIReviewExchangeError, TenantAIReviewStoreError) as exc:
         message = str(exc) or "Reviewed result is invalid."
-        location = f"/agency/projects/{project_id}/ai-review/import?error={html.escape(message, quote=True)}"
-        return RedirectResponse(location, status_code=303)
-    return RedirectResponse(f"/agency/projects/{project_id}/ai-review?imported=true", status_code=303)
+        query = urlencode({"error": message})
+        return RedirectResponse(
+            f"/agency/projects/{project_id}/ai-review/import?{query}",
+            status_code=303,
+        )
+    return RedirectResponse(
+        f"/agency/projects/{project_id}/ai-review?imported=true",
+        status_code=303,
+    )
 
 
-@router.get("/projects/{project_id}/ai-review/results/{review_id}", response_class=HTMLResponse)
-def view_project_ai_review(project_id: str, review_id: str, request: Request) -> str:
+@router.get(
+    "/projects/{project_id}/ai-review/results/{review_id}",
+    response_class=HTMLResponse,
+)
+def view_project_ai_review(
+    project_id: str,
+    review_id: str,
+    request: Request,
+) -> str:
     identity = require_request_identity(request)
     project = _project(request, identity, project_id)
     store = TenantAIReviewStore(_root(request))
     try:
-        result = store.load_result(identity, ReviewContextType.project, project_id, review_id)
+        result = store.load_result(
+            identity,
+            ReviewContextType.project,
+            project_id,
+            review_id,
+        )
     except TenantAIReviewStoreError as exc:
         raise HTTPException(status_code=404, detail="AI reviewed result not found.") from exc
     actions = "".join(
         f"<li><span class='pill'>{html.escape(item.action.value)}</span> {html.escape(item.reason)}"
-        + (f"<br><span class='muted'>Evidence: {html.escape(', '.join(item.evidence_refs))}</span>" if item.evidence_refs else "")
+        + (
+            f"<br><span class='muted'>Evidence: {html.escape(', '.join(item.evidence_refs))}</span>"
+            if item.evidence_refs
+            else ""
+        )
         + "</li>"
         for item in result.safe_actions
     ) or "<li class='muted'>No structured safe actions supplied.</li>"

--- a/src/veridra/agency_ai_review_web.py
+++ b/src/veridra/agency_ai_review_web.py
@@ -1,0 +1,183 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
+
+from .agency_navigation import agency_navigation
+from .ai_review_exchange import (
+    AIReviewExchangeError,
+    ReviewContextType,
+    parse_and_validate_result,
+)
+from .identity_tenancy import IdentityBoundaryError, RequestIdentity, TenantCapability, require_tenant_capability
+from .project_ai_review import build_project_review_bundle
+from .project_store import ClientProject
+from .request_security import require_request_identity
+from .tenant_ai_review_store import TenantAIReviewStore, TenantAIReviewStoreError
+from .tenant_history_store import TenantHistoryStore, TenantHistoryStoreError
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+
+router = APIRouter(prefix="/agency", tags=["agency-ai-review"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:980px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}.actions{display:flex;gap:8px;flex-wrap:wrap}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.ai{border-left-color:#6b4eff;background:#f7f5ff}.error{border-left-color:#b42318;background:#fff4f2}textarea{width:100%;min-height:360px;padding:12px;border:1px solid #cfd4da;border-radius:7px;font:12px Consolas,monospace}ul{padding-left:20px}.history{width:100%;border-collapse:collapse}.history th,.history td{text-align:left;padding:9px;border-bottom:1px solid #e5e7eb;vertical-align:top}.pill{display:inline-block;padding:3px 7px;border-radius:999px;background:#eee;font-size:12px}code{overflow-wrap:anywhere}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _project(request: Request, identity: RequestIdentity, project_id: str) -> ClientProject:
+    store = TenantProjectStore(_root(request))
+    try:
+        return store.load(identity, store.ref(identity, project_id))
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+
+def _can_manage(identity: RequestIdentity) -> bool:
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_reports)
+    except IdentityBoundaryError:
+        return False
+    return True
+
+
+def _latest_bundle(request: Request, identity: RequestIdentity, project_id: str):
+    project = _project(request, identity, project_id)
+    history = TenantHistoryStore(_root(request))
+    try:
+        entries = history.list(identity, project_id)
+    except TenantHistoryStoreError as exc:
+        raise HTTPException(status_code=404, detail="Project history not found.") from exc
+    if not entries:
+        raise HTTPException(status_code=409, detail="Run and save an assessment before exporting an AI review bundle.")
+    latest = entries[0]
+    try:
+        assessment = history.load(identity, history.ref(identity, project_id, latest.id))
+    except TenantHistoryStoreError as exc:
+        raise HTTPException(status_code=404, detail="Latest assessment not found.") from exc
+    return build_project_review_bundle(
+        project_id=project_id,
+        project=project,
+        assessment_id=latest.id,
+        assessment=assessment,
+    )
+
+
+def _list(values: tuple[str, ...]) -> str:
+    if not values:
+        return "<p class='muted'>None recorded.</p>"
+    return "<ul>" + "".join(f"<li>{html.escape(value)}</li>" for value in values) + "</ul>"
+
+
+@router.get("/projects/{project_id}/ai-review", response_class=HTMLResponse)
+def project_ai_review(project_id: str, request: Request, imported: bool = False) -> str:
+    identity = require_request_identity(request)
+    project = _project(request, identity, project_id)
+    store = TenantAIReviewStore(_root(request))
+    history = store.list_results(identity, ReviewContextType.project, project_id)
+    can_manage = _can_manage(identity)
+    actions = [
+        f"<a class='button' href='/agency/projects/{html.escape(project_id, quote=True)}/ai-review/export'>Export AI review JSON</a>"
+    ]
+    if can_manage:
+        actions.append(
+            f"<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}/ai-review/import'>Import reviewed result</a>"
+        )
+    rows = "".join(
+        "<tr>"
+        f"<td><a href='/agency/projects/{html.escape(project_id, quote=True)}/ai-review/results/{html.escape(item.review_id, quote=True)}'>{html.escape(item.review_id)}</a></td>"
+        f"<td>{html.escape(item.generated_at)}</td>"
+        f"<td><code>{html.escape(item.source_bundle_id)}</code></td>"
+        f"<td>{html.escape(item.model_provenance or 'Not supplied')}</td>"
+        "</tr>"
+        for item in history
+    ) or "<tr><td colspan='4' class='muted'>No reviewed result has been imported yet.</td></tr>"
+    imported_notice = "<p class='notice ai'><strong>Reviewed result imported.</strong> AI reasoning is stored as a separate provenance layer; deterministic VERIDRA evidence was not changed.</p>" if imported else ""
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>← Project overview</a></p><h1>AI review exchange — {html.escape(project.name)}</h1>{imported_notice}<p class='notice ai'><strong>Separation rule:</strong> VERIDRA owns observed evidence and deterministic state. Imported AI reasoning is advisory and visibly separate.</p><div class='actions'>{''.join(actions)}</div><p class='muted'>Normal workflow: export one JSON → attach it to ChatGPT with the standard prompt → import the returned JSON → inspect the reviewed result.</p></section><section><h2>Review history / provenance</h2><table class='history'><thead><tr><th>Review</th><th>Generated</th><th>Source bundle</th><th>Model provenance</th></tr></thead><tbody>{rows}</tbody></table></section>"""
+    return _page(f"{project.name} AI review", body)
+
+
+@router.get("/projects/{project_id}/ai-review/export")
+def export_project_ai_review(project_id: str, request: Request) -> Response:
+    identity = require_request_identity(request)
+    require_tenant_capability(identity, TenantCapability.manage_reports)
+    bundle = _latest_bundle(request, identity, project_id)
+    TenantAIReviewStore(_root(request)).save_bundle(identity, bundle)
+    content = json.dumps(bundle.model_dump(mode="json"), indent=2, ensure_ascii=False, sort_keys=True)
+    filename = f"VERIDRA_AI_REVIEW_{project_id}_{bundle.bundle_id}.json"
+    return Response(
+        content=content,
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/projects/{project_id}/ai-review/import", response_class=HTMLResponse)
+def import_project_ai_review_form(project_id: str, request: Request, error: str | None = None) -> str:
+    identity = require_request_identity(request)
+    require_tenant_capability(identity, TenantCapability.manage_reports)
+    project = _project(request, identity, project_id)
+    error_panel = f"<p class='notice error'>{html.escape(error)}</p>" if error else ""
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}/ai-review'>← AI review exchange</a></p><h1>Import reviewed result</h1>{error_panel}<p>Paste the complete <code>veridra_ai_review_result</code> JSON returned for this project. VERIDRA validates schema, source bundle id/hash, chronology, result integrity and evidence references before storing it.</p><form method='post'><label for='result_json'><strong>Reviewed result JSON</strong></label><textarea id='result_json' name='result_json' required spellcheck='false'></textarea><p><button type='submit'>Validate and import</button></p></form><p class='muted'>Import is append-only. It cannot overwrite assessments, findings, deterministic scores, customer records, prospects or outreach state.</p></section>"""
+    return _page(f"Import AI review — {project.name}", body)
+
+
+@router.post("/projects/{project_id}/ai-review/import")
+async def import_project_ai_review(project_id: str, request: Request) -> RedirectResponse:
+    identity = require_request_identity(request)
+    require_tenant_capability(identity, TenantCapability.manage_reports)
+    _project(request, identity, project_id)
+    values = parse_qs((await request.body()).decode("utf-8"), keep_blank_values=True)
+    raw = values.get("result_json", [""])[0].strip()
+    try:
+        preview = json.loads(raw)
+        if not isinstance(preview, dict):
+            raise ValueError
+        bundle_id = str(preview.get("source_bundle_id", ""))
+        if not bundle_id:
+            raise ValueError
+        store = TenantAIReviewStore(_root(request))
+        bundle = store.load_bundle(identity, ReviewContextType.project, project_id, bundle_id)
+        result = parse_and_validate_result(raw, source_bundle=bundle)
+        store.save_result(identity, bundle=bundle, result=result)
+    except (ValueError, AIReviewExchangeError, TenantAIReviewStoreError) as exc:
+        message = str(exc) or "Reviewed result is invalid."
+        location = f"/agency/projects/{project_id}/ai-review/import?error={html.escape(message, quote=True)}"
+        return RedirectResponse(location, status_code=303)
+    return RedirectResponse(f"/agency/projects/{project_id}/ai-review?imported=true", status_code=303)
+
+
+@router.get("/projects/{project_id}/ai-review/results/{review_id}", response_class=HTMLResponse)
+def view_project_ai_review(project_id: str, review_id: str, request: Request) -> str:
+    identity = require_request_identity(request)
+    project = _project(request, identity, project_id)
+    store = TenantAIReviewStore(_root(request))
+    try:
+        result = store.load_result(identity, ReviewContextType.project, project_id, review_id)
+    except TenantAIReviewStoreError as exc:
+        raise HTTPException(status_code=404, detail="AI reviewed result not found.") from exc
+    actions = "".join(
+        f"<li><span class='pill'>{html.escape(item.action.value)}</span> {html.escape(item.reason)}"
+        + (f"<br><span class='muted'>Evidence: {html.escape(', '.join(item.evidence_refs))}</span>" if item.evidence_refs else "")
+        + "</li>"
+        for item in result.safe_actions
+    ) or "<li class='muted'>No structured safe actions supplied.</li>"
+    navigation = agency_navigation(identity, current="projects")
+    body = f"""{navigation}<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}/ai-review'>← AI review exchange</a></p><h1>Reviewed result — {html.escape(project.name)}</h1><p class='notice ai'><strong>AI interpretation — imported reasoning, not VERIDRA observation.</strong> Verify recommendations against the cited deterministic evidence before acting.</p><p><strong>Review ID:</strong> <code>{html.escape(result.review_id)}</code><br><strong>Generated:</strong> {html.escape(result.generated_at.isoformat())}<br><strong>Model:</strong> {html.escape(result.model_provenance or 'Not supplied')}<br><strong>Tool:</strong> {html.escape(result.tool_provenance or 'Not supplied')}<br><strong>Source bundle:</strong> <code>{html.escape(result.source_bundle_id)}</code><br><strong>Confidence:</strong> {html.escape(result.confidence.value)}</p></section><section><h2>Interpretation</h2><p>{html.escape(result.interpretation)}</p><h3>Strengths</h3>{_list(result.strengths)}<h3>Weaknesses / gaps</h3>{_list(result.weaknesses_gaps)}<h3>Opportunity assessment</h3><p>{html.escape(result.opportunity_assessment)}</p><h3>Uncertainty</h3>{_list(result.uncertainty)}</section><section><h2>Recommended next action</h2><p>{html.escape(result.recommended_next_action)}</p><h3>Suggested messaging / positioning</h3>{_list(result.suggested_messaging_positioning)}<p class='muted'>These are imported suggestions. No outreach has been sent and no source workflow state is automatically modified.</p></section><section><h2>Structured safe actions</h2><ul>{actions}</ul><p class='muted'>Imported as review metadata only; execution remains an explicit operator decision.</p></section>"""
+    return _page(f"AI review {result.review_id}", body)

--- a/src/veridra/agency_project_customer_web.py
+++ b/src/veridra/agency_project_customer_web.py
@@ -41,9 +41,10 @@ def project_overview_with_customer(
             for customer_id, customer in linked
         )
         relationship = f"<p class='notice'><strong>Customer:</strong> {links}</p>"
-    progress = (
-        "<p><a href='/agency/projects/"
-        f"{html.escape(project_id, quote=True)}/progress'>Progress / Changes</a></p>"
+    project_id_html = html.escape(project_id, quote=True)
+    project_tools = (
+        f"<p><a href='/agency/projects/{project_id_html}/progress'>Progress / Changes</a> · "
+        f"<a href='/agency/projects/{project_id_html}/ai-review'>AI review exchange</a></p>"
     )
     marker = "<h1>"
-    return rendered.replace(marker, relationship + progress + marker, 1)
+    return rendered.replace(marker, relationship + project_tools + marker, 1)

--- a/src/veridra/ai_review_exchange.py
+++ b/src/veridra/ai_review_exchange.py
@@ -134,6 +134,10 @@ def _sha256(value: object) -> str:
     return hashlib.sha256(_canonical_bytes(value)).hexdigest()
 
 
+def _json_datetime(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
 def build_review_bundle(
     *,
     context_type: ReviewContextType,
@@ -150,7 +154,7 @@ def build_review_bundle(
     base = {
         "schema_version": EXPORT_SCHEMA_VERSION,
         "exchange_type": "veridra_ai_review_bundle",
-        "generated_at": timestamp.isoformat(),
+        "generated_at": _json_datetime(timestamp),
         "context_type": context_type.value,
         "context_id": context_id,
         "context_label": context_label,
@@ -225,7 +229,7 @@ def result_template(bundle: AIReviewBundle) -> dict[str, Any]:
         "review_id": f"review-{bundle.bundle_id}",
         "source_bundle_id": bundle.bundle_id,
         "source_bundle_hash_sha256": bundle.bundle_hash_sha256,
-        "generated_at": datetime.now(UTC).isoformat(),
+        "generated_at": _json_datetime(datetime.now(UTC)),
         "model_provenance": None,
         "tool_provenance": None,
         "interpretation": "",

--- a/src/veridra/ai_review_exchange.py
+++ b/src/veridra/ai_review_exchange.py
@@ -8,8 +8,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-EXPORT_SCHEMA_VERSION = "1.0"
-RESULT_SCHEMA_VERSION = "1.0"
+EXPORT_SCHEMA_VERSION: Literal["1.0"] = "1.0"
+RESULT_SCHEMA_VERSION: Literal["1.0"] = "1.0"
 
 
 class AIReviewExchangeError(ValueError):
@@ -124,6 +124,7 @@ class AIReviewResult(BaseModel):
 
 
 def _canonical_bytes(value: object) -> bytes:
+    payload: object
     if isinstance(value, BaseModel):
         payload = value.model_dump(mode="json")
     else:

--- a/src/veridra/ai_review_exchange.py
+++ b/src/veridra/ai_review_exchange.py
@@ -138,6 +138,24 @@ def _json_datetime(value: datetime) -> str:
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
+def _canonical_result_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    normalized.pop("result_hash_sha256", None)
+    generated_at = normalized.get("generated_at")
+    if isinstance(generated_at, datetime):
+        normalized["generated_at"] = _json_datetime(generated_at)
+    elif isinstance(generated_at, str):
+        try:
+            parsed = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        except ValueError:
+            pass
+        else:
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            normalized["generated_at"] = _json_datetime(parsed)
+    return normalized
+
+
 def build_review_bundle(
     *,
     context_type: ReviewContextType,
@@ -179,8 +197,7 @@ def bundle_integrity_hash(bundle: AIReviewBundle) -> str:
 
 def result_integrity_hash(result: AIReviewResult | dict[str, Any]) -> str:
     payload = result.model_dump(mode="json") if isinstance(result, AIReviewResult) else dict(result)
-    payload.pop("result_hash_sha256", None)
-    return _sha256(payload)
+    return _sha256(_canonical_result_payload(payload))
 
 
 def parse_and_validate_result(

--- a/src/veridra/ai_review_exchange.py
+++ b/src/veridra/ai_review_exchange.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+EXPORT_SCHEMA_VERSION = "1.0"
+RESULT_SCHEMA_VERSION = "1.0"
+
+
+class AIReviewExchangeError(ValueError):
+    pass
+
+
+class ReviewContextType(StrEnum):
+    prospect = "prospect"
+    customer = "customer"
+    project = "project"
+
+
+class ReviewConfidence(StrEnum):
+    high = "high"
+    medium = "medium"
+    low = "low"
+    unknown = "unknown"
+
+
+class SafeActionType(StrEnum):
+    flag_for_follow_up = "flag_for_follow_up"
+    request_human_review = "request_human_review"
+    create_remediation_review = "create_remediation_review"
+
+
+class EvidenceItem(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    evidence_id: str = Field(min_length=1, max_length=240)
+    source_type: str = Field(min_length=1, max_length=80)
+    source_ref: str = Field(min_length=1, max_length=500)
+    observed_at: datetime | None = None
+    facts: dict[str, Any] = Field(default_factory=dict)
+
+
+class DeterministicScore(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    key: str = Field(min_length=1, max_length=120)
+    value: int | float | str | bool
+    basis: str = Field(min_length=1, max_length=500)
+
+
+class AIReviewBundle(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    schema_version: Literal["1.0"] = EXPORT_SCHEMA_VERSION
+    exchange_type: Literal["veridra_ai_review_bundle"] = "veridra_ai_review_bundle"
+    bundle_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    bundle_hash_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    generated_at: datetime
+    context_type: ReviewContextType
+    context_id: str = Field(min_length=1, max_length=160)
+    context_label: str = Field(min_length=1, max_length=240)
+    target: str | None = Field(default=None, max_length=2048)
+    context: dict[str, Any] = Field(default_factory=dict)
+    deterministic_scores: tuple[DeterministicScore, ...] = ()
+    evidence: tuple[EvidenceItem, ...] = ()
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    instructions: tuple[str, ...] = (
+        "Treat VERIDRA evidence and deterministic scores as authoritative inputs.",
+        "Do not invent missing facts, traffic, rankings, audience data, business outcomes or outreach events.",
+        "Return a schema-valid veridra_ai_review_result bound to this exact bundle id and SHA-256 hash.",
+    )
+
+
+class SafeAction(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    action: SafeActionType
+    reason: str = Field(min_length=1, max_length=1000)
+    evidence_refs: tuple[str, ...] = ()
+
+
+class AIReviewResult(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    schema_version: Literal["1.0"] = RESULT_SCHEMA_VERSION
+    exchange_type: Literal["veridra_ai_review_result"] = "veridra_ai_review_result"
+    review_id: str = Field(min_length=8, max_length=160)
+    source_bundle_id: str = Field(pattern=r"^[0-9a-f]{24}$")
+    source_bundle_hash_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    generated_at: datetime
+    model_provenance: str | None = Field(default=None, max_length=240)
+    tool_provenance: str | None = Field(default=None, max_length=500)
+    interpretation: str = Field(min_length=1, max_length=8000)
+    strengths: tuple[str, ...] = ()
+    weaknesses_gaps: tuple[str, ...] = ()
+    opportunity_assessment: str = Field(min_length=1, max_length=5000)
+    confidence: ReviewConfidence = ReviewConfidence.unknown
+    uncertainty: tuple[str, ...] = ()
+    recommended_next_action: str = Field(min_length=1, max_length=2000)
+    suggested_messaging_positioning: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    safe_actions: tuple[SafeAction, ...] = ()
+    result_hash_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @model_validator(mode="after")
+    def referenced_evidence_is_not_empty_string(self) -> AIReviewResult:
+        if any(not value.strip() for value in self.evidence_refs):
+            raise ValueError("Evidence references must not be blank.")
+        for action in self.safe_actions:
+            if any(not value.strip() for value in action.evidence_refs):
+                raise ValueError("Safe-action evidence references must not be blank.")
+        return self
+
+
+def _canonical_bytes(value: object) -> bytes:
+    if isinstance(value, BaseModel):
+        payload = value.model_dump(mode="json")
+    else:
+        payload = value
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _sha256(value: object) -> str:
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def build_review_bundle(
+    *,
+    context_type: ReviewContextType,
+    context_id: str,
+    context_label: str,
+    target: str | None,
+    context: dict[str, Any],
+    deterministic_scores: tuple[DeterministicScore, ...] = (),
+    evidence: tuple[EvidenceItem, ...] = (),
+    provenance: dict[str, Any] | None = None,
+    generated_at: datetime | None = None,
+) -> AIReviewBundle:
+    timestamp = (generated_at or datetime.now(UTC)).astimezone(UTC)
+    base = {
+        "schema_version": EXPORT_SCHEMA_VERSION,
+        "exchange_type": "veridra_ai_review_bundle",
+        "generated_at": timestamp.isoformat(),
+        "context_type": context_type.value,
+        "context_id": context_id,
+        "context_label": context_label,
+        "target": target,
+        "context": context,
+        "deterministic_scores": [item.model_dump(mode="json") for item in deterministic_scores],
+        "evidence": [item.model_dump(mode="json") for item in evidence],
+        "provenance": provenance or {},
+        "instructions": list(AIReviewBundle.model_fields["instructions"].default),
+    }
+    bundle_id = _sha256(base)[:24]
+    with_id = {**base, "bundle_id": bundle_id}
+    bundle_hash = _sha256(with_id)
+    return AIReviewBundle.model_validate({**with_id, "bundle_hash_sha256": bundle_hash})
+
+
+def bundle_integrity_hash(bundle: AIReviewBundle) -> str:
+    payload = bundle.model_dump(mode="json")
+    payload.pop("bundle_hash_sha256", None)
+    return _sha256(payload)
+
+
+def result_integrity_hash(result: AIReviewResult | dict[str, Any]) -> str:
+    payload = result.model_dump(mode="json") if isinstance(result, AIReviewResult) else dict(result)
+    payload.pop("result_hash_sha256", None)
+    return _sha256(payload)
+
+
+def parse_and_validate_result(
+    raw: str | bytes,
+    *,
+    source_bundle: AIReviewBundle,
+) -> AIReviewResult:
+    if bundle_integrity_hash(source_bundle) != source_bundle.bundle_hash_sha256:
+        raise AIReviewExchangeError("Source AI review bundle failed integrity validation.")
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        raise AIReviewExchangeError("Reviewed result is not valid JSON.") from exc
+    if not isinstance(payload, dict):
+        raise AIReviewExchangeError("Reviewed result must be a JSON object.")
+    try:
+        result = AIReviewResult.model_validate(payload)
+    except ValueError as exc:
+        raise AIReviewExchangeError("Reviewed result does not match schema 1.0.") from exc
+    if result.source_bundle_id != source_bundle.bundle_id:
+        raise AIReviewExchangeError("Reviewed result belongs to a different AI review bundle.")
+    if result.source_bundle_hash_sha256 != source_bundle.bundle_hash_sha256:
+        raise AIReviewExchangeError("Reviewed result source hash does not match the exported bundle.")
+    if result.generated_at.astimezone(UTC) < source_bundle.generated_at.astimezone(UTC):
+        raise AIReviewExchangeError("Reviewed result predates its source bundle and is stale.")
+    if result_integrity_hash(result) != result.result_hash_sha256:
+        raise AIReviewExchangeError("Reviewed result failed integrity validation.")
+    known_refs = {item.evidence_id for item in source_bundle.evidence}
+    used_refs = set(result.evidence_refs)
+    for action in result.safe_actions:
+        used_refs.update(action.evidence_refs)
+    unknown = sorted(used_refs - known_refs)
+    if unknown:
+        raise AIReviewExchangeError(
+            "Reviewed result cites evidence that is not present in the source bundle: "
+            + ", ".join(unknown)
+        )
+    return result
+
+
+def result_template(bundle: AIReviewBundle) -> dict[str, Any]:
+    """Return a fillable result shape; the final result hash is computed over all other fields."""
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "exchange_type": "veridra_ai_review_result",
+        "review_id": f"review-{bundle.bundle_id}",
+        "source_bundle_id": bundle.bundle_id,
+        "source_bundle_hash_sha256": bundle.bundle_hash_sha256,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "model_provenance": None,
+        "tool_provenance": None,
+        "interpretation": "",
+        "strengths": [],
+        "weaknesses_gaps": [],
+        "opportunity_assessment": "",
+        "confidence": "unknown",
+        "uncertainty": [],
+        "recommended_next_action": "",
+        "suggested_messaging_positioning": [],
+        "evidence_refs": [],
+        "safe_actions": [],
+        "result_hash_sha256": "REPLACE_WITH_SHA256_OF_CANONICAL_RESULT_WITHOUT_THIS_FIELD",
+    }

--- a/src/veridra/ai_review_exchange.py
+++ b/src/veridra/ai_review_exchange.py
@@ -71,8 +71,14 @@ class AIReviewBundle(BaseModel):
     provenance: dict[str, Any] = Field(default_factory=dict)
     instructions: tuple[str, ...] = (
         "Treat VERIDRA evidence and deterministic scores as authoritative inputs.",
-        "Do not invent missing facts, traffic, rankings, audience data, business outcomes or outreach events.",
-        "Return a schema-valid veridra_ai_review_result bound to this exact bundle id and SHA-256 hash.",
+        (
+            "Do not invent missing facts, traffic, rankings, audience data, "
+            "business outcomes or outreach events."
+        ),
+        (
+            "Return a schema-valid veridra_ai_review_result bound to this exact "
+            "bundle id and SHA-256 hash."
+        ),
     )
 
 
@@ -178,7 +184,9 @@ def build_review_bundle(
         "context_label": context_label,
         "target": target,
         "context": context,
-        "deterministic_scores": [item.model_dump(mode="json") for item in deterministic_scores],
+        "deterministic_scores": [
+            item.model_dump(mode="json") for item in deterministic_scores
+        ],
         "evidence": [item.model_dump(mode="json") for item in evidence],
         "provenance": provenance or {},
         "instructions": list(AIReviewBundle.model_fields["instructions"].default),
@@ -186,7 +194,9 @@ def build_review_bundle(
     bundle_id = _sha256(base)[:24]
     with_id = {**base, "bundle_id": bundle_id}
     bundle_hash = _sha256(with_id)
-    return AIReviewBundle.model_validate({**with_id, "bundle_hash_sha256": bundle_hash})
+    return AIReviewBundle.model_validate(
+        {**with_id, "bundle_hash_sha256": bundle_hash}
+    )
 
 
 def bundle_integrity_hash(bundle: AIReviewBundle) -> str:
@@ -196,7 +206,11 @@ def bundle_integrity_hash(bundle: AIReviewBundle) -> str:
 
 
 def result_integrity_hash(result: AIReviewResult | dict[str, Any]) -> str:
-    payload = result.model_dump(mode="json") if isinstance(result, AIReviewResult) else dict(result)
+    payload = (
+        result.model_dump(mode="json")
+        if isinstance(result, AIReviewResult)
+        else dict(result)
+    )
     return _sha256(_canonical_result_payload(payload))
 
 
@@ -206,7 +220,9 @@ def parse_and_validate_result(
     source_bundle: AIReviewBundle,
 ) -> AIReviewResult:
     if bundle_integrity_hash(source_bundle) != source_bundle.bundle_hash_sha256:
-        raise AIReviewExchangeError("Source AI review bundle failed integrity validation.")
+        raise AIReviewExchangeError(
+            "Source AI review bundle failed integrity validation."
+        )
     try:
         payload = json.loads(raw)
     except (TypeError, ValueError) as exc:
@@ -216,13 +232,21 @@ def parse_and_validate_result(
     try:
         result = AIReviewResult.model_validate(payload)
     except ValueError as exc:
-        raise AIReviewExchangeError("Reviewed result does not match schema 1.0.") from exc
+        raise AIReviewExchangeError(
+            "Reviewed result does not match schema 1.0."
+        ) from exc
     if result.source_bundle_id != source_bundle.bundle_id:
-        raise AIReviewExchangeError("Reviewed result belongs to a different AI review bundle.")
+        raise AIReviewExchangeError(
+            "Reviewed result belongs to a different AI review bundle."
+        )
     if result.source_bundle_hash_sha256 != source_bundle.bundle_hash_sha256:
-        raise AIReviewExchangeError("Reviewed result source hash does not match the exported bundle.")
+        raise AIReviewExchangeError(
+            "Reviewed result source hash does not match the exported bundle."
+        )
     if result.generated_at.astimezone(UTC) < source_bundle.generated_at.astimezone(UTC):
-        raise AIReviewExchangeError("Reviewed result predates its source bundle and is stale.")
+        raise AIReviewExchangeError(
+            "Reviewed result predates its source bundle and is stale."
+        )
     if result_integrity_hash(result) != result.result_hash_sha256:
         raise AIReviewExchangeError("Reviewed result failed integrity validation.")
     known_refs = {item.evidence_id for item in source_bundle.evidence}
@@ -239,7 +263,7 @@ def parse_and_validate_result(
 
 
 def result_template(bundle: AIReviewBundle) -> dict[str, Any]:
-    """Return a fillable result shape; the final result hash is computed over all other fields."""
+    """Return a fillable result shape; hash covers all fields except the hash field."""
     return {
         "schema_version": RESULT_SCHEMA_VERSION,
         "exchange_type": "veridra_ai_review_result",
@@ -259,5 +283,7 @@ def result_template(bundle: AIReviewBundle) -> dict[str, Any]:
         "suggested_messaging_positioning": [],
         "evidence_refs": [],
         "safe_actions": [],
-        "result_hash_sha256": "REPLACE_WITH_SHA256_OF_CANONICAL_RESULT_WITHOUT_THIS_FIELD",
+        "result_hash_sha256": (
+            "REPLACE_WITH_SHA256_OF_CANONICAL_RESULT_WITHOUT_THIS_FIELD"
+        ),
     }

--- a/src/veridra/project_ai_review.py
+++ b/src/veridra/project_ai_review.py
@@ -14,7 +14,10 @@ from .observations import ObservedAssessment
 from .project_store import ClientProject
 
 
-def _finding_evidence(assessment_id: str, assessment: Assessment) -> tuple[EvidenceItem, ...]:
+def _finding_evidence(
+    assessment_id: str,
+    assessment: Assessment,
+) -> tuple[EvidenceItem, ...]:
     items: list[EvidenceItem] = []
     for finding in assessment.findings:
         facts: dict[str, Any] = {
@@ -74,7 +77,10 @@ def build_project_review_bundle(
         "assessment_schema_version": assessment.schema_version,
         "assessment_generated_at": assessment.generated_at.isoformat(),
         "assessment_mode": assessment.mode,
-        "source_rule": "saved VERIDRA assessment and deterministic finding summaries remain authoritative",
+        "source_rule": (
+            "saved VERIDRA assessment and deterministic finding summaries "
+            "remain authoritative"
+        ),
     }
     context: dict[str, Any] = {
         "project_name": project.name,

--- a/src/veridra/project_ai_review.py
+++ b/src/veridra/project_ai_review.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .ai_review_exchange import (
+    AIReviewBundle,
+    DeterministicScore,
+    EvidenceItem,
+    ReviewContextType,
+    build_review_bundle,
+)
+from .core import Assessment
+from .observations import ObservedAssessment
+from .project_store import ClientProject
+
+
+def _finding_evidence(assessment_id: str, assessment: Assessment) -> tuple[EvidenceItem, ...]:
+    items: list[EvidenceItem] = []
+    for finding in assessment.findings:
+        facts: dict[str, Any] = {
+            "area": finding.area,
+            "title": finding.title,
+            "status": finding.status.value,
+            "severity": finding.severity,
+            "summary": finding.summary,
+            "recommendation": finding.recommendation,
+            "evidence": finding.evidence,
+        }
+        items.append(
+            EvidenceItem(
+                evidence_id=f"finding:{finding.id}",
+                source_type="saved_finding",
+                source_ref=f"assessment:{assessment_id}:finding:{finding.id}",
+                observed_at=assessment.generated_at,
+                facts=facts,
+            )
+        )
+    return tuple(items)
+
+
+def _scores(assessment: Assessment) -> tuple[DeterministicScore, ...]:
+    values: list[DeterministicScore] = []
+    for key in ("passed", "attention", "unavailable", "total"):
+        if key in assessment.summary:
+            values.append(
+                DeterministicScore(
+                    key=f"findings.{key}",
+                    value=assessment.summary[key],
+                    basis="saved assessment summary",
+                )
+            )
+    for area, counts in sorted(assessment.area_summary.items()):
+        for key in ("passed", "attention", "unavailable", "total"):
+            if key in counts:
+                values.append(
+                    DeterministicScore(
+                        key=f"area.{area}.{key}",
+                        value=counts[key],
+                        basis="saved deterministic area summary",
+                    )
+                )
+    return tuple(values)
+
+
+def build_project_review_bundle(
+    *,
+    project_id: str,
+    project: ClientProject,
+    assessment_id: str,
+    assessment: Assessment,
+) -> AIReviewBundle:
+    provenance: dict[str, Any] = {
+        "assessment_id": assessment_id,
+        "assessment_schema_version": assessment.schema_version,
+        "assessment_generated_at": assessment.generated_at.isoformat(),
+        "assessment_mode": assessment.mode,
+        "source_rule": "saved VERIDRA assessment and deterministic finding summaries remain authoritative",
+    }
+    context: dict[str, Any] = {
+        "project_name": project.name,
+        "target_url": project.target_url,
+        "client_label": project.client_label,
+        "contact_label": project.contact_label,
+        "crawl_profile": project.crawl_profile.value,
+        "assessment_id": assessment_id,
+        "assessment_summary": assessment.summary,
+        "assessment_area_summary": assessment.area_summary,
+    }
+    if isinstance(assessment, ObservedAssessment):
+        provenance["collector_version"] = assessment.collector_version
+        provenance["crawl_profile"] = assessment.crawl_profile
+        provenance["effective_crawl_limits"] = assessment.effective_crawl_limits
+        context["observed_page_count"] = len(assessment.pages)
+        context["observation_count"] = len(assessment.observations)
+
+    return build_review_bundle(
+        context_type=ReviewContextType.project,
+        context_id=project_id,
+        context_label=project.name,
+        target=project.target_url,
+        context=context,
+        deterministic_scores=_scores(assessment),
+        evidence=_finding_evidence(assessment_id, assessment),
+        provenance=provenance,
+        generated_at=assessment.generated_at,
+    )

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -119,8 +119,6 @@ _ACCESSIBILITY_TOOL = ToolDefinition(
     ),
 )
 if _ACCESSIBILITY_TOOL.slug not in public_web._TOOL_BY_SLUG:
-    vars(app_module)["_AREAS"] = (*app_module._AREAS, "Accessibility")
-if _ACCESSIBILITY_TOOL.slug not in public_web._TOOL_BY_SLUG:
     vars(public_web)["TOOLS"] = (*public_web.TOOLS, _ACCESSIBILITY_TOOL)
     public_web._TOOL_BY_SLUG[_ACCESSIBILITY_TOOL.slug] = _ACCESSIBILITY_TOOL
 

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -6,6 +6,7 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from . import app as app_module
 from . import public_web
 from .access_logging import StructuredAccessLogMiddleware, configure_access_logger
+from .agency_ai_review_web import router as agency_ai_review_router
 from .agency_commercial_dashboard_web import router as agency_commercial_dashboard_router
 from .agency_conversion_web import router as agency_conversion_router
 from .agency_crawl_profile_web import router as agency_crawl_profile_router
@@ -118,6 +119,8 @@ _ACCESSIBILITY_TOOL = ToolDefinition(
     ),
 )
 if _ACCESSIBILITY_TOOL.slug not in public_web._TOOL_BY_SLUG:
+    vars(app_module)["_AREAS"] = (*app_module._AREAS, "Accessibility")
+if _ACCESSIBILITY_TOOL.slug not in public_web._TOOL_BY_SLUG:
     vars(public_web)["TOOLS"] = (*public_web.TOOLS, _ACCESSIBILITY_TOOL)
     public_web._TOOL_BY_SLUG[_ACCESSIBILITY_TOOL.slug] = _ACCESSIBILITY_TOOL
 
@@ -180,6 +183,7 @@ app.include_router(agency_task_router)
 app.include_router(agency_task_management_router)
 app.include_router(agency_monitoring_router)
 app.include_router(agency_progress_router)
+app.include_router(agency_ai_review_router)
 app.include_router(agency_report_profile_router)
 app.include_router(agency_report_profile_edit_router)
 app.include_router(agency_report_router)

--- a/src/veridra/tenant_ai_review_store.py
+++ b/src/veridra/tenant_ai_review_store.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from .ai_review_exchange import AIReviewBundle, AIReviewResult, ReviewContextType
+from .identity_tenancy import (
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+
+
+class TenantAIReviewStoreError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class AIReviewHistoryEntry:
+    review_id: str
+    context_type: ReviewContextType
+    context_id: str
+    generated_at: str
+    source_bundle_id: str
+    model_provenance: str | None
+
+
+def default_ai_review_directory() -> Path:
+    configured = os.environ.get("VERIDRA_DATA_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve() / "tenants"
+    return Path.home() / ".veridra" / "tenants"
+
+
+def _safe_component(value: str) -> str:
+    if not value or len(value) > 160:
+        raise TenantAIReviewStoreError("Invalid AI review storage identifier.")
+    if any(character not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_." for character in value):
+        raise TenantAIReviewStoreError("Invalid AI review storage identifier.")
+    return value
+
+
+class TenantAIReviewStore:
+    """Tenant-isolated append-only storage for exported bundles and imported reasoning."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or default_ai_review_directory()
+
+    def _context_directory(
+        self,
+        identity: RequestIdentity,
+        context_type: ReviewContextType,
+        context_id: str,
+    ) -> Path:
+        return (
+            self.root
+            / identity.tenant_id
+            / "ai-reviews"
+            / context_type.value
+            / _safe_component(context_id)
+        )
+
+    @staticmethod
+    def _write_json(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        encoded = json.dumps(
+            payload,
+            indent=2,
+            ensure_ascii=False,
+            sort_keys=True,
+        ).encode("utf-8")
+        with NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            prefix=f".{path.stem}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(encoded)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(path)
+
+    def save_bundle(self, identity: RequestIdentity, bundle: AIReviewBundle) -> Path:
+        require_tenant_capability(identity, TenantCapability.manage_reports)
+        directory = self._context_directory(
+            identity,
+            bundle.context_type,
+            bundle.context_id,
+        )
+        path = directory / "bundles" / f"{bundle.bundle_id}.json"
+        if path.exists():
+            existing = self.load_bundle(
+                identity,
+                bundle.context_type,
+                bundle.context_id,
+                bundle.bundle_id,
+            )
+            if existing != bundle:
+                raise TenantAIReviewStoreError("AI review bundle id collision detected.")
+            return path
+        self._write_json(path, bundle.model_dump(mode="json"))
+        return path
+
+    def load_bundle(
+        self,
+        identity: RequestIdentity,
+        context_type: ReviewContextType,
+        context_id: str,
+        bundle_id: str,
+    ) -> AIReviewBundle:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        path = (
+            self._context_directory(identity, context_type, context_id)
+            / "bundles"
+            / f"{_safe_component(bundle_id)}.json"
+        )
+        try:
+            return AIReviewBundle.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise TenantAIReviewStoreError("Saved AI review bundle was not found or is invalid.") from exc
+
+    def save_result(
+        self,
+        identity: RequestIdentity,
+        *,
+        bundle: AIReviewBundle,
+        result: AIReviewResult,
+    ) -> Path:
+        require_tenant_capability(identity, TenantCapability.manage_reports)
+        if result.source_bundle_id != bundle.bundle_id:
+            raise TenantAIReviewStoreError("AI review result is not bound to the supplied bundle.")
+        directory = self._context_directory(
+            identity,
+            bundle.context_type,
+            bundle.context_id,
+        )
+        path = directory / "results" / f"{_safe_component(result.review_id)}.json"
+        if path.exists():
+            existing = self.load_result(
+                identity,
+                bundle.context_type,
+                bundle.context_id,
+                result.review_id,
+            )
+            if existing != result:
+                raise TenantAIReviewStoreError("AI review id already exists with different content.")
+            return path
+        self._write_json(path, result.model_dump(mode="json"))
+        return path
+
+    def load_result(
+        self,
+        identity: RequestIdentity,
+        context_type: ReviewContextType,
+        context_id: str,
+        review_id: str,
+    ) -> AIReviewResult:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        path = (
+            self._context_directory(identity, context_type, context_id)
+            / "results"
+            / f"{_safe_component(review_id)}.json"
+        )
+        try:
+            return AIReviewResult.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise TenantAIReviewStoreError("Saved AI review result was not found or is invalid.") from exc
+
+    def list_results(
+        self,
+        identity: RequestIdentity,
+        context_type: ReviewContextType,
+        context_id: str,
+    ) -> list[AIReviewHistoryEntry]:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        directory = self._context_directory(identity, context_type, context_id) / "results"
+        if not directory.exists():
+            return []
+        entries: list[AIReviewHistoryEntry] = []
+        for path in directory.glob("*.json"):
+            try:
+                result = AIReviewResult.model_validate_json(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            entries.append(
+                AIReviewHistoryEntry(
+                    review_id=result.review_id,
+                    context_type=context_type,
+                    context_id=context_id,
+                    generated_at=result.generated_at.isoformat(),
+                    source_bundle_id=result.source_bundle_id,
+                    model_provenance=result.model_provenance,
+                )
+            )
+        return sorted(entries, key=lambda item: (item.generated_at, item.review_id), reverse=True)

--- a/src/veridra/tenant_ai_review_store.py
+++ b/src/veridra/tenant_ai_review_store.py
@@ -38,7 +38,8 @@ def default_ai_review_directory() -> Path:
 def _safe_component(value: str) -> str:
     if not value or len(value) > 160:
         raise TenantAIReviewStoreError("Invalid AI review storage identifier.")
-    if any(character not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_." for character in value):
+    allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_."
+    if any(character not in allowed for character in value):
         raise TenantAIReviewStoreError("Invalid AI review storage identifier.")
     return value
 
@@ -101,7 +102,9 @@ class TenantAIReviewStore:
                 bundle.bundle_id,
             )
             if existing != bundle:
-                raise TenantAIReviewStoreError("AI review bundle id collision detected.")
+                raise TenantAIReviewStoreError(
+                    "AI review bundle id collision detected."
+                )
             return path
         self._write_json(path, bundle.model_dump(mode="json"))
         return path
@@ -122,7 +125,9 @@ class TenantAIReviewStore:
         try:
             return AIReviewBundle.model_validate_json(path.read_text(encoding="utf-8"))
         except (OSError, ValueError) as exc:
-            raise TenantAIReviewStoreError("Saved AI review bundle was not found or is invalid.") from exc
+            raise TenantAIReviewStoreError(
+                "Saved AI review bundle was not found or is invalid."
+            ) from exc
 
     def save_result(
         self,
@@ -133,7 +138,9 @@ class TenantAIReviewStore:
     ) -> Path:
         require_tenant_capability(identity, TenantCapability.manage_reports)
         if result.source_bundle_id != bundle.bundle_id:
-            raise TenantAIReviewStoreError("AI review result is not bound to the supplied bundle.")
+            raise TenantAIReviewStoreError(
+                "AI review result is not bound to the supplied bundle."
+            )
         directory = self._context_directory(
             identity,
             bundle.context_type,
@@ -148,7 +155,9 @@ class TenantAIReviewStore:
                 result.review_id,
             )
             if existing != result:
-                raise TenantAIReviewStoreError("AI review id already exists with different content.")
+                raise TenantAIReviewStoreError(
+                    "AI review id already exists with different content."
+                )
             return path
         self._write_json(path, result.model_dump(mode="json"))
         return path
@@ -169,7 +178,9 @@ class TenantAIReviewStore:
         try:
             return AIReviewResult.model_validate_json(path.read_text(encoding="utf-8"))
         except (OSError, ValueError) as exc:
-            raise TenantAIReviewStoreError("Saved AI review result was not found or is invalid.") from exc
+            raise TenantAIReviewStoreError(
+                "Saved AI review result was not found or is invalid."
+            ) from exc
 
     def list_results(
         self,
@@ -184,7 +195,9 @@ class TenantAIReviewStore:
         entries: list[AIReviewHistoryEntry] = []
         for path in directory.glob("*.json"):
             try:
-                result = AIReviewResult.model_validate_json(path.read_text(encoding="utf-8"))
+                result = AIReviewResult.model_validate_json(
+                    path.read_text(encoding="utf-8")
+                )
             except (OSError, ValueError):
                 continue
             entries.append(
@@ -197,4 +210,8 @@ class TenantAIReviewStore:
                     model_provenance=result.model_provenance,
                 )
             )
-        return sorted(entries, key=lambda item: (item.generated_at, item.review_id), reverse=True)
+        return sorted(
+            entries,
+            key=lambda item: (item.generated_at, item.review_id),
+            reverse=True,
+        )

--- a/tests/test_agency_ai_review_web.py
+++ b/tests/test_agency_ai_review_web.py
@@ -1,0 +1,182 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+
+from veridra.agency_ai_review_web import router
+from veridra.ai_review_exchange import result_integrity_hash
+from veridra.core import Assessment, Finding, Status
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_history_store import TenantHistoryStore
+from veridra.tenant_project_store import TenantProjectStore
+
+NOW = datetime(2026, 9, 1, 12, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="ai-review-owner-session-0001",
+    authenticated_at=NOW,
+)
+OTHER = RequestIdentity(
+    user_id="2" * 24,
+    tenant_id="b" * 24,
+    membership_role=TenantRole.owner,
+    session_id="ai-review-other-session-0001",
+    authenticated_at=NOW,
+)
+
+
+def _app(root: Path) -> TestClient:
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        bind_verified_request_identity(
+            request,
+            OTHER if request.headers.get("x-test-tenant") == "other" else OWNER,
+        )
+        return await call_next(request)
+
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _project_with_assessment(tmp_path: Path) -> tuple[Path, str]:
+    root = tmp_path / "tenants"
+    project_id = TenantProjectStore(root).save(
+        OWNER,
+        ClientProject.build(name="AI Review Client", target_url="https://example.com"),
+    )
+    assessment = Assessment.build(
+        "https://example.com",
+        [
+            Finding(
+                id="privacy-link",
+                area="Trust",
+                title="Privacy link needs attention",
+                status=Status.attention,
+                severity="medium",
+                summary="The saved assessment found a trust-path issue.",
+                recommendation="Review the privacy-link destination.",
+                evidence={"path": "/privacy"},
+            )
+        ],
+        generated_at=NOW,
+    )
+    TenantHistoryStore(root).save(OWNER, project_id, assessment)
+    return root, project_id
+
+
+def _review_result(bundle: dict[str, object]) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "1.0",
+        "exchange_type": "veridra_ai_review_result",
+        "review_id": "review-browser-fixture-001",
+        "source_bundle_id": bundle["bundle_id"],
+        "source_bundle_hash_sha256": bundle["bundle_hash_sha256"],
+        "generated_at": (NOW + timedelta(minutes=10)).isoformat(),
+        "model_provenance": "GPT fixture",
+        "tool_provenance": "structured JSON acceptance",
+        "interpretation": "The evidence supports a bounded trust-path improvement.",
+        "strengths": ["The issue is directly traceable to saved evidence."],
+        "weaknesses_gaps": ["The trust path needs operator review."],
+        "opportunity_assessment": "A small evidence-backed remediation opportunity exists.",
+        "confidence": "high",
+        "uncertainty": ["No conversion impact is known."],
+        "recommended_next_action": "Review the privacy destination before deciding remediation.",
+        "suggested_messaging_positioning": ["Describe the observed trust-path issue without estimating lost business."],
+        "evidence_refs": ["finding:privacy-link"],
+        "safe_actions": [
+            {
+                "action": "request_human_review",
+                "reason": "Human verification is appropriate before any workflow action.",
+                "evidence_refs": ["finding:privacy-link"],
+            }
+        ],
+    }
+    payload["result_hash_sha256"] = result_integrity_hash(payload)
+    return payload
+
+
+def test_project_ai_review_export_import_view_round_trip(tmp_path: Path) -> None:
+    root, project_id = _project_with_assessment(tmp_path)
+    client = _app(root)
+
+    landing = client.get(f"/agency/projects/{project_id}/ai-review")
+    assert landing.status_code == 200
+    assert "Export AI review JSON" in landing.text
+    assert "Import reviewed result" in landing.text
+
+    exported = client.get(f"/agency/projects/{project_id}/ai-review/export")
+    assert exported.status_code == 200
+    assert exported.headers["content-type"].startswith("application/json")
+    assert "attachment" in exported.headers["content-disposition"]
+    bundle = exported.json()
+    assert bundle["exchange_type"] == "veridra_ai_review_bundle"
+    assert bundle["context"]["assessment_id"]
+    assert bundle["evidence"][0]["evidence_id"] == "finding:privacy-link"
+
+    result = _review_result(bundle)
+    imported = client.post(
+        f"/agency/projects/{project_id}/ai-review/import",
+        data={"result_json": json.dumps(result)},
+        follow_redirects=False,
+    )
+    assert imported.status_code == 303
+    assert imported.headers["location"].endswith("?imported=true")
+
+    history = client.get(f"/agency/projects/{project_id}/ai-review")
+    assert "review-browser-fixture-001" in history.text
+    assert "GPT fixture" in history.text
+
+    viewed = client.get(
+        f"/agency/projects/{project_id}/ai-review/results/review-browser-fixture-001"
+    )
+    assert viewed.status_code == 200
+    assert "AI interpretation — imported reasoning, not VERIDRA observation" in viewed.text
+    assert "No conversion impact is known" in viewed.text
+    assert "request_human_review" in viewed.text
+    assert "No outreach has been sent" in viewed.text
+
+
+def test_project_ai_review_rejects_tampered_result(tmp_path: Path) -> None:
+    root, project_id = _project_with_assessment(tmp_path)
+    client = _app(root)
+    bundle = client.get(f"/agency/projects/{project_id}/ai-review/export").json()
+    result = _review_result(bundle)
+    result["interpretation"] = "Tampered content."
+
+    response = client.post(
+        f"/agency/projects/{project_id}/ai-review/import",
+        data={"result_json": json.dumps(result)},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert "/ai-review/import?error=" in response.headers["location"]
+    assert "integrity" in response.headers["location"].lower()
+
+
+def test_project_ai_review_conceals_cross_tenant_context(tmp_path: Path) -> None:
+    root, project_id = _project_with_assessment(tmp_path)
+
+    response = _app(root).get(
+        f"/agency/projects/{project_id}/ai-review",
+        headers={"x-test-tenant": "other"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Project not found."}

--- a/tests/test_ai_review_exchange.py
+++ b/tests/test_ai_review_exchange.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from veridra.ai_review_exchange import (
+    AIReviewExchangeError,
+    DeterministicScore,
+    EvidenceItem,
+    ReviewContextType,
+    build_review_bundle,
+    parse_and_validate_result,
+    result_integrity_hash,
+)
+
+BASE = datetime(2026, 9, 1, 12, 0, tzinfo=UTC)
+
+
+def _bundle():
+    return build_review_bundle(
+        context_type=ReviewContextType.project,
+        context_id="abc123",
+        context_label="Example delivery",
+        target="https://example.com/",
+        context={"client": "Example", "assessment_id": "assessment-1"},
+        deterministic_scores=(
+            DeterministicScore(key="finding_count", value=2, basis="saved assessment findings"),
+        ),
+        evidence=(
+            EvidenceItem(
+                evidence_id="finding:one",
+                source_type="finding",
+                source_ref="assessment:assessment-1:finding:one",
+                observed_at=BASE,
+                facts={"status": "attention", "severity": "medium"},
+            ),
+        ),
+        provenance={"assessment_id": "assessment-1"},
+        generated_at=BASE,
+    )
+
+
+def _result_payload(bundle) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "1.0",
+        "exchange_type": "veridra_ai_review_result",
+        "review_id": "review-example-001",
+        "source_bundle_id": bundle.bundle_id,
+        "source_bundle_hash_sha256": bundle.bundle_hash_sha256,
+        "generated_at": (BASE + timedelta(minutes=5)).isoformat(),
+        "model_provenance": "GPT test fixture",
+        "tool_provenance": "manual structured-file exchange",
+        "interpretation": "The saved evidence supports a bounded improvement opportunity.",
+        "strengths": ["Evidence is directly traceable."],
+        "weaknesses_gaps": ["One medium-severity finding needs review."],
+        "opportunity_assessment": "Prioritise the observed issue without inventing business impact.",
+        "confidence": "high",
+        "uncertainty": ["No traffic or conversion evidence is available."],
+        "recommended_next_action": "Review the finding with a human operator.",
+        "suggested_messaging_positioning": ["Lead with the observed issue, not estimated impact."],
+        "evidence_refs": ["finding:one"],
+        "safe_actions": [
+            {
+                "action": "request_human_review",
+                "reason": "A human should decide whether remediation is commercially relevant.",
+                "evidence_refs": ["finding:one"],
+            }
+        ],
+    }
+    payload["result_hash_sha256"] = result_integrity_hash(payload)
+    return payload
+
+
+def test_bundle_is_single_self_contained_hash_bound_contract() -> None:
+    bundle = _bundle()
+
+    assert bundle.schema_version == "1.0"
+    assert bundle.exchange_type == "veridra_ai_review_bundle"
+    assert len(bundle.bundle_id) == 24
+    assert len(bundle.bundle_hash_sha256) == 64
+    assert bundle.evidence[0].evidence_id == "finding:one"
+    assert bundle.deterministic_scores[0].basis == "saved assessment findings"
+
+
+def test_result_accepts_exact_bundle_and_known_evidence() -> None:
+    bundle = _bundle()
+    payload = _result_payload(bundle)
+
+    result = parse_and_validate_result(json.dumps(payload), source_bundle=bundle)
+
+    assert result.review_id == "review-example-001"
+    assert result.source_bundle_id == bundle.bundle_id
+    assert result.safe_actions[0].action.value == "request_human_review"
+
+
+def test_result_rejects_tampered_content() -> None:
+    bundle = _bundle()
+    payload = _result_payload(bundle)
+    payload["interpretation"] = "Tampered after the integrity digest was produced."
+
+    with pytest.raises(AIReviewExchangeError, match="integrity"):
+        parse_and_validate_result(json.dumps(payload), source_bundle=bundle)
+
+
+def test_result_rejects_wrong_or_stale_bundle_binding() -> None:
+    bundle = _bundle()
+    payload = _result_payload(bundle)
+    payload["source_bundle_id"] = "0" * 24
+    payload["result_hash_sha256"] = result_integrity_hash(payload)
+
+    with pytest.raises(AIReviewExchangeError, match="different"):
+        parse_and_validate_result(json.dumps(payload), source_bundle=bundle)
+
+    payload = _result_payload(bundle)
+    payload["generated_at"] = (BASE - timedelta(minutes=1)).isoformat()
+    payload["result_hash_sha256"] = result_integrity_hash(payload)
+    with pytest.raises(AIReviewExchangeError, match="stale"):
+        parse_and_validate_result(json.dumps(payload), source_bundle=bundle)
+
+
+def test_result_rejects_unknown_evidence_reference() -> None:
+    bundle = _bundle()
+    payload = _result_payload(bundle)
+    payload["evidence_refs"] = ["finding:missing"]
+    payload["result_hash_sha256"] = result_integrity_hash(payload)
+
+    with pytest.raises(AIReviewExchangeError, match="not present"):
+        parse_and_validate_result(json.dumps(payload), source_bundle=bundle)

--- a/tests/test_ai_review_exchange.py
+++ b/tests/test_ai_review_exchange.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from veridra.ai_review_exchange import (
+    AIReviewBundle,
     AIReviewExchangeError,
     DeterministicScore,
     EvidenceItem,
@@ -18,7 +19,7 @@ from veridra.ai_review_exchange import (
 BASE = datetime(2026, 9, 1, 12, 0, tzinfo=UTC)
 
 
-def _bundle():
+def _bundle() -> AIReviewBundle:
     return build_review_bundle(
         context_type=ReviewContextType.project,
         context_id="abc123",
@@ -26,7 +27,11 @@ def _bundle():
         target="https://example.com/",
         context={"client": "Example", "assessment_id": "assessment-1"},
         deterministic_scores=(
-            DeterministicScore(key="finding_count", value=2, basis="saved assessment findings"),
+            DeterministicScore(
+                key="finding_count",
+                value=2,
+                basis="saved assessment findings",
+            ),
         ),
         evidence=(
             EvidenceItem(
@@ -42,7 +47,7 @@ def _bundle():
     )
 
 
-def _result_payload(bundle) -> dict[str, object]:
+def _result_payload(bundle: AIReviewBundle) -> dict[str, object]:
     payload: dict[str, object] = {
         "schema_version": "1.0",
         "exchange_type": "veridra_ai_review_result",
@@ -52,19 +57,27 @@ def _result_payload(bundle) -> dict[str, object]:
         "generated_at": (BASE + timedelta(minutes=5)).isoformat(),
         "model_provenance": "GPT test fixture",
         "tool_provenance": "manual structured-file exchange",
-        "interpretation": "The saved evidence supports a bounded improvement opportunity.",
+        "interpretation": (
+            "The saved evidence supports a bounded improvement opportunity."
+        ),
         "strengths": ["Evidence is directly traceable."],
         "weaknesses_gaps": ["One medium-severity finding needs review."],
-        "opportunity_assessment": "Prioritise the observed issue without inventing business impact.",
+        "opportunity_assessment": (
+            "Prioritise the observed issue without inventing business impact."
+        ),
         "confidence": "high",
         "uncertainty": ["No traffic or conversion evidence is available."],
         "recommended_next_action": "Review the finding with a human operator.",
-        "suggested_messaging_positioning": ["Lead with the observed issue, not estimated impact."],
+        "suggested_messaging_positioning": [
+            "Lead with the observed issue, not estimated impact."
+        ],
         "evidence_refs": ["finding:one"],
         "safe_actions": [
             {
                 "action": "request_human_review",
-                "reason": "A human should decide whether remediation is commercially relevant.",
+                "reason": (
+                    "A human should decide whether remediation is commercially relevant."
+                ),
                 "evidence_refs": ["finding:one"],
             }
         ],

--- a/tests/test_tenant_ai_review_store.py
+++ b/tests/test_tenant_ai_review_store.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from veridra.ai_review_exchange import (
+    AIReviewResult,
+    EvidenceItem,
+    ReviewContextType,
+    build_review_bundle,
+    result_integrity_hash,
+)
+from veridra.identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantRole,
+)
+from veridra.tenant_ai_review_store import TenantAIReviewStore, TenantAIReviewStoreError
+
+BASE = datetime(2026, 9, 1, 12, 0, tzinfo=UTC)
+
+
+def _identity(tenant: str) -> RequestIdentity:
+    return RequestIdentity(
+        user_id="1" * 24,
+        tenant_id=tenant,
+        membership_role=TenantRole.owner,
+        session_id="s" * 24,
+        authenticated_at=BASE,
+    )
+
+
+def _bundle():
+    return build_review_bundle(
+        context_type=ReviewContextType.project,
+        context_id="project-1",
+        context_label="Project One",
+        target="https://example.com/",
+        context={"name": "Project One"},
+        evidence=(
+            EvidenceItem(
+                evidence_id="finding:one",
+                source_type="finding",
+                source_ref="assessment:a:finding:one",
+                facts={"severity": "medium"},
+            ),
+        ),
+        generated_at=BASE,
+    )
+
+
+def _result(bundle) -> AIReviewResult:
+    payload = {
+        "schema_version": "1.0",
+        "exchange_type": "veridra_ai_review_result",
+        "review_id": "review-project-1",
+        "source_bundle_id": bundle.bundle_id,
+        "source_bundle_hash_sha256": bundle.bundle_hash_sha256,
+        "generated_at": (BASE + timedelta(minutes=1)).isoformat(),
+        "model_provenance": "test-model",
+        "tool_provenance": "test",
+        "interpretation": "Bounded interpretation.",
+        "strengths": [],
+        "weaknesses_gaps": [],
+        "opportunity_assessment": "Human review opportunity.",
+        "confidence": "medium",
+        "uncertainty": [],
+        "recommended_next_action": "Review manually.",
+        "suggested_messaging_positioning": [],
+        "evidence_refs": ["finding:one"],
+        "safe_actions": [],
+    }
+    payload["result_hash_sha256"] = result_integrity_hash(payload)
+    return AIReviewResult.model_validate(payload)
+
+
+def test_store_preserves_bundle_and_append_only_review_history(tmp_path: Path) -> None:
+    store = TenantAIReviewStore(tmp_path)
+    identity = _identity("a" * 24)
+    bundle = _bundle()
+    result = _result(bundle)
+
+    store.save_bundle(identity, bundle)
+    store.save_result(identity, bundle=bundle, result=result)
+
+    assert store.load_bundle(
+        identity,
+        ReviewContextType.project,
+        "project-1",
+        bundle.bundle_id,
+    ) == bundle
+    assert store.load_result(
+        identity,
+        ReviewContextType.project,
+        "project-1",
+        result.review_id,
+    ) == result
+    history = store.list_results(identity, ReviewContextType.project, "project-1")
+    assert [item.review_id for item in history] == ["review-project-1"]
+    assert history[0].source_bundle_id == bundle.bundle_id
+    assert history[0].model_provenance == "test-model"
+
+
+def test_store_never_allows_same_review_id_to_change_content(tmp_path: Path) -> None:
+    store = TenantAIReviewStore(tmp_path)
+    identity = _identity("a" * 24)
+    bundle = _bundle()
+    result = _result(bundle)
+    store.save_bundle(identity, bundle)
+    store.save_result(identity, bundle=bundle, result=result)
+
+    changed = result.model_copy(update={"interpretation": "Changed reasoning."})
+    with pytest.raises(TenantAIReviewStoreError, match="already exists"):
+        store.save_result(identity, bundle=bundle, result=changed)
+
+
+def test_tenant_storage_isolated_by_identity(tmp_path: Path) -> None:
+    store = TenantAIReviewStore(tmp_path)
+    first = _identity("a" * 24)
+    second = _identity("b" * 24)
+    bundle = _bundle()
+    store.save_bundle(first, bundle)
+
+    with pytest.raises(TenantAIReviewStoreError, match="not found"):
+        store.load_bundle(
+            second,
+            ReviewContextType.project,
+            "project-1",
+            bundle.bundle_id,
+        )
+
+    assert store.list_results(second, ReviewContextType.project, "project-1") == []

--- a/tests/test_tenant_ai_review_store.py
+++ b/tests/test_tenant_ai_review_store.py
@@ -12,11 +12,7 @@ from veridra.ai_review_exchange import (
     build_review_bundle,
     result_integrity_hash,
 )
-from veridra.identity_tenancy import (
-    IdentityBoundaryError,
-    RequestIdentity,
-    TenantRole,
-)
+from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.tenant_ai_review_store import TenantAIReviewStore, TenantAIReviewStoreError
 
 BASE = datetime(2026, 9, 1, 12, 0, tzinfo=UTC)

--- a/tests/test_tenant_ai_review_store.py
+++ b/tests/test_tenant_ai_review_store.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from veridra.ai_review_exchange import (
+    AIReviewBundle,
     AIReviewResult,
     EvidenceItem,
     ReviewContextType,
@@ -28,7 +29,7 @@ def _identity(tenant: str) -> RequestIdentity:
     )
 
 
-def _bundle():
+def _bundle() -> AIReviewBundle:
     return build_review_bundle(
         context_type=ReviewContextType.project,
         context_id="project-1",
@@ -47,8 +48,8 @@ def _bundle():
     )
 
 
-def _result(bundle) -> AIReviewResult:
-    payload = {
+def _result(bundle: AIReviewBundle) -> AIReviewResult:
+    payload: dict[str, object] = {
         "schema_version": "1.0",
         "exchange_type": "veridra_ai_review_result",
         "review_id": "review-project-1",

--- a/tools/operator_e2e_acceptance_entry.py
+++ b/tools/operator_e2e_acceptance_entry.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import operator_e2e_acceptance as acceptance
 from playwright.sync_api import Page
+
 from veridra.ai_review_exchange import result_integrity_hash
 
 
@@ -110,16 +111,24 @@ def _manual_assessment(page: Page, project_url: str) -> str:
         page.get_by_role("link", name="Export AI review JSON").click()
     download_path = download_info.value.path()
     if download_path is None:
-        raise AssertionError("AI review export did not produce a downloadable JSON artifact.")
+        raise AssertionError(
+            "AI review export did not produce a downloadable JSON artifact."
+        )
     bundle = json.loads(Path(download_path).read_text(encoding="utf-8"))
     if bundle.get("exchange_type") != "veridra_ai_review_bundle":
-        raise AssertionError("AI review export did not contain the standard bundle contract.")
+        raise AssertionError(
+            "AI review export did not contain the standard bundle contract."
+        )
     evidence = bundle.get("evidence")
-    refs = [
-        item.get("evidence_id")
-        for item in evidence
-        if isinstance(item, dict) and isinstance(item.get("evidence_id"), str)
-    ] if isinstance(evidence, list) else []
+    refs = (
+        [
+            item.get("evidence_id")
+            for item in evidence
+            if isinstance(item, dict) and isinstance(item.get("evidence_id"), str)
+        ]
+        if isinstance(evidence, list)
+        else []
+    )
     if not refs:
         raise AssertionError("AI review export contained no traceable finding evidence.")
 
@@ -132,19 +141,27 @@ def _manual_assessment(page: Page, project_url: str) -> str:
         "generated_at": datetime.now(UTC).isoformat(),
         "model_provenance": "synthetic-playwright-fixture",
         "tool_provenance": "VERIDRA operator E2E",
-        "interpretation": "Synthetic evidence-bound interpretation for operator acceptance only.",
+        "interpretation": (
+            "Synthetic evidence-bound interpretation for operator acceptance only."
+        ),
         "strengths": ["The exported evidence is traceable by stable evidence id."],
         "weaknesses_gaps": ["A human operator must decide commercial relevance."],
-        "opportunity_assessment": "Synthetic acceptance opportunity; no real business claim is made.",
+        "opportunity_assessment": (
+            "Synthetic acceptance opportunity; no real business claim is made."
+        ),
         "confidence": "high",
         "uncertainty": ["No traffic, conversion or revenue impact is inferred."],
         "recommended_next_action": "Request human review of the cited finding.",
-        "suggested_messaging_positioning": ["Use only the directly observed issue if messaging is later approved."],
+        "suggested_messaging_positioning": [
+            "Use only the directly observed issue if messaging is later approved."
+        ],
         "evidence_refs": [refs[0]],
         "safe_actions": [
             {
                 "action": "request_human_review",
-                "reason": "Operator acceptance keeps execution explicitly human-controlled.",
+                "reason": (
+                    "Operator acceptance keeps execution explicitly human-controlled."
+                ),
                 "evidence_refs": [refs[0]],
             }
         ],
@@ -159,7 +176,10 @@ def _manual_assessment(page: Page, project_url: str) -> str:
     acceptance._assert_text(page, "Reviewed result imported")
     page.get_by_role("link", name="review-e2e-standard-exchange").click()
     page.wait_for_url("**/ai-review/results/review-e2e-standard-exchange")
-    acceptance._assert_text(page, "AI interpretation — imported reasoning, not VERIDRA observation")
+    acceptance._assert_text(
+        page,
+        "AI interpretation — imported reasoning, not VERIDRA observation",
+    )
     acceptance._assert_text(page, "request_human_review")
 
     page.goto(monitoring_url, wait_until="networkidle")

--- a/tools/operator_e2e_acceptance_entry.py
+++ b/tools/operator_e2e_acceptance_entry.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import tempfile
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 import operator_e2e_acceptance as acceptance
 from playwright.sync_api import Page
+from veridra.ai_review_exchange import result_integrity_hash
 
 
 def _run_launcher(repo: Path, env: dict[str, str], command: str, *args: str) -> str:
@@ -15,9 +18,6 @@ def _run_launcher(repo: Path, env: dict[str, str], command: str, *args: str) -> 
     script = repo / "scripts" / "windows" / "veridra-local.ps1"
     print(f"[E2E] launcher {command}: start", flush=True)
 
-    # Long-lived VERIDRA child processes can briefly retain inherited Windows file
-    # handles after PowerShell exits. Keep launcher logs in the system temp directory
-    # instead of synchronously deleting a TemporaryDirectory and racing those handles.
     output_path = (
         Path(tempfile.gettempdir())
         / f"veridra-launcher-{uuid.uuid4().hex}-{command}.log"
@@ -96,6 +96,74 @@ def _create_and_qualify_prospect(page: Page, base_url: str) -> str:
     page.wait_for_load_state("networkidle")
     acceptance._assert_text(page, "14/14")
     return prospect_url
+
+
+def _manual_assessment(page: Page, project_url: str) -> str:
+    """Run the established assessment, then prove the JSON AI exchange through the browser."""
+    monitoring_url = _ORIGINAL_MANUAL_ASSESSMENT(page, project_url)
+    page.goto(project_url, wait_until="networkidle")
+    page.get_by_role("link", name="AI review exchange").click()
+    page.wait_for_url("**/ai-review")
+    acceptance._assert_text(page, "AI review exchange")
+
+    with page.expect_download(timeout=30_000) as download_info:
+        page.get_by_role("link", name="Export AI review JSON").click()
+    download_path = download_info.value.path()
+    if download_path is None:
+        raise AssertionError("AI review export did not produce a downloadable JSON artifact.")
+    bundle = json.loads(Path(download_path).read_text(encoding="utf-8"))
+    if bundle.get("exchange_type") != "veridra_ai_review_bundle":
+        raise AssertionError("AI review export did not contain the standard bundle contract.")
+    evidence = bundle.get("evidence")
+    refs = [
+        item.get("evidence_id")
+        for item in evidence
+        if isinstance(item, dict) and isinstance(item.get("evidence_id"), str)
+    ] if isinstance(evidence, list) else []
+    if not refs:
+        raise AssertionError("AI review export contained no traceable finding evidence.")
+
+    result: dict[str, object] = {
+        "schema_version": "1.0",
+        "exchange_type": "veridra_ai_review_result",
+        "review_id": "review-e2e-standard-exchange",
+        "source_bundle_id": bundle["bundle_id"],
+        "source_bundle_hash_sha256": bundle["bundle_hash_sha256"],
+        "generated_at": datetime.now(UTC).isoformat(),
+        "model_provenance": "synthetic-playwright-fixture",
+        "tool_provenance": "VERIDRA operator E2E",
+        "interpretation": "Synthetic evidence-bound interpretation for operator acceptance only.",
+        "strengths": ["The exported evidence is traceable by stable evidence id."],
+        "weaknesses_gaps": ["A human operator must decide commercial relevance."],
+        "opportunity_assessment": "Synthetic acceptance opportunity; no real business claim is made.",
+        "confidence": "high",
+        "uncertainty": ["No traffic, conversion or revenue impact is inferred."],
+        "recommended_next_action": "Request human review of the cited finding.",
+        "suggested_messaging_positioning": ["Use only the directly observed issue if messaging is later approved."],
+        "evidence_refs": [refs[0]],
+        "safe_actions": [
+            {
+                "action": "request_human_review",
+                "reason": "Operator acceptance keeps execution explicitly human-controlled.",
+                "evidence_refs": [refs[0]],
+            }
+        ],
+    }
+    result["result_hash_sha256"] = result_integrity_hash(result)
+
+    page.get_by_role("link", name="Import reviewed result").click()
+    page.wait_for_url("**/ai-review/import")
+    page.get_by_label("Reviewed result JSON").fill(json.dumps(result))
+    page.get_by_role("button", name="Validate and import").click()
+    page.wait_for_url("**/ai-review?imported=true")
+    acceptance._assert_text(page, "Reviewed result imported")
+    page.get_by_role("link", name="review-e2e-standard-exchange").click()
+    page.wait_for_url("**/ai-review/results/review-e2e-standard-exchange")
+    acceptance._assert_text(page, "AI interpretation — imported reasoning, not VERIDRA observation")
+    acceptance._assert_text(page, "request_human_review")
+
+    page.goto(monitoring_url, wait_until="networkidle")
+    return monitoring_url
 
 
 def _report(page: Page, project_url: str, evidence: Path) -> None:
@@ -179,9 +247,11 @@ def _preserve_playwright_browser_cache() -> None:
         print(f"[E2E] Reusing Playwright browser cache: {browser_cache}", flush=True)
 
 
+_ORIGINAL_MANUAL_ASSESSMENT = acceptance._manual_assessment
 _ORIGINAL_WAIT_AUTONOMOUS_MONITORING = acceptance._wait_autonomous_monitoring
 acceptance._run_launcher = _run_launcher
 acceptance._create_and_qualify_prospect = _create_and_qualify_prospect
+acceptance._manual_assessment = _manual_assessment
 acceptance._report = _report
 acceptance._wait_autonomous_monitoring = _wait_autonomous_monitoring
 


### PR DESCRIPTION
## Scope
Implements the reusable VERIDRA ↔ ChatGPT review contract from #273.

- adds a versioned single-JSON `veridra_ai_review_bundle` contract for one project context;
- exports latest saved project assessment evidence, deterministic summaries, provenance and stable evidence references without hidden side state;
- adds a versioned `veridra_ai_review_result` contract covering interpretation, strengths, gaps, opportunity, confidence/uncertainty, next action, messaging and whitelisted safe actions;
- cryptographically binds reviewed results to the exact source bundle and validates result integrity, chronology and evidence references;
- rejects malformed, mismatched, stale and tampered results;
- persists exported bundles and reviewed results in tenant-isolated append-only storage without mutating source evidence or deterministic state;
- adds Project → AI review exchange with compact Export JSON → Import reviewed result → View reviewed result flow and inspectable history/provenance;
- visibly labels imported AI reasoning as advisory and separate from VERIDRA observation;
- adds reusable ChatGPT prompt/template under `docs/ai-review-chatgpt-prompt.md`;
- extends the real Windows Playwright first-customer acceptance to download the actual JSON bundle, import a hash-bound synthetic reviewed result through the browser, and inspect the stored result.

## Compatibility / safety
- existing legacy ZIP AI evidence exchange remains intact;
- no model/API integration is introduced;
- no real outreach is sent or authorized;
- safe actions are imported as review metadata only and never auto-executed;
- no assessments, findings, deterministic scores, prospects, customers or outreach state are overwritten.

## Validation gate
Do not merge until Ruff, strict mypy, full pytest, deterministic audit, Chromium/browser acceptance, commercial acceptance, Windows portability and the true Playwright operator E2E are green.

Closes #273 when the complete validation gate passes.