### PR TITLE
#229: one-click live Review Intelligence gate

### DIFF
--- a/VERIDRA_REVIEW_LIVE_GATE.bat
+++ b/VERIDRA_REVIEW_LIVE_GATE.bat
@@ -1,0 +1,63 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+set "ROOT=%~dp0"
+set "DOWNLOADS=%USERPROFILE%\Downloads"
+
+echo ======================================================
+echo VERIDRA - REVIEW INTELLIGENCE LIVE ACCEPTANCE GATE
+echo ======================================================
+echo.
+echo This gate is read-only for prospect evidence and sends no outreach.
+echo Google consent, sign-in, or CAPTCHA may require manual interaction.
+echo.
+
+call "%ROOT%VERIDRA_REVIEW_INTELLIGENCE.bat" %*
+if errorlevel 1 (
+  echo.
+  echo [FAIL] Review collection did not produce acceptable non-zero evidence.
+  exit /b %ERRORLEVEL%
+)
+
+call "%ROOT%VERIDRA_REVIEW_ACCEPTANCE.bat"
+if errorlevel 1 (
+  echo.
+  echo [FAIL] Review evidence artifact failed deterministic acceptance.
+  exit /b %ERRORLEVEL%
+)
+
+call "%ROOT%VERIDRA_AI_EXPORT.bat"
+if errorlevel 1 (
+  echo.
+  echo [FAIL] Review-aware AI evidence export failed.
+  exit /b %ERRORLEVEL%
+)
+
+set "AI_EXPORT="
+for /f "delims=" %%F in ('dir /b /a-d /o-d "%DOWNLOADS%\VERIDRA_AI_EXPORT_*.zip" 2^>nul') do (
+  if not defined AI_EXPORT set "AI_EXPORT=%DOWNLOADS%\%%F"
+)
+
+if not defined AI_EXPORT (
+  echo.
+  echo [FAIL] No VERIDRA_AI_EXPORT_*.zip was found in Downloads.
+  exit /b 2
+)
+
+echo.
+echo [Veridra] Final traceability check against:
+echo   %AI_EXPORT%
+call "%ROOT%VERIDRA_REVIEW_ACCEPTANCE.bat" --ai-export "%AI_EXPORT%"
+if errorlevel 1 (
+  echo.
+  echo [FAIL] Review evidence was not accepted as traceable in the AI export.
+  exit /b %ERRORLEVEL%
+)
+
+echo.
+echo ======================================================
+echo [PASS] REVIEW INTELLIGENCE LIVE GATE
+echo ======================================================
+echo Review evidence is non-zero, bounded, deterministic, indexed,
+echo and traceable into the review-aware AI evidence export.
+echo No outreach was sent.
+exit /b 0


### PR DESCRIPTION
## Scope
Adds one compact Windows operator launcher for the remaining live #229 acceptance:

`VERIDRA_REVIEW_LIVE_GATE.bat`

The launcher executes, in order:
1. bounded live Review Intelligence collection;
2. deterministic review artifact acceptance;
3. review-aware AI evidence export;
4. automatic selection of the newest AI export;
5. final acceptance verifying traceable `google_review` evidence in that export.

It exits immediately on any failed stage and prints a final PASS only when the complete artifact chain succeeds. It sends no outreach and does not bypass Google consent, sign-in, or CAPTCHA.

This reduces the remaining local live acceptance to one command without weakening #229's evidence requirements.

Does not close #229 until a real Dublin dental run passes.