### PR TITLE
#229: harden review intelligence provenance and retries

### DIFF
--- a/VERIDRA_REVIEW_ACCEPTANCE.bat
+++ b/VERIDRA_REVIEW_ACCEPTANCE.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+set "ROOT=%~dp0"
+set "PYTHON=%ROOT%.venv\Scripts\python.exe"
+if not exist "%PYTHON%" (
+  echo [Veridra] Local environment is missing or outdated. Running setup...
+  call "%ROOT%VERIDRA_SETUP.bat"
+  if errorlevel 1 exit /b %ERRORLEVEL%
+)
+
+echo [Veridra] Validating latest Review Intelligence artifact...
+"%PYTHON%" -m veridra.review_intelligence_acceptance_cli --downloads "%USERPROFILE%\Downloads" %*
+exit /b %ERRORLEVEL%

--- a/docs/REVIEW_INTELLIGENCE_ACCEPTANCE.md
+++ b/docs/REVIEW_INTELLIGENCE_ACCEPTANCE.md
@@ -1,0 +1,63 @@
+# Review Intelligence acceptance
+
+This is the compact operator gate for issue #229.
+
+## 1. Collect bounded review evidence
+
+From the VERIDRA repository root on Windows:
+
+```bat
+VERIDRA_REVIEW_INTELLIGENCE.bat
+```
+
+The collector is read-only and bounded. It attempts the `newest`, `lowest`, and `highest` Google Maps review strategies. Transient review-tab and sort failures are retried automatically. Consent, sign-in, and CAPTCHA surfaces are treated as explicit manual interruptions and are not bypassed.
+
+Success requires at least one actual review evidence row. Opening a review UI but collecting zero rows is a failure.
+
+## 2. Validate the review artifact
+
+```bat
+VERIDRA_REVIEW_ACCEPTANCE.bat
+```
+
+The validator automatically selects the newest `VERIDRA_REVIEW_INTELLIGENCE_*.zip` in Downloads and checks:
+
+- non-zero review evidence;
+- at least one business with a non-empty sample;
+- manifest/index consistency;
+- plausible integer ratings from 1 through 5 when present;
+- parseable approximate review/owner-response dates when present;
+- stable, unique, indexed evidence IDs;
+- bounded newest/lowest/highest sampling;
+- absence of deterministic sentiment/theme/fake-review inference.
+
+Exit code `0` means PASS. Exit code `2` means the artifact did not satisfy the deterministic gate.
+
+## 3. Build the AI evidence export
+
+```bat
+VERIDRA_AI_EXPORT.bat
+```
+
+The review-aware AI exporter recomputes sampling-safe statistics from raw review rows and adds traceable `google_review` entries to its `evidence_index.json`. VERIDRA does not infer review themes; external AI may interpret them only by citing evidence IDs.
+
+## 4. Verify review evidence reached the AI export
+
+Pass the current AI export explicitly to the acceptance checker:
+
+```bat
+VERIDRA_REVIEW_ACCEPTANCE.bat --ai-export "%USERPROFILE%\Downloads\VERIDRA_AI_EXPORT_YYYYMMDD_HHMMSS.zip"
+```
+
+The report must show:
+
+```text
+"passed": true
+"ai_export_contains_traceable_review_evidence": true
+```
+
+## Final #229 boundary
+
+The deterministic repository work is not, by itself, the final live acceptance. Issue #229 is complete only when a real Dublin dental Google Maps run produces non-zero bounded review evidence and the acceptance checker passes that artifact (plus the review-aware AI export when supplied).
+
+No real prospect outreach is part of this gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ veridra-dublin-visual-reprocess = "veridra.dublin_visual_reprocess_cli:main"
 veridra-local-competitive-context = "veridra.local_competitive_context_cli:main"
 veridra-ai-evidence-exchange = "veridra.ai_evidence_exchange_review_cli:main"
 veridra-review-intelligence = "veridra.review_intelligence_sampling_safe_cli:main"
+veridra-review-intelligence-acceptance = "veridra.review_intelligence_acceptance_cli:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "veridra.version.__version__"}

--- a/src/veridra/review_intelligence_acceptance_cli.py
+++ b/src/veridra/review_intelligence_acceptance_cli.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import argparse
+import json
+import zipfile
+from collections.abc import Sequence
+from datetime import date
+from pathlib import Path
+
+from .review_intelligence_cli import _latest, _text
+
+_PROHIBITED_INTERPRETATION_KEYS = {
+    "sentiment",
+    "sentiment_score",
+    "themes",
+    "review_themes",
+    "fake_review",
+    "fake_review_score",
+    "authenticity_score",
+}
+
+
+def _read_json(archive: zipfile.ZipFile, name: str) -> object:
+    try:
+        return json.loads(archive.read(name))
+    except KeyError as exc:
+        raise ValueError(f"Required file is missing from ZIP: {name}") from exc
+
+
+def _load_review_pack(
+    path: Path,
+) -> tuple[dict[str, object], list[dict[str, object]], dict[str, object]]:
+    with zipfile.ZipFile(path) as archive:
+        manifest = _read_json(archive, "manifest.json")
+        evidence = _read_json(archive, "review_evidence.json")
+        evidence_index = _read_json(archive, "evidence_index.json")
+    if not isinstance(manifest, dict):
+        raise ValueError("Review Intelligence manifest is invalid.")
+    if not isinstance(evidence, list):
+        raise ValueError("Review Intelligence evidence is invalid.")
+    if not isinstance(evidence_index, dict):
+        raise ValueError("Review Intelligence evidence index is invalid.")
+    rows = [item for item in evidence if isinstance(item, dict)]
+    return manifest, rows, evidence_index
+
+
+def _load_ai_index(path: Path | None) -> dict[str, object] | None:
+    if path is None:
+        return None
+    with zipfile.ZipFile(path) as archive:
+        index = _read_json(archive, "evidence_index.json")
+    if not isinstance(index, dict):
+        raise ValueError("AI export evidence index is invalid.")
+    return index
+
+
+def _iso_date_or_none(value: object) -> bool:
+    raw = _text(value)
+    if not raw:
+        return True
+    try:
+        date.fromisoformat(raw)
+    except ValueError:
+        return False
+    return True
+
+
+def _strategy_set(review: dict[str, object]) -> set[str]:
+    strategies = review.get("sample_strategies")
+    output = {
+        _text(item)
+        for item in strategies
+        if isinstance(item, str) and _text(item)
+    } if isinstance(strategies, list) else set()
+    strategy = _text(review.get("sample_strategy"))
+    if strategy:
+        output.add(strategy)
+    return output
+
+
+def _all_reviews(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    reviews: list[dict[str, object]] = []
+    for business in rows:
+        raw = business.get("reviews")
+        if isinstance(raw, list):
+            reviews.extend(item for item in raw if isinstance(item, dict))
+    return reviews
+
+
+def _contains_prohibited_interpretation(value: object) -> bool:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key.casefold() in _PROHIBITED_INTERPRETATION_KEYS:
+                return True
+            if _contains_prohibited_interpretation(child):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_prohibited_interpretation(item) for item in value)
+    return False
+
+
+def validate_review_intelligence(
+    review_pack: Path,
+    *,
+    ai_export: Path | None = None,
+) -> dict[str, object]:
+    manifest, businesses, evidence_index = _load_review_pack(review_pack)
+    reviews = _all_reviews(businesses)
+    ai_index = _load_ai_index(ai_export)
+
+    ids = [_text(item.get("evidence_id")) for item in reviews]
+    nonempty_ids = [item for item in ids if item]
+    unique_ids = set(nonempty_ids)
+    ratings_ok = all(
+        rating is None or (isinstance(rating, int) and not isinstance(rating, bool) and 1 <= rating <= 5)
+        for rating in (item.get("rating") for item in reviews)
+    )
+    dates_ok = all(
+        _iso_date_or_none(item.get("approximate_review_date"))
+        and _iso_date_or_none(item.get("approximate_owner_response_date"))
+        for item in reviews
+    )
+    indexed_ok = bool(nonempty_ids) and all(item in evidence_index for item in nonempty_ids)
+    unique_ok = len(nonempty_ids) == len(unique_ids)
+
+    sampling = manifest.get("sampling")
+    sampling_dict = sampling if isinstance(sampling, dict) else {}
+    per_strategy = sampling_dict.get("per_strategy_limit")
+    per_strategy_limit = per_strategy if isinstance(per_strategy, int) else None
+    strategy_counts: dict[str, int] = {"newest": 0, "lowest": 0, "highest": 0}
+    for review in reviews:
+        for strategy in _strategy_set(review):
+            if strategy in strategy_counts:
+                strategy_counts[strategy] += 1
+    bounded_ok = per_strategy_limit is not None and all(
+        value <= per_strategy_limit * max(1, len(businesses))
+        for value in strategy_counts.values()
+    )
+
+    nonempty_businesses = sum(
+        1
+        for business in businesses
+        if isinstance(business.get("reviews"), list) and bool(business.get("reviews"))
+    )
+    manifest_count = manifest.get("review_evidence_items")
+    manifest_count_ok = isinstance(manifest_count, int) and manifest_count == len(evidence_index)
+    no_interpretation = not _contains_prohibited_interpretation(
+        {"businesses": businesses, "manifest": manifest}
+    )
+
+    ai_review_refs: list[str] = []
+    if ai_index is not None:
+        ai_review_refs = [
+            evidence_id
+            for evidence_id, entry in ai_index.items()
+            if isinstance(entry, dict) and entry.get("type") == "google_review"
+        ]
+    ai_integration_ok: bool | None = None
+    if ai_index is not None:
+        ai_integration_ok = bool(ai_review_refs) and any(
+            evidence_id in unique_ids for evidence_id in ai_review_refs
+        )
+
+    checks: dict[str, bool | None] = {
+        "nonzero_review_evidence": len(reviews) > 0,
+        "business_with_nonempty_sample": nonempty_businesses > 0,
+        "manifest_evidence_count_matches_index": manifest_count_ok,
+        "ratings_plausible": ratings_ok,
+        "approximate_dates_parse": dates_ok,
+        "evidence_ids_present_and_indexed": indexed_ok,
+        "evidence_ids_unique": unique_ok,
+        "sampling_bounded": bounded_ok,
+        "no_deterministic_interpretation_fields": no_interpretation,
+        "ai_export_contains_traceable_review_evidence": ai_integration_ok,
+    }
+    required_results = [value for value in checks.values() if value is not None]
+    passed = bool(required_results) and all(required_results)
+
+    return {
+        "passed": passed,
+        "review_pack": str(review_pack),
+        "ai_export": str(ai_export) if ai_export is not None else None,
+        "review_evidence_items": len(reviews),
+        "businesses_with_review_evidence": nonempty_businesses,
+        "evidence_index_items": len(evidence_index),
+        "strategy_counts": strategy_counts,
+        "per_strategy_limit": per_strategy_limit,
+        "checks": checks,
+        "manual_boundary": (
+            "This validator proves artifact semantics only. A live Google Maps collection still "
+            "requires the operator run and any Google consent/sign-in/CAPTCHA interruption."
+        ),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="veridra-review-intelligence-acceptance")
+    parser.add_argument("--downloads", type=Path, default=Path.home() / "Downloads")
+    parser.add_argument("--review-pack", type=Path)
+    parser.add_argument("--ai-export", type=Path)
+    return parser
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    review_pack = args.review_pack or _latest(
+        args.downloads,
+        "VERIDRA_REVIEW_INTELLIGENCE_*.zip",
+    )
+    if review_pack is None:
+        raise FileNotFoundError("No VERIDRA Review Intelligence ZIP was found.")
+    ai_export = args.ai_export
+    report = validate_review_intelligence(review_pack, ai_export=ai_export)
+    print(json.dumps(report, indent=2))
+    return 0 if report["passed"] is True else 2
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/veridra/review_intelligence_acceptance_cli.py
+++ b/src/veridra/review_intelligence_acceptance_cli.py
@@ -112,7 +112,12 @@ def validate_review_intelligence(
     nonempty_ids = [item for item in ids if item]
     unique_ids = set(nonempty_ids)
     ratings_ok = all(
-        rating is None or (isinstance(rating, int) and not isinstance(rating, bool) and 1 <= rating <= 5)
+        rating is None
+        or (
+            isinstance(rating, int)
+            and not isinstance(rating, bool)
+            and 1 <= rating <= 5
+        )
         for rating in (item.get("rating") for item in reviews)
     )
     dates_ok = all(

--- a/src/veridra/review_intelligence_sampling_safe_cli.py
+++ b/src/veridra/review_intelligence_sampling_safe_cli.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from . import review_intelligence_hardened_cli as hardened
 from .review_intelligence_cli import _text
+
+_BASE_CLICK_REVIEWS = hardened._click_reviews
+_BASE_CHOOSE_SORT = hardened._choose_sort
+_BASE_COLLECT_STRATEGY = hardened._collect_strategy
+_BASE_REVIEW_FROM_CARD = hardened._review_from_card
+_MANUAL_INTERRUPTION_SELECTORS: tuple[tuple[str, str], ...] = (
+    ("consent", "button:has-text('Accept all')"),
+    ("consent", "button:has-text('Reject all')"),
+    ("sign-in", "form[action*='signin']"),
+    ("sign-in", "input[type='email']"),
+    ("captcha", "iframe[src*='recaptcha']"),
+    ("captcha", "form[action*='captcha']"),
+)
 
 
 def _strategy_rows(
@@ -120,8 +134,214 @@ def strategy_safe_statistics(
     }
 
 
-def run(argv: Sequence[str] | None = None) -> int:
+def _first_text(card: Any, selectors: tuple[str, ...]) -> str:
+    for selector in selectors:
+        try:
+            node = card.locator(selector).first
+            if not node.count():
+                continue
+            value = _text(node.inner_text(timeout=2000))
+            if value:
+                return value
+        except Exception:
+            continue
+    return ""
+
+
+def _first_attribute(card: Any, selectors: tuple[str, ...], attribute: str) -> str:
+    for selector in selectors:
+        try:
+            node = card.locator(selector).first
+            if not node.count():
+                continue
+            value = _text(node.get_attribute(attribute))
+            if value:
+                return value
+        except Exception:
+            continue
+    return ""
+
+
+def review_with_provenance(
+    card: Any,
+    *,
+    business_name: str,
+    strategy: str,
+    observed_at: datetime,
+) -> dict[str, object] | None:
+    row = _BASE_REVIEW_FROM_CARD(
+        card,
+        business_name=business_name,
+        strategy=strategy,
+        observed_at=observed_at,
+    )
+    if row is None:
+        return None
+
+    owner_response_date_text = _first_text(
+        card,
+        (
+            ".CDe7pd .rsqaWe",
+            ".CDe7pd span.rsqaWe",
+        ),
+    )
+    reviewer_name = _first_text(
+        card,
+        (
+            ".d4r55",
+            "button.WNxzHc .d4r55",
+            "button[aria-label] .d4r55",
+        ),
+    )
+    reviewer_metadata = _first_text(
+        card,
+        (
+            ".RfnDt",
+            ".A503be",
+            ".WNxzHc + div",
+        ),
+    )
+    translation_label = _first_attribute(
+        card,
+        (
+            "button[aria-label*='translation' i]",
+            "button[aria-label*='translate' i]",
+        ),
+        "aria-label",
+    )
+    translated_text = _first_text(
+        card,
+        (
+            ".wiI7pd[lang]",
+            "span[lang]",
+        ),
+    )
+
+    row.update(
+        {
+            "owner_response_date_text": owner_response_date_text or None,
+            "approximate_owner_response_date": (
+                hardened._relative_date(owner_response_date_text, observed_at=observed_at)
+                if owner_response_date_text
+                else None
+            ),
+            "reviewer_name": reviewer_name or None,
+            "reviewer_metadata": reviewer_metadata or None,
+            "language_translation": {
+                "translation_control_label": translation_label or None,
+                "translated_text_exposed": translated_text or None,
+            },
+        }
+    )
+    return row
+
+
+def _manual_interruption(page: Any) -> str | None:
+    for kind, selector in _MANUAL_INTERRUPTION_SELECTORS:
+        try:
+            if page.locator(selector).count():
+                return kind
+        except Exception:
+            continue
+    return None
+
+
+def _retry_call(
+    operation: Callable[[], Any],
+    *,
+    page: Any,
+    succeeded: Callable[[Any], bool],
+    attempts: int = 3,
+) -> tuple[Any, int, str | None]:
+    last: Any = None
+    for attempt in range(1, attempts + 1):
+        interruption = _manual_interruption(page)
+        if interruption:
+            return last, attempt - 1, interruption
+        last = operation()
+        if succeeded(last):
+            return last, attempt, None
+        if attempt < attempts:
+            try:
+                page.wait_for_timeout(400 * attempt)
+            except Exception:
+                pass
+    return last, attempts, None
+
+
+def retry_click_reviews(page: Any) -> tuple[bool, str, int]:
+    result, attempts, interruption = _retry_call(
+        lambda: _BASE_CLICK_REVIEWS(page),
+        page=page,
+        succeeded=lambda value: isinstance(value, tuple) and bool(value[0]),
+    )
+    if interruption:
+        return False, f"manual-interruption:{interruption}", 0
+    if not isinstance(result, tuple) or len(result) != 3:
+        return False, f"retry-exhausted:{attempts}", 0
+    opened, selector, count = result
+    if opened:
+        return bool(opened), f"retry-{attempts}:{selector}", int(count)
+    return False, f"retry-exhausted:{attempts}", int(count)
+
+
+def retry_choose_sort(page: Any, strategy: str) -> dict[str, object]:
+    result, attempts, interruption = _retry_call(
+        lambda: _BASE_CHOOSE_SORT(page, strategy),
+        page=page,
+        succeeded=lambda value: isinstance(value, dict) and value.get("selected") is True,
+    )
+    if not isinstance(result, dict):
+        result = {
+            "requested": strategy,
+            "selected": False,
+            "button_selector": None,
+            "option_label": None,
+            "fallback": "sort-unavailable",
+        }
+    output = dict(result)
+    output["attempts"] = attempts
+    output["manual_interruption"] = interruption
+    if interruption:
+        output["fallback"] = f"manual-interruption:{interruption}"
+    return output
+
+
+def collect_strategy_with_provenance(
+    page: Any,
+    *,
+    business_name: str,
+    strategy: str,
+    limit: int,
+) -> tuple[list[dict[str, object]], dict[str, object]]:
+    rows, diagnostics = _BASE_COLLECT_STRATEGY(
+        page,
+        business_name=business_name,
+        strategy=strategy,
+        limit=limit,
+    )
+    source_url = ""
+    try:
+        source_url = _text(page.url)
+    except Exception:
+        pass
+    for row in rows:
+        row["source_url"] = source_url or None
+    diagnostics = dict(diagnostics)
+    diagnostics["source_url"] = source_url or None
+    return rows, diagnostics
+
+
+def _install_hardened_hooks() -> None:
     hardened._statistics = strategy_safe_statistics
+    hardened._review_from_card = review_with_provenance
+    hardened._click_reviews = retry_click_reviews
+    hardened._choose_sort = retry_choose_sort
+    hardened._collect_strategy = collect_strategy_with_provenance
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    _install_hardened_hooks()
     return hardened.run(argv)
 
 

--- a/tests/test_review_intelligence_acceptance_cli.py
+++ b/tests/test_review_intelligence_acceptance_cli.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from veridra.review_intelligence_acceptance_cli import validate_review_intelligence
+
+
+def _write_review_pack(path: Path) -> None:
+    reviews = [
+        {
+            "evidence_id": "review:example:1",
+            "rating": 5,
+            "approximate_review_date": "2026-08-31",
+            "approximate_owner_response_date": None,
+            "owner_response_present": False,
+            "sample_strategy": "newest",
+            "sample_strategies": ["newest", "highest"],
+        },
+        {
+            "evidence_id": "review:example:2",
+            "rating": 2,
+            "approximate_review_date": "2026-08-01",
+            "approximate_owner_response_date": "2026-08-02",
+            "owner_response_present": True,
+            "sample_strategy": "lowest",
+            "sample_strategies": ["lowest"],
+        },
+    ]
+    manifest = {
+        "review_evidence_items": 2,
+        "sampling": {"per_strategy_limit": 5, "strategies": ["newest", "lowest", "highest"]},
+        "interpretation": "none",
+        "persistence": "none",
+        "outreach": "none",
+    }
+    evidence = [
+        {
+            "business_name": "Example Dental",
+            "reviews": reviews,
+        }
+    ]
+    index = {
+        "review:example:1": {"type": "google_review"},
+        "review:example:2": {"type": "google_review"},
+    }
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("manifest.json", json.dumps(manifest))
+        archive.writestr("review_evidence.json", json.dumps(evidence))
+        archive.writestr("evidence_index.json", json.dumps(index))
+
+
+def _write_ai_export(path: Path) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            "evidence_index.json",
+            json.dumps(
+                {
+                    "review:example:1": {
+                        "type": "google_review",
+                        "business_name": "Example Dental",
+                    }
+                }
+            ),
+        )
+
+
+def test_acceptance_passes_valid_review_pack(tmp_path: Path) -> None:
+    review_pack = tmp_path / "VERIDRA_REVIEW_INTELLIGENCE_test.zip"
+    _write_review_pack(review_pack)
+
+    report = validate_review_intelligence(review_pack)
+
+    assert report["passed"] is True
+    checks = report["checks"]
+    assert isinstance(checks, dict)
+    assert checks["nonzero_review_evidence"] is True
+    assert checks["sampling_bounded"] is True
+    assert checks["ai_export_contains_traceable_review_evidence"] is None
+
+
+def test_acceptance_can_verify_ai_export_integration(tmp_path: Path) -> None:
+    review_pack = tmp_path / "VERIDRA_REVIEW_INTELLIGENCE_test.zip"
+    ai_export = tmp_path / "VERIDRA_AI_EXPORT_test.zip"
+    _write_review_pack(review_pack)
+    _write_ai_export(ai_export)
+
+    report = validate_review_intelligence(review_pack, ai_export=ai_export)
+
+    assert report["passed"] is True
+    checks = report["checks"]
+    assert isinstance(checks, dict)
+    assert checks["ai_export_contains_traceable_review_evidence"] is True
+
+
+def test_acceptance_rejects_zero_evidence(tmp_path: Path) -> None:
+    review_pack = tmp_path / "VERIDRA_REVIEW_INTELLIGENCE_empty.zip"
+    with zipfile.ZipFile(review_pack, "w") as archive:
+        archive.writestr(
+            "manifest.json",
+            json.dumps({"review_evidence_items": 0, "sampling": {"per_strategy_limit": 5}}),
+        )
+        archive.writestr("review_evidence.json", json.dumps([]))
+        archive.writestr("evidence_index.json", json.dumps({}))
+
+    report = validate_review_intelligence(review_pack)
+
+    assert report["passed"] is False
+    checks = report["checks"]
+    assert isinstance(checks, dict)
+    assert checks["nonzero_review_evidence"] is False
+    assert checks["business_with_nonempty_sample"] is False
+
+
+def test_acceptance_rejects_interpretation_fields(tmp_path: Path) -> None:
+    review_pack = tmp_path / "VERIDRA_REVIEW_INTELLIGENCE_interpreted.zip"
+    _write_review_pack(review_pack)
+    with zipfile.ZipFile(review_pack, "a") as archive:
+        archive.writestr(
+            "review_evidence.json",
+            json.dumps(
+                [
+                    {
+                        "business_name": "Example Dental",
+                        "reviews": [
+                            {
+                                "evidence_id": "review:example:1",
+                                "rating": 5,
+                                "sentiment": "positive",
+                                "sample_strategy": "newest",
+                                "sample_strategies": ["newest"],
+                            }
+                        ],
+                    }
+                ]
+            ),
+        )
+
+    report = validate_review_intelligence(review_pack)
+
+    assert report["passed"] is False
+    checks = report["checks"]
+    assert isinstance(checks, dict)
+    assert checks["no_deterministic_interpretation_fields"] is False

--- a/tests/test_review_intelligence_operator_hardening.py
+++ b/tests/test_review_intelligence_operator_hardening.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import veridra.review_intelligence_sampling_safe_cli as safe
+
+
+class FakeLocator:
+    def __init__(
+        self,
+        *,
+        count: int = 0,
+        text: str = "",
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        self._count = count
+        self._text = text
+        self._attributes = attributes or {}
+
+    @property
+    def first(self) -> "FakeLocator":
+        return self
+
+    def count(self) -> int:
+        return self._count
+
+    def inner_text(self, timeout: int = 0) -> str:
+        _ = timeout
+        return self._text
+
+    def get_attribute(self, name: str) -> str | None:
+        return self._attributes.get(name)
+
+
+class FakeCard:
+    def __init__(self) -> None:
+        self._nodes = {
+            ".CDe7pd .rsqaWe": FakeLocator(count=1, text="3 days ago"),
+            ".d4r55": FakeLocator(count=1, text="Local Reviewer"),
+            ".RfnDt": FakeLocator(count=1, text="Local Guide · 42 reviews"),
+            "button[aria-label*='translation' i]": FakeLocator(
+                count=1,
+                attributes={"aria-label": "See translation"},
+            ),
+            ".wiI7pd[lang]": FakeLocator(count=1, text="Translated review text"),
+        }
+
+    def locator(self, selector: str) -> FakeLocator:
+        return self._nodes.get(selector, FakeLocator())
+
+
+class FakePage:
+    def __init__(self, *, selectors: dict[str, int] | None = None) -> None:
+        self._selectors = selectors or {}
+        self.url = "https://www.google.com/maps/place/example"
+        self.waits: list[int] = []
+
+    def locator(self, selector: str) -> FakeLocator:
+        return FakeLocator(count=self._selectors.get(selector, 0))
+
+    def wait_for_timeout(self, timeout: int) -> None:
+        self.waits.append(timeout)
+
+
+def test_review_provenance_adds_optional_metadata(monkeypatch: Any) -> None:
+    observed_at = datetime(2026, 9, 1, 12, 0, tzinfo=UTC)
+    base_row: dict[str, object] = {
+        "evidence_id": "review:example:123",
+        "rating": 5,
+        "text": "Great visit",
+        "owner_response_present": True,
+    }
+    monkeypatch.setattr(safe, "_BASE_REVIEW_FROM_CARD", lambda *_args, **_kwargs: dict(base_row))
+
+    row = safe.review_with_provenance(
+        FakeCard(),
+        business_name="Example Dental",
+        strategy="newest",
+        observed_at=observed_at,
+    )
+
+    assert row is not None
+    assert row["reviewer_name"] == "Local Reviewer"
+    assert row["reviewer_metadata"] == "Local Guide · 42 reviews"
+    assert row["owner_response_date_text"] == "3 days ago"
+    assert row["approximate_owner_response_date"] == "2026-08-29"
+    language = row["language_translation"]
+    assert isinstance(language, dict)
+    assert language["translation_control_label"] == "See translation"
+    assert language["translated_text_exposed"] == "Translated review text"
+
+
+def test_retry_click_reviews_recovers_transient_failure(monkeypatch: Any) -> None:
+    calls = 0
+
+    def fake_click(_page: object) -> tuple[bool, str, int]:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            return False, "", 0
+        return True, "reviews-button", 4
+
+    monkeypatch.setattr(safe, "_BASE_CLICK_REVIEWS", fake_click)
+    result = safe.retry_click_reviews(FakePage())
+
+    assert calls == 3
+    assert result == (True, "retry-3:reviews-button", 4)
+
+
+def test_manual_interruption_prevents_automated_retry(monkeypatch: Any) -> None:
+    calls = 0
+
+    def fake_click(_page: object) -> tuple[bool, str, int]:
+        nonlocal calls
+        calls += 1
+        return False, "", 0
+
+    monkeypatch.setattr(safe, "_BASE_CLICK_REVIEWS", fake_click)
+    page = FakePage(selectors={"iframe[src*='recaptcha']": 1})
+
+    result = safe.retry_click_reviews(page)
+
+    assert calls == 0
+    assert result == (False, "manual-interruption:captcha", 0)
+
+
+def test_collect_strategy_attaches_source_url(monkeypatch: Any) -> None:
+    def fake_collect(
+        _page: object,
+        *,
+        business_name: str,
+        strategy: str,
+        limit: int,
+    ) -> tuple[list[dict[str, object]], dict[str, object]]:
+        _ = business_name, strategy, limit
+        return [{"evidence_id": "review:example:1"}], {"rows_collected": 1}
+
+    monkeypatch.setattr(safe, "_BASE_COLLECT_STRATEGY", fake_collect)
+    rows, diagnostics = safe.collect_strategy_with_provenance(
+        FakePage(),
+        business_name="Example Dental",
+        strategy="newest",
+        limit=5,
+    )
+
+    assert rows[0]["source_url"] == "https://www.google.com/maps/place/example"
+    assert diagnostics["source_url"] == "https://www.google.com/maps/place/example"
+
+
+def test_sort_retry_exposes_attempt_count(monkeypatch: Any) -> None:
+    calls = 0
+
+    def fake_sort(_page: object, strategy: str) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        return {
+            "requested": strategy,
+            "selected": calls == 2,
+            "button_selector": "sort-button" if calls == 2 else None,
+            "option_label": "Newest" if calls == 2 else None,
+            "fallback": None,
+        }
+
+    monkeypatch.setattr(safe, "_BASE_CHOOSE_SORT", fake_sort)
+    result = safe.retry_choose_sort(FakePage(), "newest")
+
+    assert calls == 2
+    assert result["selected"] is True
+    assert result["attempts"] == 2
+    assert result["manual_interruption"] is None

--- a/tests/test_review_intelligence_operator_hardening.py
+++ b/tests/test_review_intelligence_operator_hardening.py
@@ -19,7 +19,7 @@ class FakeLocator:
         self._attributes = attributes or {}
 
     @property
-    def first(self) -> "FakeLocator":
+    def first(self) -> FakeLocator:
         return self
 
     def count(self) -> int:


### PR DESCRIPTION
## Scope
Continues #229 Deep Review Intelligence from the existing sampling-safe collector.

- preserves optional reviewer name/local metadata when Google Maps exposes it;
- preserves owner-response date text plus bounded approximate response date;
- preserves translation-control / translated-text metadata when exposed;
- attaches the observed Google Maps source URL to each collected review row;
- adds bounded retries for transient review-tab and sort UI failures;
- detects consent/sign-in/CAPTCHA surfaces as explicit manual-interruption states rather than retrying through them;
- keeps newest/lowest/highest statistics strategy-scoped and population metrics suppressed;
- adds deterministic tests for provenance, retry recovery, interruption handling and source URL propagation.

## Existing #229 coverage reused
The repository already has bounded review collection, stable review evidence IDs, strategy-safe deterministic statistics, ZIP artifacts, diagnostics, Windows launcher and review evidence integration into the AI evidence export. This PR hardens the remaining collector/provenance gaps instead of duplicating that implementation.

## Boundary
No outreach, persistence, sentiment/theme inference, fake-review classification or population estimates are introduced. Live Dublin Google Maps acceptance remains a separate final gate after CI.

Closes #229 only after the live Dublin acceptance is evidenced.