### PR TITLE
#285 sales-to-contract workflow foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,21 @@ jobs:
         shell: pwsh
         run: |
           pytest tests/test_monitoring_schedule.py tests/test_monitoring_service.py tests/test_backup_restore.py tests/test_session_lifecycle_api.py tests/test_project_store.py tests/test_report_delivery.py
+      - name: Sales-to-contract Playwright acceptance
+        timeout-minutes: 10
+        shell: pwsh
+        run: python tools/sales_contract_acceptance.py
       - name: True Playwright first-customer operator acceptance
         timeout-minutes: 15
         shell: cmd
         run: VERIDRA_OPERATOR_E2E_ACCEPTANCE.bat
+      - name: Upload Playwright sales-contract evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: veridra-sales-contract-acceptance
+          path: artifacts/sales-contract-acceptance
+          if-no-files-found: warn
       - name: Upload Playwright visual acceptance evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           pytest tests/test_monitoring_schedule.py tests/test_monitoring_service.py tests/test_backup_restore.py tests/test_session_lifecycle_api.py tests/test_project_store.py tests/test_report_delivery.py
       - name: Sales-to-contract Playwright acceptance
-        timeout-minutes: 10
+        timeout-minutes: 15
         shell: pwsh
         run: python tools/sales_contract_acceptance.py
       - name: True Playwright first-customer operator acceptance

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Install Chromium
         timeout-minutes: 5
         run: python -m playwright install chromium
+      - name: Prepare supported launcher environment
+        shell: pwsh
+        run: python -m venv .venv --system-site-packages
       - name: Verify timezone database
         shell: pwsh
         run: |

--- a/src/veridra/agency_change_request_transition_web.py
+++ b/src/veridra/agency_change_request_transition_web.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from pydantic import ValidationError
+
+from .deal_lifecycle import ChangeRequestStatus, ScopeChangeRequest
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .request_security import require_request_identity
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .tenant_deal_store import TenantDealStore
+
+router = APIRouter(tags=["agency-change-request-transition"])
+
+_ALLOWED: dict[ChangeRequestStatus, frozenset[ChangeRequestStatus]] = {
+    ChangeRequestStatus.requested: frozenset(
+        {
+            ChangeRequestStatus.requested,
+            ChangeRequestStatus.reviewing,
+            ChangeRequestStatus.approved,
+            ChangeRequestStatus.declined,
+        }
+    ),
+    ChangeRequestStatus.reviewing: frozenset(
+        {
+            ChangeRequestStatus.reviewing,
+            ChangeRequestStatus.approved,
+            ChangeRequestStatus.declined,
+        }
+    ),
+    ChangeRequestStatus.approved: frozenset(
+        {ChangeRequestStatus.approved, ChangeRequestStatus.incorporated}
+    ),
+    ChangeRequestStatus.declined: frozenset({ChangeRequestStatus.declined}),
+    ChangeRequestStatus.incorporated: frozenset({ChangeRequestStatus.incorporated}),
+}
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Sales workflow is not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(
+            status_code=403,
+            detail="Sales workflow request is not permitted.",
+        ) from exc
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+@router.post("/agency/prospects/{prospect_id}/deal/change-requests/{sequence}/status")
+async def update_change_request_strict(
+    prospect_id: str,
+    sequence: int,
+    request: Request,
+) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    values = _values(await request.body())
+    try:
+        next_status = ChangeRequestStatus(_one(values, "status"))
+        version_raw = _one(values, "resulting_proposal_version")
+        resulting_version = int(version_raw) if version_raw else None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Change request status is invalid.") from exc
+
+    store = TenantDealStore(_root(request))
+    deal = store.load_or_empty(identity, prospect_id)
+    changes = list(deal.change_requests)
+    for index, change in enumerate(changes):
+        if change.sequence != sequence:
+            continue
+        if next_status not in _ALLOWED[change.status]:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Change #{sequence} cannot move from {change.status.value} "
+                    f"to {next_status.value}."
+                ),
+            )
+        if next_status is ChangeRequestStatus.incorporated:
+            if resulting_version is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Incorporated changes require the resulting proposal version.",
+                )
+            if not any(item.version == resulting_version for item in deal.proposals):
+                raise HTTPException(
+                    status_code=409,
+                    detail="Resulting proposal version does not exist in this deal.",
+                )
+        decision_reference = _one(values, "decision_reference")
+        if change.status in {
+            ChangeRequestStatus.approved,
+            ChangeRequestStatus.declined,
+        }:
+            decision_reference = change.decision_reference
+        try:
+            changes[index] = ScopeChangeRequest.model_validate(
+                {
+                    **change.model_dump(mode="json"),
+                    "status": next_status,
+                    "decision_reference": decision_reference,
+                    "resulting_proposal_version": resulting_version,
+                    "updated_at": datetime.now(UTC),
+                }
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Approved or declined changes require decision evidence.",
+            ) from exc
+        break
+    else:
+        raise HTTPException(status_code=404, detail="Change request not found.")
+
+    store.save(identity, deal.model_copy(update={"change_requests": tuple(changes)}))
+    return RedirectResponse(
+        f"/agency/prospects/{prospect_id}/deal/change-requests",
+        status_code=303,
+    )

--- a/src/veridra/agency_change_request_web.py
+++ b/src/veridra/agency_change_request_web.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E501
 from __future__ import annotations
 
 import html

--- a/src/veridra/agency_change_request_web.py
+++ b/src/veridra/agency_change_request_web.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import html
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .agency_navigation import agency_navigation
+from .deal_lifecycle import ChangeRequestStatus, ScopeChangeRequest
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .request_security import require_request_identity
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .tenant_deal_store import TenantDealStore
+from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
+
+router = APIRouter(tags=["agency-change-request"])
+
+_STYLE = """
+body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}
+main{max-width:980px;margin:36px auto;padding:0 20px}
+section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}
+label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}
+textarea{min-height:90px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.card{border:1px solid #e1e5ea;border-radius:8px;padding:16px;margin:12px 0}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.muted{color:#68707a}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:700px){.row{grid-template-columns:1fr}}
+"""
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Sales workflow is not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Sales workflow request is not permitted.") from exc
+
+
+def _one(body: bytes, name: str) -> str:
+    values = parse_qs(body.decode("utf-8"), keep_blank_values=True)
+    return values.get(name, [""])[0].strip()
+
+
+def _status_options(current: ChangeRequestStatus) -> str:
+    return "".join(
+        f"<option value='{item.value}'{' selected' if item is current else ''}>"
+        f"{item.value.replace('_', ' ').title()}</option>"
+        for item in ChangeRequestStatus
+    )
+
+
+@router.get(
+    "/agency/prospects/{prospect_id}/deal/change-requests",
+    response_class=HTMLResponse,
+)
+def change_request_page(prospect_id: str, request: Request) -> str:
+    identity = _identity(request)
+    root = _root(request)
+    try:
+        prospect = TenantProspectStore(root).load(
+            identity,
+            TenantProspectStore.ref(identity, prospect_id),
+        )
+    except TenantProspectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Prospect not found.") from exc
+    deal = TenantDealStore(root).load_or_empty(identity, prospect_id)
+    cards: list[str] = []
+    for item in reversed(deal.change_requests):
+        resulting = (
+            f"v{item.resulting_proposal_version}"
+            if item.resulting_proposal_version is not None
+            else "—"
+        )
+        cards.append(
+            f"<div class='card'><h3>Change #{item.sequence} "
+            f"<span class='badge'>{html.escape(item.status.value)}</span></h3>"
+            f"<p><strong>Request:</strong> {html.escape(item.summary)}</p>"
+            f"<p><strong>Scope impact:</strong> {html.escape(item.scope_impact)}</p>"
+            f"<p><strong>Price impact:</strong> {html.escape(item.price_impact or 'Not assessed')}</p>"
+            f"<p><strong>Timeline impact:</strong> {html.escape(item.timeline_impact or 'Not assessed')}</p>"
+            f"<p><strong>Resulting proposal:</strong> {html.escape(resulting)}</p>"
+            f"<form method='post' action='/agency/prospects/{html.escape(prospect_id, quote=True)}/deal/change-requests/{item.sequence}/status'>"
+            f"<label>Status</label><select name='status'>{_status_options(item.status)}</select>"
+            "<label>Decision evidence/reference</label>"
+            f"<input name='decision_reference' maxlength='1000' value='{html.escape(item.decision_reference, quote=True)}'>"
+            "<label>Resulting proposal version (required when incorporated)</label>"
+            f"<input name='resulting_proposal_version' type='number' min='1' value='{resulting if resulting != '—' else ''}'>"
+            "<button type='submit'>Update change request</button></form></div>"
+        )
+    history = "".join(cards) or "<p class='muted'>No scope changes recorded.</p>"
+    navigation = agency_navigation(identity, current="deals")
+    body = (
+        f"{navigation}<section><p><a href='/agency/prospects/{html.escape(prospect_id, quote=True)}/deal'>← Sales workflow</a></p>"
+        f"<h1>Scope changes — {html.escape(prospect.business_name)}</h1>"
+        "<p class='muted'>Record requested changes separately. Approved changes should become a new proposal version rather than rewriting a proposal already sent or accepted.</p></section>"
+        f"<section><h2>New scope change</h2><form method='post' action='/agency/prospects/{html.escape(prospect_id, quote=True)}/deal/change-requests'>"
+        "<label>Requested change</label><textarea name='summary' required></textarea>"
+        "<label>Requested by</label><input name='requested_by' value='customer'>"
+        "<label>Scope impact</label><textarea name='scope_impact' required></textarea>"
+        "<div class='row'><div><label>Price impact</label><input name='price_impact'></div>"
+        "<div><label>Timeline impact</label><input name='timeline_impact'></div></div>"
+        "<button type='submit'>Record change request</button></form></section>"
+        f"<section><h2>Change history</h2>{history}</section>"
+    )
+    return (
+        "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        f"<title>Scope changes</title><style>{_STYLE}</style></head>"
+        f"<body><main>{body}</main></body></html>"
+    )
+
+
+@router.post("/agency/prospects/{prospect_id}/deal/change-requests")
+async def create_change_request(prospect_id: str, request: Request) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    root = _root(request)
+    try:
+        TenantProspectStore(root).load(
+            identity,
+            TenantProspectStore.ref(identity, prospect_id),
+        )
+    except TenantProspectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Prospect not found.") from exc
+    body = await request.body()
+    store = TenantDealStore(root)
+    deal = store.load_or_empty(identity, prospect_id)
+    try:
+        change = ScopeChangeRequest(
+            sequence=len(deal.change_requests) + 1,
+            summary=_one(body, "summary"),
+            requested_by=_one(body, "requested_by") or "customer",
+            scope_impact=_one(body, "scope_impact"),
+            price_impact=_one(body, "price_impact"),
+            timeline_impact=_one(body, "timeline_impact"),
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="Scope change is incomplete.") from exc
+    store.save(
+        identity,
+        deal.model_copy(
+            update={
+                "change_requests": (*deal.change_requests, change),
+                "next_action": "Review scope, price and timeline impact",
+                "updated_at": datetime.now(UTC),
+            }
+        ),
+    )
+    return RedirectResponse(
+        f"/agency/prospects/{prospect_id}/deal/change-requests",
+        status_code=303,
+    )
+
+
+@router.post("/agency/prospects/{prospect_id}/deal/change-requests/{sequence}/status")
+async def update_change_request(
+    prospect_id: str,
+    sequence: int,
+    request: Request,
+) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    body = await request.body()
+    store = TenantDealStore(_root(request))
+    deal = store.load_or_empty(identity, prospect_id)
+    try:
+        next_status = ChangeRequestStatus(_one(body, "status"))
+        version_raw = _one(body, "resulting_proposal_version")
+        resulting_version = int(version_raw) if version_raw else None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Change request status is invalid.") from exc
+
+    changes = list(deal.change_requests)
+    for index, change in enumerate(changes):
+        if change.sequence != sequence:
+            continue
+        try:
+            changes[index] = ScopeChangeRequest.model_validate(
+                {
+                    **change.model_dump(mode="json"),
+                    "status": next_status,
+                    "decision_reference": _one(body, "decision_reference"),
+                    "resulting_proposal_version": resulting_version,
+                    "updated_at": datetime.now(UTC),
+                }
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Approved/declined changes require decision evidence; incorporated "
+                    "changes also require the resulting proposal version."
+                ),
+            ) from exc
+        break
+    else:
+        raise HTTPException(status_code=404, detail="Change request not found.")
+    store.save(identity, deal.model_copy(update={"change_requests": tuple(changes)}))
+    return RedirectResponse(
+        f"/agency/prospects/{prospect_id}/deal/change-requests",
+        status_code=303,
+    )

--- a/src/veridra/agency_deal_index_web.py
+++ b/src/veridra/agency_deal_index_web.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E501
 from __future__ import annotations
 
 import html

--- a/src/veridra/agency_deal_index_web.py
+++ b/src/veridra/agency_deal_index_web.py
@@ -25,8 +25,10 @@ body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}
 main{max-width:1180px;margin:36px auto;padding:0 20px}
 section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}
 .button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:9px 12px;text-decoration:none}
+.secondary{background:#59636e}
 .muted{color:#68707a}
 .badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}
+.actions{display:flex;gap:6px;flex-wrap:wrap}
 table{width:100%;border-collapse:collapse}
 th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}
 .agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}
@@ -74,10 +76,17 @@ def deal_index(request: Request) -> str:
         business = html.escape(prospect.business_name)
         prospect_status = html.escape(prospect.status.value)
         next_action = html.escape(prospect.next_action or deal.next_action or "—")
-        deal_url = (
-            "/agency/prospects/"
-            f"{html.escape(prospect_id, quote=True)}/deal"
-        )
+        escaped_id = html.escape(prospect_id, quote=True)
+        deal_url = f"/agency/prospects/{escaped_id}/deal"
+        artifact_action = ""
+        if latest is not None:
+            artifact_url = (
+                f"/agency/prospects/{escaped_id}/deal/proposals/"
+                f"{latest.version}/artifact"
+            )
+            artifact_action = (
+                f"<a class='button secondary' href='{artifact_url}'>Preview proposal</a>"
+            )
         rows.append(
             "<tr>"
             f"<td><strong>{business}</strong><br>"
@@ -86,8 +95,9 @@ def deal_index(request: Request) -> str:
             f"<td>{html.escape(discovery)}</td>"
             f"<td><span class='badge'>{html.escape(proposal)}</span></td>"
             f"<td>{next_action}</td>"
-            f"<td><a class='button' href='{deal_url}'>"
-            "Open sales workflow</a></td>"
+            "<td><div class='actions'>"
+            f"<a class='button' href='{deal_url}'>Open sales workflow</a>"
+            f"{artifact_action}</div></td>"
             "</tr>"
         )
     table = (

--- a/src/veridra/agency_deal_index_web.py
+++ b/src/veridra/agency_deal_index_web.py
@@ -20,7 +20,19 @@ from .tenant_prospect_store import TenantProspectStore
 router = APIRouter(tags=["agency-deal-index"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1180px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:9px 12px;text-decoration:none}.muted{color:#68707a}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:760px){table{display:block;overflow:auto}}
+*{box-sizing:border-box}
+body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}
+main{max-width:1180px;margin:36px auto;padding:0 20px}
+section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}
+.button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:9px 12px;text-decoration:none}
+.muted{color:#68707a}
+.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}
+table{width:100%;border-collapse:collapse}
+th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}
+.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}
+.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}
+.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}
+@media(max-width:760px){table{display:block;overflow:auto}}
 """
 
 
@@ -47,7 +59,11 @@ def deal_index(request: Request) -> str:
     rows: list[str] = []
     for prospect_id, prospect in prospects:
         deal = deal_store.load_or_empty(identity, prospect_id)
-        reply = deal.reply_outcome.value.replace("_", " ") if deal.reply_outcome else "Not recorded"
+        reply = (
+            deal.reply_outcome.value.replace("_", " ")
+            if deal.reply_outcome
+            else "Not recorded"
+        )
         discovery = "Ready" if deal.discovery is not None else "Not captured"
         latest = deal.latest_proposal
         proposal = (
@@ -55,18 +71,30 @@ def deal_index(request: Request) -> str:
             if latest is not None
             else "No proposal"
         )
+        business = html.escape(prospect.business_name)
+        prospect_status = html.escape(prospect.status.value)
+        next_action = html.escape(prospect.next_action or deal.next_action or "—")
+        deal_url = (
+            "/agency/prospects/"
+            f"{html.escape(prospect_id, quote=True)}/deal"
+        )
         rows.append(
             "<tr>"
-            f"<td><strong>{html.escape(prospect.business_name)}</strong><br><span class='muted'>{html.escape(prospect.status.value)}</span></td>"
+            f"<td><strong>{business}</strong><br>"
+            f"<span class='muted'>{prospect_status}</span></td>"
             f"<td>{html.escape(reply.title())}</td>"
             f"<td>{html.escape(discovery)}</td>"
             f"<td><span class='badge'>{html.escape(proposal)}</span></td>"
-            f"<td>{html.escape(prospect.next_action or deal.next_action or '—')}</td>"
-            f"<td><a class='button' href='/agency/prospects/{html.escape(prospect_id, quote=True)}/deal'>Open sales workflow</a></td>"
+            f"<td>{next_action}</td>"
+            f"<td><a class='button' href='{deal_url}'>"
+            "Open sales workflow</a></td>"
             "</tr>"
         )
     table = (
-        "<table><thead><tr><th>Prospect</th><th>Reply</th><th>Discovery</th><th>Proposal</th><th>Next action</th><th></th></tr></thead><tbody>"
+        "<table><thead><tr>"
+        "<th>Prospect</th><th>Reply</th><th>Discovery</th>"
+        "<th>Proposal</th><th>Next action</th><th></th>"
+        "</tr></thead><tbody>"
         + "".join(rows)
         + "</tbody></table>"
         if rows
@@ -75,11 +103,14 @@ def deal_index(request: Request) -> str:
     navigation = agency_navigation(identity, current="deals")
     body = (
         f"{navigation}<section><h1>Sales / proposals</h1>"
-        "<p class='muted'>Move real replies through discovery and a bounded, versioned proposal before agreement/payment. This is a record of the sales process; VERIDRA is not the email inbox or signature provider.</p>"
+        "<p class='muted'>Move real replies through discovery and a bounded, "
+        "versioned proposal before agreement/payment. This records the sales process; "
+        "VERIDRA is not the email inbox or signature provider.</p>"
         f"{table}</section>"
     )
     return (
         "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
         "<meta name='viewport' content='width=device-width,initial-scale=1'>"
-        f"<title>Sales / proposals</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+        f"<title>Sales / proposals</title><style>{_STYLE}</style>"
+        f"</head><body><main>{body}</main></body></html>"
     )

--- a/src/veridra/agency_deal_index_web.py
+++ b/src/veridra/agency_deal_index_web.py
@@ -78,6 +78,7 @@ def deal_index(request: Request) -> str:
         next_action = html.escape(prospect.next_action or deal.next_action or "—")
         escaped_id = html.escape(prospect_id, quote=True)
         deal_url = f"/agency/prospects/{escaped_id}/deal"
+        changes_url = f"/agency/prospects/{escaped_id}/deal/change-requests"
         artifact_action = ""
         if latest is not None:
             artifact_url = (
@@ -87,6 +88,11 @@ def deal_index(request: Request) -> str:
             artifact_action = (
                 f"<a class='button secondary' href='{artifact_url}'>Preview proposal</a>"
             )
+        change_label = (
+            f"Scope changes ({len(deal.change_requests)})"
+            if deal.change_requests
+            else "Scope changes"
+        )
         rows.append(
             "<tr>"
             f"<td><strong>{business}</strong><br>"
@@ -97,7 +103,9 @@ def deal_index(request: Request) -> str:
             f"<td>{next_action}</td>"
             "<td><div class='actions'>"
             f"<a class='button' href='{deal_url}'>Open sales workflow</a>"
-            f"{artifact_action}</div></td>"
+            f"{artifact_action}"
+            f"<a class='button secondary' href='{changes_url}'>{change_label}</a>"
+            "</div></td>"
             "</tr>"
         )
     table = (

--- a/src/veridra/agency_deal_index_web.py
+++ b/src/veridra/agency_deal_index_web.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import html
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from .agency_navigation import agency_navigation
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .request_security import require_request_identity
+from .tenant_deal_store import TenantDealStore
+from .tenant_prospect_store import TenantProspectStore
+
+router = APIRouter(tags=["agency-deal-index"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1180px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:9px 12px;text-decoration:none}.muted{color:#68707a}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}table{width:100%;border-collapse:collapse}th,td{padding:11px;text-align:left;border-bottom:1px solid #e5e7eb;vertical-align:top}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:760px){table{display:block;overflow:auto}}
+"""
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+@router.get("/agency/deals", response_class=HTMLResponse)
+def deal_index(request: Request) -> str:
+    identity = _identity(request)
+    root = _root(request)
+    prospects = TenantProspectStore(root).list(identity)
+    deal_store = TenantDealStore(root)
+    rows: list[str] = []
+    for prospect_id, prospect in prospects:
+        deal = deal_store.load_or_empty(identity, prospect_id)
+        reply = deal.reply_outcome.value.replace("_", " ") if deal.reply_outcome else "Not recorded"
+        discovery = "Ready" if deal.discovery is not None else "Not captured"
+        latest = deal.latest_proposal
+        proposal = (
+            f"v{latest.version} · {latest.status.value}"
+            if latest is not None
+            else "No proposal"
+        )
+        rows.append(
+            "<tr>"
+            f"<td><strong>{html.escape(prospect.business_name)}</strong><br><span class='muted'>{html.escape(prospect.status.value)}</span></td>"
+            f"<td>{html.escape(reply.title())}</td>"
+            f"<td>{html.escape(discovery)}</td>"
+            f"<td><span class='badge'>{html.escape(proposal)}</span></td>"
+            f"<td>{html.escape(prospect.next_action or deal.next_action or '—')}</td>"
+            f"<td><a class='button' href='/agency/prospects/{html.escape(prospect_id, quote=True)}/deal'>Open sales workflow</a></td>"
+            "</tr>"
+        )
+    table = (
+        "<table><thead><tr><th>Prospect</th><th>Reply</th><th>Discovery</th><th>Proposal</th><th>Next action</th><th></th></tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+        if rows
+        else "<p class='muted'>No prospects yet. Create or discover a prospect first.</p>"
+    )
+    navigation = agency_navigation(identity, current="deals")
+    body = (
+        f"{navigation}<section><h1>Sales / proposals</h1>"
+        "<p class='muted'>Move real replies through discovery and a bounded, versioned proposal before agreement/payment. This is a record of the sales process; VERIDRA is not the email inbox or signature provider.</p>"
+        f"{table}</section>"
+    )
+    return (
+        "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        f"<title>Sales / proposals</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+    )

--- a/src/veridra/agency_deal_web.py
+++ b/src/veridra/agency_deal_web.py
@@ -1,0 +1,318 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+import os
+from datetime import UTC, date, datetime
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .agency_navigation import agency_navigation
+from .deal_lifecycle import (
+    DiscoveryRequirements,
+    ProposalStatus,
+    ProposalVersion,
+    ReplyOutcome,
+)
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .prospect import Prospect, ProspectStatus
+from .request_security import require_request_identity
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .tenant_deal_store import TenantDealStore, TenantDealStoreError
+from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
+
+router = APIRouter(tags=["agency-deal"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1180px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#247a3c;background:#f2fbf4}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.actions{display:flex;gap:8px;flex-wrap:wrap}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:90px}.proposal{border:1px solid #e1e5ea;border-radius:8px;padding:16px;margin:12px 0}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:760px){.row{grid-template-columns:1fr}}
+"""
+
+
+def _page(title: str, body: str) -> str:
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>{html.escape(title)}</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Sales workflow is not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Sales workflow request is not permitted.") from exc
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _load_prospect(request: Request, identity: RequestIdentity, prospect_id: str) -> Prospect:
+    store = TenantProspectStore(_root(request))
+    try:
+        return store.load(identity, store.ref(identity, prospect_id))
+    except TenantProspectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Prospect not found.") from exc
+
+
+def _sync_prospect(
+    request: Request,
+    identity: RequestIdentity,
+    prospect_id: str,
+    *,
+    status: ProspectStatus,
+    next_action: str,
+) -> None:
+    store = TenantProspectStore(_root(request))
+    prospect = _load_prospect(request, identity, prospect_id)
+    updated = Prospect.model_validate(
+        {
+            **prospect.model_dump(mode="json"),
+            "status": status,
+            "next_action": next_action,
+            "updated_at": datetime.now(UTC),
+        }
+    )
+    try:
+        store.replace(identity, store.ref(identity, prospect_id), updated)
+    except TenantProspectStoreError as exc:
+        raise HTTPException(status_code=409, detail="Prospect stage could not be synchronized.") from exc
+
+
+def _reply_options(current: ReplyOutcome | None) -> str:
+    return "<option value=''>Not recorded</option>" + "".join(
+        f"<option value='{item.value}'{' selected' if current is item else ''}>{item.value.replace('_', ' ').title()}</option>"
+        for item in ReplyOutcome
+    )
+
+
+def _proposal_cards(prospect_id: str, proposals: tuple[ProposalVersion, ...]) -> str:
+    if not proposals:
+        return "<p class='notice'>No proposal versions yet. Complete discovery before creating a bounded quote.</p>"
+    cards: list[str] = []
+    for item in reversed(proposals):
+        recurring = (
+            f" · recurring {item.currency} {item.recurring_amount:.2f} {html.escape(item.recurring_cadence)}"
+            if item.recurring_amount is not None
+            else ""
+        )
+        acceptance = (
+            f"<p><strong>Acceptance evidence:</strong> {html.escape(item.acceptance_reference)}</p>"
+            if item.acceptance_reference
+            else ""
+        )
+        status_options = "".join(
+            f"<option value='{status.value}'{' selected' if item.status is status else ''}>{status.value.title()}</option>"
+            for status in ProposalStatus
+        )
+        cards.append(
+            f"<div class='proposal'><h3>v{item.version} — {html.escape(item.title)} <span class='badge'>{html.escape(item.status.value)}</span></h3>"
+            f"<p><strong>Price:</strong> {html.escape(item.currency)} {item.price_amount:.2f}{recurring}<br><strong>Valid until:</strong> {item.valid_until.isoformat()}<br><strong>Timeline:</strong> {html.escape(item.timeline)}</p>"
+            f"<p><strong>Scope:</strong> {html.escape(item.scope)}</p><p><strong>Deliverables:</strong> {html.escape(item.deliverables)}</p>"
+            f"<p><strong>Exclusions:</strong> {html.escape(item.exclusions or 'None recorded')}</p>{acceptance}"
+            f"<form method='post' action='/agency/prospects/{html.escape(prospect_id, quote=True)}/deal/proposals/{item.version}/status'><div class='row'><div><label>Status</label><select name='status'>{status_options}</select></div><div><label>Acceptance evidence/reference</label><input name='acceptance_reference' maxlength='1000' value='{html.escape(item.acceptance_reference, quote=True)}' placeholder='Required when accepting'></div></div><button type='submit'>Update proposal status</button></form></div>"
+        )
+    return "".join(cards)
+
+
+@router.get("/agency/prospects/{prospect_id}/deal", response_class=HTMLResponse)
+def deal_page(prospect_id: str, request: Request) -> str:
+    identity = _identity(request)
+    prospect = _load_prospect(request, identity, prospect_id)
+    deal = TenantDealStore(_root(request)).load_or_empty(identity, prospect_id)
+    navigation = agency_navigation(identity, current="prospects")
+    discovery = deal.discovery
+    accepted = "<p class='notice success'><strong>Proposal accepted.</strong> Next gate: agreement and payment evidence before work starts.</p>" if deal.has_accepted_proposal else ""
+    body = f"{navigation}<section><p><a href='/agency/prospects/{html.escape(prospect_id, quote=True)}'>← Prospect</a></p><h1>Sales / proposal — {html.escape(prospect.business_name)}</h1><p class='muted'>VERIDRA records the commercial process and evidence. Email/calls and signatures remain external unless explicitly integrated later.</p>{accepted}</section>"
+    body += f"<section><h2>1. Reply / conversation</h2><form method='post' action='/agency/prospects/{html.escape(prospect_id, quote=True)}/deal/reply'><label>Reply outcome</label><select name='reply_outcome'>{_reply_options(deal.reply_outcome)}</select><label>Conversation summary</label><textarea name='conversation_summary' maxlength='4000'>{html.escape(deal.conversation_summary)}</textarea><label>Next action</label><input name='next_action' maxlength='1000' value='{html.escape(deal.next_action, quote=True)}'><button type='submit'>Save reply context</button></form></section>"
+    body += f"<section><h2>2. Discovery / requirements</h2><p class='muted'>Capture facts needed to define a bounded service. Do not store passwords or secrets here.</p><form method='post' action='/agency/prospects/{html.escape(prospect_id, quote=True)}/deal/discovery'><label>Business goals</label><textarea name='goals' required>{html.escape(discovery.goals if discovery else '')}</textarea><div class='row'><div><label>Current platform</label><input name='current_platform' value='{html.escape(discovery.current_platform if discovery else '', quote=True)}'></div><div><label>Hosting</label><input name='hosting' value='{html.escape(discovery.hosting if discovery else '', quote=True)}'></div></div><div class='row'><div><label>Decision maker</label><input name='decision_maker' value='{html.escape(discovery.decision_maker if discovery else '', quote=True)}'></div><div><label>Urgency</label><input name='urgency' value='{html.escape(discovery.urgency if discovery else '', quote=True)}'></div></div><label>Constraints</label><textarea name='constraints'>{html.escape(discovery.constraints if discovery else '')}</textarea><label>Access readiness</label><textarea name='access_readiness'>{html.escape(discovery.access_readiness if discovery else '')}</textarea><label>Measurable scope</label><textarea name='measurable_scope' required>{html.escape(discovery.measurable_scope if discovery else '')}</textarea><label>Deliverables</label><textarea name='deliverables' required>{html.escape(discovery.deliverables if discovery else '')}</textarea><label>Exclusions</label><textarea name='exclusions'>{html.escape(discovery.exclusions if discovery else '')}</textarea><label>Assumptions</label><textarea name='assumptions'>{html.escape(discovery.assumptions if discovery else '')}</textarea><label>Timeline</label><input name='timeline' required value='{html.escape(discovery.timeline if discovery else '', quote=True)}'><button type='submit'>Save discovery</button></form></section>"
+    disabled_note = "" if discovery else "<p class='notice'>Complete discovery before drafting a proposal.</p>"
+    body += f"<section><h2>3. Proposal / quote</h2>{disabled_note}<form method='post' action='/agency/prospects/{html.escape(prospect_id, quote=True)}/deal/proposals'><label>Proposal title</label><input name='title' required placeholder='Website Improvement Sprint'><label>Scope</label><textarea name='scope' required>{html.escape(discovery.measurable_scope if discovery else '')}</textarea><label>Deliverables</label><textarea name='deliverables' required>{html.escape(discovery.deliverables if discovery else '')}</textarea><label>Exclusions</label><textarea name='exclusions'>{html.escape(discovery.exclusions if discovery else '')}</textarea><label>Assumptions</label><textarea name='assumptions'>{html.escape(discovery.assumptions if discovery else '')}</textarea><div class='row'><div><label>Timeline</label><input name='timeline' required value='{html.escape(discovery.timeline if discovery else '', quote=True)}'></div><div><label>Valid until</label><input name='valid_until' type='date' required></div></div><div class='row'><div><label>One-off price</label><input name='price_amount' type='number' step='0.01' min='0.01' required></div><div><label>Currency</label><input name='currency' maxlength='3' placeholder='EUR' required></div></div><div class='row'><div><label>Recurring amount (optional)</label><input name='recurring_amount' type='number' step='0.01' min='0.01'></div><div><label>Recurring cadence</label><input name='recurring_cadence' placeholder='monthly'></div></div><button type='submit'>Create proposal version</button></form>{_proposal_cards(prospect_id, deal.proposals)}</section>"
+    return _page(f"Sales / proposal — {prospect.business_name}", body)
+
+
+@router.post("/agency/prospects/{prospect_id}/deal/reply")
+async def save_reply(prospect_id: str, request: Request) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    _load_prospect(request, identity, prospect_id)
+    values = _values(await request.body())
+    outcome_raw = _one(values, "reply_outcome")
+    try:
+        outcome = ReplyOutcome(outcome_raw) if outcome_raw else None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Unknown reply outcome.") from exc
+    store = TenantDealStore(_root(request))
+    deal = store.load_or_empty(identity, prospect_id).model_copy(
+        update={
+            "reply_outcome": outcome,
+            "conversation_summary": _one(values, "conversation_summary"),
+            "next_action": _one(values, "next_action"),
+        }
+    )
+    try:
+        store.save(identity, deal)
+    except TenantDealStoreError as exc:
+        raise HTTPException(status_code=500, detail="Reply context could not be saved.") from exc
+    if outcome is not None:
+        _sync_prospect(
+            request,
+            identity,
+            prospect_id,
+            status=ProspectStatus.responded,
+            next_action=deal.next_action or "Review reply and complete discovery",
+        )
+    return RedirectResponse(f"/agency/prospects/{prospect_id}/deal", status_code=303)
+
+
+@router.post("/agency/prospects/{prospect_id}/deal/discovery")
+async def save_discovery(prospect_id: str, request: Request) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    _load_prospect(request, identity, prospect_id)
+    values = _values(await request.body())
+    try:
+        discovery = DiscoveryRequirements(
+            goals=_one(values, "goals"),
+            current_platform=_one(values, "current_platform"),
+            hosting=_one(values, "hosting"),
+            decision_maker=_one(values, "decision_maker"),
+            urgency=_one(values, "urgency"),
+            constraints=_one(values, "constraints"),
+            access_readiness=_one(values, "access_readiness"),
+            measurable_scope=_one(values, "measurable_scope"),
+            deliverables=_one(values, "deliverables"),
+            exclusions=_one(values, "exclusions"),
+            assumptions=_one(values, "assumptions"),
+            timeline=_one(values, "timeline"),
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail="Discovery requirements are incomplete.") from exc
+    store = TenantDealStore(_root(request))
+    deal = store.load_or_empty(identity, prospect_id).model_copy(update={"discovery": discovery})
+    store.save(identity, deal)
+    _sync_prospect(
+        request,
+        identity,
+        prospect_id,
+        status=ProspectStatus.conversation,
+        next_action="Prepare bounded proposal/quote",
+    )
+    return RedirectResponse(f"/agency/prospects/{prospect_id}/deal", status_code=303)
+
+
+@router.post("/agency/prospects/{prospect_id}/deal/proposals")
+async def create_proposal(prospect_id: str, request: Request) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    _load_prospect(request, identity, prospect_id)
+    store = TenantDealStore(_root(request))
+    deal = store.load_or_empty(identity, prospect_id)
+    if deal.discovery is None:
+        raise HTTPException(status_code=409, detail="Complete discovery before creating a proposal.")
+    values = _values(await request.body())
+    recurring_raw = _one(values, "recurring_amount")
+    try:
+        proposal = ProposalVersion(
+            version=len(deal.proposals) + 1,
+            title=_one(values, "title"),
+            scope=_one(values, "scope"),
+            deliverables=_one(values, "deliverables"),
+            exclusions=_one(values, "exclusions"),
+            assumptions=_one(values, "assumptions"),
+            timeline=_one(values, "timeline"),
+            price_amount=float(_one(values, "price_amount")),
+            currency=_one(values, "currency").upper(),
+            recurring_amount=float(recurring_raw) if recurring_raw else None,
+            recurring_cadence=_one(values, "recurring_cadence"),
+            valid_until=date.fromisoformat(_one(values, "valid_until")),
+        )
+    except (ValueError, ValidationError) as exc:
+        raise HTTPException(status_code=400, detail="Proposal values are invalid.") from exc
+    store.save(identity, deal.model_copy(update={"proposals": (*deal.proposals, proposal)}))
+    _sync_prospect(
+        request,
+        identity,
+        prospect_id,
+        status=ProspectStatus.proposal,
+        next_action="Review and send proposal externally",
+    )
+    return RedirectResponse(f"/agency/prospects/{prospect_id}/deal", status_code=303)
+
+
+@router.post("/agency/prospects/{prospect_id}/deal/proposals/{version}/status")
+async def update_proposal_status(
+    prospect_id: str,
+    version: int,
+    request: Request,
+) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    store = TenantDealStore(_root(request))
+    deal = store.load_or_empty(identity, prospect_id)
+    values = _values(await request.body())
+    try:
+        next_status = ProposalStatus(_one(values, "status"))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Unknown proposal status.") from exc
+    proposals = list(deal.proposals)
+    for index, proposal in enumerate(proposals):
+        if proposal.version != version:
+            continue
+        try:
+            proposals[index] = ProposalVersion.model_validate(
+                {
+                    **proposal.model_dump(mode="json"),
+                    "status": next_status,
+                    "acceptance_reference": _one(values, "acceptance_reference"),
+                    "updated_at": datetime.now(UTC),
+                }
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Accepted proposals require acceptance evidence/reference.",
+            ) from exc
+        break
+    else:
+        raise HTTPException(status_code=404, detail="Proposal version not found.")
+    store.save(identity, deal.model_copy(update={"proposals": tuple(proposals)}))
+    next_action = (
+        "Complete agreement and payment gate before work starts"
+        if next_status is ProposalStatus.accepted
+        else "Continue proposal follow-up"
+    )
+    _sync_prospect(
+        request,
+        identity,
+        prospect_id,
+        status=ProspectStatus.proposal,
+        next_action=next_action,
+    )
+    return RedirectResponse(f"/agency/prospects/{prospect_id}/deal", status_code=303)

--- a/src/veridra/agency_navigation.py
+++ b/src/veridra/agency_navigation.py
@@ -15,6 +15,7 @@ def agency_navigation(identity: RequestIdentity, *, current: str | None = None) 
     ]
     if TenantCapability.manage_leads in capabilities:
         destinations.append(("prospects", "/agency/prospects", "Prospects"))
+        destinations.append(("deals", "/agency/deals", "Sales / proposals"))
         destinations.append(
             ("prospect-discovery", "/agency/prospects/discover", "Discover prospects")
         )

--- a/src/veridra/agency_proposal_artifact_web.py
+++ b/src/veridra/agency_proposal_artifact_web.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E501
 from __future__ import annotations
 
 import html

--- a/src/veridra/agency_proposal_artifact_web.py
+++ b/src/veridra/agency_proposal_artifact_web.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, Response
+
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .request_security import require_request_identity
+from .tenant_deal_store import TenantDealStore
+from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
+
+router = APIRouter(tags=["agency-proposal-artifact"])
+
+_STYLE = """
+body{margin:0;background:#f5f6f8;color:#17191c;font:15px Arial,sans-serif}
+main{max-width:860px;margin:36px auto;background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:40px}
+h1,h2{margin-top:0}section{margin:28px 0}.meta{display:grid;grid-template-columns:1fr 1fr;gap:12px}.box{border:1px solid #e1e5ea;border-radius:8px;padding:16px}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.price{font-size:24px;font-weight:700}@media(max-width:700px){main{margin:0;border:0;border-radius:0}.meta{grid-template-columns:1fr}}
+"""
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _proposal_html(prospect_id: str, version: int, request: Request) -> tuple[str, str]:
+    identity = _identity(request)
+    root = _root(request)
+    try:
+        prospect = TenantProspectStore(root).load(
+            identity,
+            TenantProspectStore.ref(identity, prospect_id),
+        )
+    except TenantProspectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Prospect not found.") from exc
+    deal = TenantDealStore(root).load_or_empty(identity, prospect_id)
+    proposal = next((item for item in deal.proposals if item.version == version), None)
+    if proposal is None:
+        raise HTTPException(status_code=404, detail="Proposal version not found.")
+
+    recurring = (
+        f"<p><strong>Recurring service:</strong> {html.escape(proposal.currency)} "
+        f"{proposal.recurring_amount:.2f} {html.escape(proposal.recurring_cadence)}</p>"
+        if proposal.recurring_amount is not None
+        else ""
+    )
+    acceptance = (
+        "<section><h2>Acceptance record</h2>"
+        f"<p>{html.escape(proposal.acceptance_reference)}</p></section>"
+        if proposal.acceptance_reference
+        else ""
+    )
+    body = (
+        "<!doctype html><html lang='en'><head><meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+        f"<title>{html.escape(proposal.title)}</title><style>{_STYLE}</style></head><body><main>"
+        "<p class='muted'>Webify Digital Solutions · Proposal / quote</p>"
+        f"<h1>{html.escape(proposal.title)}</h1>"
+        f"<p><strong>Client:</strong> {html.escape(prospect.business_name)}</p>"
+        "<div class='meta'>"
+        f"<div class='box'><strong>Version</strong><br>v{proposal.version}</div>"
+        f"<div class='box'><strong>Status</strong><br>{html.escape(proposal.status.value.title())}</div>"
+        f"<div class='box'><strong>Valid until</strong><br>{proposal.valid_until.isoformat()}</div>"
+        f"<div class='box'><strong>Timeline</strong><br>{html.escape(proposal.timeline)}</div>"
+        "</div>"
+        "<section><h2>Scope</h2>"
+        f"<p>{html.escape(proposal.scope)}</p></section>"
+        "<section><h2>Deliverables</h2>"
+        f"<p>{html.escape(proposal.deliverables)}</p></section>"
+        "<section><h2>Exclusions</h2>"
+        f"<p>{html.escape(proposal.exclusions or 'None recorded')}</p></section>"
+        "<section><h2>Assumptions</h2>"
+        f"<p>{html.escape(proposal.assumptions or 'None recorded')}</p></section>"
+        "<section><h2>Commercial terms</h2>"
+        f"<p class='price'>{html.escape(proposal.currency)} {proposal.price_amount:.2f}</p>"
+        f"{recurring}</section>{acceptance}"
+        "<p class='notice'>This proposal records scope and commercial intent. It is not an "
+        "accounting invoice, payment receipt, or e-signature record. Agreement and payment "
+        "evidence are handled by the next business-cycle gate.</p>"
+        "</main></body></html>"
+    )
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", prospect.business_name).strip("-") or "client"
+    return body, f"{slug}-proposal-v{proposal.version}.html"
+
+
+@router.get(
+    "/agency/prospects/{prospect_id}/deal/proposals/{version}/artifact",
+    response_class=HTMLResponse,
+)
+def proposal_preview(prospect_id: str, version: int, request: Request) -> str:
+    body, _ = _proposal_html(prospect_id, version, request)
+    return body
+
+
+@router.get("/agency/prospects/{prospect_id}/deal/proposals/{version}/download")
+def proposal_download(prospect_id: str, version: int, request: Request) -> Response:
+    body, filename = _proposal_html(prospect_id, version, request)
+    return Response(
+        content=body.encode("utf-8"),
+        media_type="text/html; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/src/veridra/agency_proposal_transition_web.py
+++ b/src/veridra/agency_proposal_transition_web.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, date, datetime
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from pydantic import ValidationError
+
+from .deal_lifecycle import ProposalStatus, ProposalVersion
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .prospect import Prospect, ProspectStatus
+from .request_security import require_request_identity
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .tenant_deal_store import TenantDealStore
+from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
+
+router = APIRouter(tags=["agency-proposal-transition"])
+
+_ALLOWED_TRANSITIONS: dict[ProposalStatus, frozenset[ProposalStatus]] = {
+    ProposalStatus.draft: frozenset({ProposalStatus.draft, ProposalStatus.sent}),
+    ProposalStatus.sent: frozenset(
+        {
+            ProposalStatus.sent,
+            ProposalStatus.accepted,
+            ProposalStatus.declined,
+            ProposalStatus.expired,
+        }
+    ),
+    ProposalStatus.accepted: frozenset({ProposalStatus.accepted}),
+    ProposalStatus.declined: frozenset({ProposalStatus.declined}),
+    ProposalStatus.expired: frozenset({ProposalStatus.expired}),
+}
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Sales workflow is not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Sales workflow request is not permitted.") from exc
+
+
+def _one(body: bytes, name: str) -> str:
+    values = parse_qs(body.decode("utf-8"), keep_blank_values=True)
+    return values.get(name, [""])[0].strip()
+
+
+def _sync_next_action(
+    request: Request,
+    identity: RequestIdentity,
+    prospect_id: str,
+    next_action: str,
+) -> None:
+    store = TenantProspectStore(_root(request))
+    try:
+        prospect = store.load(identity, store.ref(identity, prospect_id))
+        updated = Prospect.model_validate(
+            {
+                **prospect.model_dump(mode="json"),
+                "status": ProspectStatus.proposal,
+                "next_action": next_action,
+                "updated_at": datetime.now(UTC),
+            }
+        )
+        store.replace(identity, store.ref(identity, prospect_id), updated)
+    except TenantProspectStoreError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="Prospect stage could not be synchronized.",
+        ) from exc
+
+
+@router.post("/agency/prospects/{prospect_id}/deal/proposals/{version}/status")
+async def update_proposal_status_strict(
+    prospect_id: str,
+    version: int,
+    request: Request,
+) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    body = await request.body()
+    try:
+        next_status = ProposalStatus(_one(body, "status"))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Unknown proposal status.") from exc
+
+    store = TenantDealStore(_root(request))
+    deal = store.load_or_empty(identity, prospect_id)
+    proposals = list(deal.proposals)
+    for index, proposal in enumerate(proposals):
+        if proposal.version != version:
+            continue
+        if next_status not in _ALLOWED_TRANSITIONS[proposal.status]:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Proposal v{version} cannot move from {proposal.status.value} "
+                    f"to {next_status.value}. Create a new proposal version for changed scope."
+                ),
+            )
+        acceptance_reference = _one(body, "acceptance_reference")
+        if proposal.status is ProposalStatus.accepted:
+            acceptance_reference = proposal.acceptance_reference
+        if next_status is ProposalStatus.accepted and proposal.valid_until < date.today():
+            raise HTTPException(
+                status_code=409,
+                detail="Expired proposal validity cannot be accepted; create a new version.",
+            )
+        try:
+            proposals[index] = ProposalVersion.model_validate(
+                {
+                    **proposal.model_dump(mode="json"),
+                    "status": next_status,
+                    "acceptance_reference": acceptance_reference,
+                    "updated_at": datetime.now(UTC),
+                }
+            )
+        except ValidationError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Accepted proposals require acceptance evidence/reference.",
+            ) from exc
+        break
+    else:
+        raise HTTPException(status_code=404, detail="Proposal version not found.")
+
+    store.save(identity, deal.model_copy(update={"proposals": tuple(proposals)}))
+    next_action = {
+        ProposalStatus.draft: "Review proposal before sending externally",
+        ProposalStatus.sent: "Follow up on proposal before validity expires",
+        ProposalStatus.accepted: "Complete agreement and payment gate before work starts",
+        ProposalStatus.declined: "Record loss reason or create a new scoped version if requested",
+        ProposalStatus.expired: "Create a new proposal version if the opportunity remains active",
+    }[next_status]
+    _sync_next_action(request, identity, prospect_id, next_action)
+    return RedirectResponse(f"/agency/prospects/{prospect_id}/deal", status_code=303)

--- a/src/veridra/agency_proposal_transition_web.py
+++ b/src/veridra/agency_proposal_transition_web.py
@@ -61,7 +61,10 @@ def _trusted_origin(request: Request) -> None:
     try:
         TrustedSameOriginPolicy(configured).validate(request)
     except SameOriginRequestError as exc:
-        raise HTTPException(status_code=403, detail="Sales workflow request is not permitted.") from exc
+        raise HTTPException(
+            status_code=403,
+            detail="Sales workflow request is not permitted.",
+        ) from exc
 
 
 def _one(body: bytes, name: str) -> str:

--- a/src/veridra/agency_reply_transition_web.py
+++ b/src/veridra/agency_reply_transition_web.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
+
+from .deal_lifecycle import ReplyOutcome
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .prospect import Prospect, ProspectStatus
+from .request_security import require_request_identity
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .tenant_deal_store import TenantDealStore, TenantDealStoreError
+from .tenant_prospect_store import TenantProspectStore, TenantProspectStoreError
+
+router = APIRouter(tags=["agency-reply-transition"])
+
+_NEXT_ACTIONS = {
+    ReplyOutcome.positive: "Complete discovery before preparing a scoped proposal",
+    ReplyOutcome.negative: "Record the explicit commercial loss reason and close the opportunity",
+    ReplyOutcome.price_request: "Confirm minimum scope and requirements before quoting a price",
+    ReplyOutcome.call_request: "Schedule and complete the discovery call",
+    ReplyOutcome.different_scope: "Capture the requested scope and assess fit before quoting",
+    ReplyOutcome.no_response: "Set a bounded follow-up date or close as no response",
+}
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _identity(request: Request) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Sales workflow is not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(
+            status_code=403,
+            detail="Sales workflow request is not permitted.",
+        ) from exc
+
+
+def _one(body: bytes, name: str) -> str:
+    values = parse_qs(body.decode("utf-8"), keep_blank_values=True)
+    return values.get(name, [""])[0].strip()
+
+
+@router.post("/agency/prospects/{prospect_id}/deal/reply")
+async def save_reply_with_next_action(
+    prospect_id: str,
+    request: Request,
+) -> RedirectResponse:
+    identity = _identity(request)
+    _trusted_origin(request)
+    root = _root(request)
+    prospect_store = TenantProspectStore(root)
+    try:
+        prospect = prospect_store.load(
+            identity,
+            prospect_store.ref(identity, prospect_id),
+        )
+    except TenantProspectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Prospect not found.") from exc
+
+    body = await request.body()
+    outcome_raw = _one(body, "reply_outcome")
+    if not outcome_raw:
+        raise HTTPException(
+            status_code=400,
+            detail="Choose the observed reply outcome before saving.",
+        )
+    try:
+        outcome = ReplyOutcome(outcome_raw)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Unknown reply outcome.") from exc
+
+    explicit_next_action = _one(body, "next_action")
+    next_action = explicit_next_action or _NEXT_ACTIONS[outcome]
+    deal_store = TenantDealStore(root)
+    deal = deal_store.load_or_empty(identity, prospect_id).model_copy(
+        update={
+            "reply_outcome": outcome,
+            "conversation_summary": _one(body, "conversation_summary"),
+            "next_action": next_action,
+            "updated_at": datetime.now(UTC),
+        }
+    )
+    try:
+        deal_store.save(identity, deal)
+    except TenantDealStoreError as exc:
+        raise HTTPException(status_code=500, detail="Reply context could not be saved.") from exc
+
+    prospect_status = (
+        ProspectStatus.conversation
+        if outcome in {ReplyOutcome.call_request, ReplyOutcome.different_scope}
+        else ProspectStatus.responded
+    )
+    updated = Prospect.model_validate(
+        {
+            **prospect.model_dump(mode="json"),
+            "status": prospect_status,
+            "next_action": next_action,
+            "updated_at": datetime.now(UTC),
+        }
+    )
+    try:
+        prospect_store.replace(identity, prospect_store.ref(identity, prospect_id), updated)
+    except TenantProspectStoreError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="Prospect reply state could not be synchronized.",
+        ) from exc
+    return RedirectResponse(f"/agency/prospects/{prospect_id}/deal", status_code=303)

--- a/src/veridra/deal_lifecycle.py
+++ b/src/veridra/deal_lifecycle.py
@@ -27,6 +27,14 @@ class ProposalStatus(StrEnum):
     expired = "expired"
 
 
+class ChangeRequestStatus(StrEnum):
+    requested = "requested"
+    reviewing = "reviewing"
+    approved = "approved"
+    declined = "declined"
+    incorporated = "incorporated"
+
+
 class DiscoveryRequirements(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
 
@@ -76,6 +84,32 @@ class ProposalVersion(BaseModel):
         return self
 
 
+class ScopeChangeRequest(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    sequence: int = Field(ge=1)
+    status: ChangeRequestStatus = ChangeRequestStatus.requested
+    summary: str = Field(min_length=1, max_length=4000)
+    requested_by: str = Field(default="customer", max_length=240)
+    scope_impact: str = Field(min_length=1, max_length=4000)
+    price_impact: str = Field(default="", max_length=1000)
+    timeline_impact: str = Field(default="", max_length=1000)
+    decision_reference: str = Field(default="", max_length=1000)
+    resulting_proposal_version: int | None = Field(default=None, ge=1)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @model_validator(mode="after")
+    def validate_decision(self) -> ScopeChangeRequest:
+        if self.status in {ChangeRequestStatus.approved, ChangeRequestStatus.declined}:
+            if not self.decision_reference:
+                raise ValueError("Approved/declined change requests require decision evidence.")
+        if self.status is ChangeRequestStatus.incorporated:
+            if self.resulting_proposal_version is None:
+                raise ValueError("Incorporated change requests require a proposal version.")
+        return self
+
+
 class DealRecord(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
 
@@ -85,6 +119,7 @@ class DealRecord(BaseModel):
     next_action: str = Field(default="", max_length=1000)
     discovery: DiscoveryRequirements | None = None
     proposals: tuple[ProposalVersion, ...] = ()
+    change_requests: tuple[ScopeChangeRequest, ...] = ()
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/src/veridra/deal_lifecycle.py
+++ b/src/veridra/deal_lifecycle.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, date, datetime
+from enum import StrEnum
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ReplyOutcome(StrEnum):
+    positive = "positive"
+    negative = "negative"
+    price_request = "price_request"
+    call_request = "call_request"
+    different_scope = "different_scope"
+    no_response = "no_response"
+
+
+class ProposalStatus(StrEnum):
+    draft = "draft"
+    sent = "sent"
+    accepted = "accepted"
+    declined = "declined"
+    expired = "expired"
+
+
+class DiscoveryRequirements(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    goals: str = Field(min_length=1, max_length=4000)
+    current_platform: str = Field(default="", max_length=240)
+    hosting: str = Field(default="", max_length=240)
+    decision_maker: str = Field(default="", max_length=240)
+    urgency: str = Field(default="", max_length=500)
+    constraints: str = Field(default="", max_length=4000)
+    access_readiness: str = Field(default="", max_length=1000)
+    measurable_scope: str = Field(min_length=1, max_length=4000)
+    deliverables: str = Field(min_length=1, max_length=4000)
+    exclusions: str = Field(default="", max_length=4000)
+    assumptions: str = Field(default="", max_length=4000)
+    timeline: str = Field(min_length=1, max_length=1000)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class ProposalVersion(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    version: int = Field(ge=1)
+    status: ProposalStatus = ProposalStatus.draft
+    title: str = Field(min_length=1, max_length=240)
+    scope: str = Field(min_length=1, max_length=4000)
+    deliverables: str = Field(min_length=1, max_length=4000)
+    exclusions: str = Field(default="", max_length=4000)
+    assumptions: str = Field(default="", max_length=4000)
+    timeline: str = Field(min_length=1, max_length=1000)
+    price_amount: float = Field(gt=0, le=10_000_000)
+    currency: str = Field(min_length=3, max_length=3)
+    recurring_amount: float | None = Field(default=None, gt=0, le=10_000_000)
+    recurring_cadence: str = Field(default="", max_length=120)
+    valid_until: date
+    acceptance_reference: str = Field(default="", max_length=1000)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @model_validator(mode="after")
+    def validate_recurring_pair(self) -> ProposalVersion:
+        if self.recurring_amount is not None and not self.recurring_cadence:
+            raise ValueError("Recurring proposals require a cadence.")
+        if self.recurring_amount is None and self.recurring_cadence:
+            raise ValueError("Recurring cadence requires a recurring amount.")
+        if self.status is ProposalStatus.accepted and not self.acceptance_reference:
+            raise ValueError("Accepted proposals require acceptance evidence/reference.")
+        return self
+
+
+class DealRecord(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    prospect_id: str = Field(min_length=24, max_length=24)
+    reply_outcome: ReplyOutcome | None = None
+    conversation_summary: str = Field(default="", max_length=4000)
+    next_action: str = Field(default="", max_length=1000)
+    discovery: DiscoveryRequirements | None = None
+    proposals: tuple[ProposalVersion, ...] = ()
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @property
+    def latest_proposal(self) -> ProposalVersion | None:
+        return self.proposals[-1] if self.proposals else None
+
+    @property
+    def has_accepted_proposal(self) -> bool:
+        return any(item.status is ProposalStatus.accepted for item in self.proposals)
+
+
+class DealStoreError(RuntimeError):
+    pass
+
+
+class DealStore:
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def _path(self, prospect_id: str) -> Path:
+        return self.directory / f"{prospect_id}.json"
+
+    def load(self, prospect_id: str) -> DealRecord:
+        try:
+            return DealRecord.model_validate_json(self._path(prospect_id).read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise DealStoreError("Saved deal record was not found or is invalid.") from exc
+
+    def save(self, record: DealRecord) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        content = json.dumps(
+            record.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        path = self._path(record.prospect_id)
+        with NamedTemporaryFile(
+            mode="wb",
+            dir=self.directory,
+            prefix=f".{record.prospect_id}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(path)

--- a/src/veridra/deal_lifecycle.py
+++ b/src/veridra/deal_lifecycle.py
@@ -110,7 +110,8 @@ class DealStore:
 
     def load(self, prospect_id: str) -> DealRecord:
         try:
-            return DealRecord.model_validate_json(self._path(prospect_id).read_text(encoding="utf-8"))
+            text = self._path(prospect_id).read_text(encoding="utf-8")
+            return DealRecord.model_validate_json(text)
         except (OSError, ValueError) as exc:
             raise DealStoreError("Saved deal record was not found or is invalid.") from exc
 

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -20,6 +20,7 @@ from .agency_monitoring_web import router as agency_monitoring_router
 from .agency_progress_web import router as agency_progress_router
 from .agency_project_customer_web import router as agency_project_customer_router
 from .agency_project_index_web import router as agency_project_index_router
+from .agency_proposal_artifact_web import router as agency_proposal_artifact_router
 from .agency_prospect_discovery_evidence_web import (
     router as agency_prospect_discovery_evidence_router,
 )
@@ -178,6 +179,7 @@ app.include_router(agency_prospect_discovery_router)
 app.include_router(agency_prospect_discovery_evidence_router)
 app.include_router(agency_deal_index_router)
 app.include_router(agency_deal_router)
+app.include_router(agency_proposal_artifact_router)
 app.include_router(agency_prospect_router)
 app.include_router(agency_lead_router)
 app.include_router(agency_lead_form_router)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -21,6 +21,7 @@ from .agency_progress_web import router as agency_progress_router
 from .agency_project_customer_web import router as agency_project_customer_router
 from .agency_project_index_web import router as agency_project_index_router
 from .agency_proposal_artifact_web import router as agency_proposal_artifact_router
+from .agency_proposal_transition_web import router as agency_proposal_transition_router
 from .agency_prospect_discovery_evidence_web import (
     router as agency_prospect_discovery_evidence_router,
 )
@@ -166,8 +167,8 @@ app.include_router(workspace_members_router)
 app.include_router(member_assignments_router)
 app.include_router(agency_workflow_router)
 app.include_router(agency_commercial_dashboard_router)
-# The wrapper routers precede their base routers so they can add customer/project
-# relationship actions without duplicating the established operator pages.
+# The wrapper routers precede their base routers so they can add or tighten operator actions
+# without duplicating the established pages.
 app.include_router(agency_customer_project_router)
 app.include_router(agency_customer_router)
 app.include_router(agency_project_index_router)
@@ -178,6 +179,7 @@ app.include_router(agency_prospect_import_router)
 app.include_router(agency_prospect_discovery_router)
 app.include_router(agency_prospect_discovery_evidence_router)
 app.include_router(agency_deal_index_router)
+app.include_router(agency_proposal_transition_router)
 app.include_router(agency_deal_router)
 app.include_router(agency_proposal_artifact_router)
 app.include_router(agency_prospect_router)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -12,6 +12,7 @@ from .agency_conversion_web import router as agency_conversion_router
 from .agency_crawl_profile_web import router as agency_crawl_profile_router
 from .agency_customer_project_web import router as agency_customer_project_router
 from .agency_customer_web import router as agency_customer_router
+from .agency_deal_web import router as agency_deal_router
 from .agency_lead_form_web import router as agency_lead_form_router
 from .agency_lead_web import router as agency_lead_router
 from .agency_monitoring_web import router as agency_monitoring_router
@@ -174,6 +175,7 @@ app.include_router(agency_crawl_profile_router)
 app.include_router(agency_prospect_import_router)
 app.include_router(agency_prospect_discovery_router)
 app.include_router(agency_prospect_discovery_evidence_router)
+app.include_router(agency_deal_router)
 app.include_router(agency_prospect_router)
 app.include_router(agency_lead_router)
 app.include_router(agency_lead_form_router)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -7,6 +7,7 @@ from . import app as app_module
 from . import public_web
 from .access_logging import StructuredAccessLogMiddleware, configure_access_logger
 from .agency_ai_review_web import router as agency_ai_review_router
+from .agency_change_request_web import router as agency_change_request_router
 from .agency_commercial_dashboard_web import router as agency_commercial_dashboard_router
 from .agency_conversion_web import router as agency_conversion_router
 from .agency_crawl_profile_web import router as agency_crawl_profile_router
@@ -182,6 +183,7 @@ app.include_router(agency_deal_index_router)
 app.include_router(agency_proposal_transition_router)
 app.include_router(agency_deal_router)
 app.include_router(agency_proposal_artifact_router)
+app.include_router(agency_change_request_router)
 app.include_router(agency_prospect_router)
 app.include_router(agency_lead_router)
 app.include_router(agency_lead_form_router)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -12,6 +12,7 @@ from .agency_conversion_web import router as agency_conversion_router
 from .agency_crawl_profile_web import router as agency_crawl_profile_router
 from .agency_customer_project_web import router as agency_customer_project_router
 from .agency_customer_web import router as agency_customer_router
+from .agency_deal_index_web import router as agency_deal_index_router
 from .agency_deal_web import router as agency_deal_router
 from .agency_lead_form_web import router as agency_lead_form_router
 from .agency_lead_web import router as agency_lead_router
@@ -175,6 +176,7 @@ app.include_router(agency_crawl_profile_router)
 app.include_router(agency_prospect_import_router)
 app.include_router(agency_prospect_discovery_router)
 app.include_router(agency_prospect_discovery_evidence_router)
+app.include_router(agency_deal_index_router)
 app.include_router(agency_deal_router)
 app.include_router(agency_prospect_router)
 app.include_router(agency_lead_router)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -7,6 +7,9 @@ from . import app as app_module
 from . import public_web
 from .access_logging import StructuredAccessLogMiddleware, configure_access_logger
 from .agency_ai_review_web import router as agency_ai_review_router
+from .agency_change_request_transition_web import (
+    router as agency_change_request_transition_router,
+)
 from .agency_change_request_web import router as agency_change_request_router
 from .agency_commercial_dashboard_web import router as agency_commercial_dashboard_router
 from .agency_conversion_web import router as agency_conversion_router
@@ -185,6 +188,7 @@ app.include_router(agency_reply_transition_router)
 app.include_router(agency_proposal_transition_router)
 app.include_router(agency_deal_router)
 app.include_router(agency_proposal_artifact_router)
+app.include_router(agency_change_request_transition_router)
 app.include_router(agency_change_request_router)
 app.include_router(agency_prospect_router)
 app.include_router(agency_lead_router)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -29,6 +29,7 @@ from .agency_prospect_discovery_evidence_web import (
 from .agency_prospect_discovery_web import router as agency_prospect_discovery_router
 from .agency_prospect_import_web import router as agency_prospect_import_router
 from .agency_prospect_web import router as agency_prospect_router
+from .agency_reply_transition_web import router as agency_reply_transition_router
 from .agency_report_profile_edit_web import router as agency_report_profile_edit_router
 from .agency_report_profile_web import router as agency_report_profile_router
 from .agency_report_web import router as agency_report_router
@@ -180,6 +181,7 @@ app.include_router(agency_prospect_import_router)
 app.include_router(agency_prospect_discovery_router)
 app.include_router(agency_prospect_discovery_evidence_router)
 app.include_router(agency_deal_index_router)
+app.include_router(agency_reply_transition_router)
 app.include_router(agency_proposal_transition_router)
 app.include_router(agency_deal_router)
 app.include_router(agency_proposal_artifact_router)

--- a/src/veridra/tenant_deal_store.py
+++ b/src/veridra/tenant_deal_store.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .deal_lifecycle import DealRecord, DealStore, DealStoreError
+from .identity_tenancy import RequestIdentity, TenantCapability, require_tenant_capability
+from .tenant_project_store import default_tenant_data_directory
+
+
+class TenantDealStoreError(RuntimeError):
+    pass
+
+
+class TenantDealStore:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or default_tenant_data_directory()
+
+    def _store(self, identity: RequestIdentity) -> DealStore:
+        return DealStore(self.root / identity.tenant_id / "deals")
+
+    def load_or_empty(self, identity: RequestIdentity, prospect_id: str) -> DealRecord:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        try:
+            return self._store(identity).load(prospect_id)
+        except DealStoreError:
+            return DealRecord(prospect_id=prospect_id)
+
+    def save(self, identity: RequestIdentity, record: DealRecord) -> None:
+        require_tenant_capability(identity, TenantCapability.manage_leads)
+        stamped = record.model_copy(update={"updated_at": datetime.now(UTC)})
+        try:
+            self._store(identity).save(stamped)
+        except (OSError, ValueError) as exc:
+            raise TenantDealStoreError("Deal record could not be saved safely.") from exc

--- a/tests/test_agency_change_request_transition_web.py
+++ b/tests/test_agency_change_request_transition_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from datetime import UTC, date, datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 from fastapi import FastAPI, Request
@@ -87,15 +88,18 @@ def _update(
     decision_reference: str = "",
     resulting_proposal_version: str = "",
 ) -> Response:
-    return client.post(
-        f"/agency/prospects/{PROSPECT_ID}/deal/change-requests/1/status",
-        headers={"Origin": ORIGIN},
-        data={
-            "status": status,
-            "decision_reference": decision_reference,
-            "resulting_proposal_version": resulting_proposal_version,
-        },
-        follow_redirects=False,
+    return cast(
+        Response,
+        client.post(
+            f"/agency/prospects/{PROSPECT_ID}/deal/change-requests/1/status",
+            headers={"Origin": ORIGIN},
+            data={
+                "status": status,
+                "decision_reference": decision_reference,
+                "resulting_proposal_version": resulting_proposal_version,
+            },
+            follow_redirects=False,
+        ),
     )
 
 

--- a/tests/test_agency_change_request_transition_web.py
+++ b/tests/test_agency_change_request_transition_web.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi import Response as FastAPIResponse
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from veridra.agency_change_request_transition_web import router as transition_router
 from veridra.deal_lifecycle import (
@@ -85,7 +86,7 @@ def _update(
     *,
     decision_reference: str = "",
     resulting_proposal_version: str = "",
-):
+) -> Response:
     return client.post(
         f"/agency/prospects/{PROSPECT_ID}/deal/change-requests/1/status",
         headers={"Origin": ORIGIN},

--- a/tests/test_agency_change_request_transition_web.py
+++ b/tests/test_agency_change_request_transition_web.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi import Response as FastAPIResponse
+from fastapi.testclient import TestClient
+
+from veridra.agency_change_request_transition_web import router as transition_router
+from veridra.deal_lifecycle import (
+    ChangeRequestStatus,
+    DealRecord,
+    ProposalVersion,
+    ScopeChangeRequest,
+)
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_deal_store import TenantDealStore
+
+ORIGIN = "http://testserver"
+NOW = datetime(2026, 9, 3, 12, 0, tzinfo=UTC)
+PROSPECT_ID = "c" * 24
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id="b" * 24,
+        membership_role=TenantRole.sales,
+        session_id="change-transition-session",
+        authenticated_at=NOW,
+    )
+
+
+def _client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TestClient, RequestIdentity]:
+    identity = _identity()
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path
+
+    @app.middleware("http")
+    async def bind_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[FastAPIResponse]],
+    ) -> FastAPIResponse:
+        bind_verified_request_identity(request, identity)
+        return await call_next(request)
+
+    app.include_router(transition_router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    proposal = ProposalVersion(
+        version=2,
+        title="Revised scope",
+        scope="Original scope plus approved booking form.",
+        deliverables="Website fixes and verification.",
+        timeline="6 business days",
+        price_amount=800,
+        currency="EUR",
+        valid_until=date(2026, 9, 30),
+    )
+    change = ScopeChangeRequest(
+        sequence=1,
+        summary="Add booking form",
+        scope_impact="Adds implementation and verification.",
+    )
+    TenantDealStore(tmp_path).save(
+        identity,
+        DealRecord(
+            prospect_id=PROSPECT_ID,
+            proposals=(proposal,),
+            change_requests=(change,),
+        ),
+    )
+    return TestClient(app), identity
+
+
+def _update(
+    client: TestClient,
+    status: str,
+    *,
+    decision_reference: str = "",
+    resulting_proposal_version: str = "",
+):
+    return client.post(
+        f"/agency/prospects/{PROSPECT_ID}/deal/change-requests/1/status",
+        headers={"Origin": ORIGIN},
+        data={
+            "status": status,
+            "decision_reference": decision_reference,
+            "resulting_proposal_version": resulting_proposal_version,
+        },
+        follow_redirects=False,
+    )
+
+
+def test_change_must_be_approved_before_incorporation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity = _client(tmp_path, monkeypatch)
+
+    premature = _update(client, "incorporated", resulting_proposal_version="2")
+    assert premature.status_code == 409
+
+    approved = _update(
+        client,
+        "approved",
+        decision_reference="Customer approved change by email.",
+    )
+    assert approved.status_code == 303
+
+    incorporated = _update(client, "incorporated", resulting_proposal_version="2")
+    assert incorporated.status_code == 303
+    saved = TenantDealStore(tmp_path).load_or_empty(identity, PROSPECT_ID)
+    assert saved.change_requests[0].status is ChangeRequestStatus.incorporated
+    assert saved.change_requests[0].resulting_proposal_version == 2
+    assert saved.change_requests[0].decision_reference == "Customer approved change by email."
+
+
+def test_incorporation_rejects_unknown_proposal_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _client(tmp_path, monkeypatch)
+    assert (
+        _update(
+            client,
+            "approved",
+            decision_reference="Customer approved change by email.",
+        ).status_code
+        == 303
+    )
+
+    unknown = _update(client, "incorporated", resulting_proposal_version="99")
+    assert unknown.status_code == 409
+
+
+def test_declined_change_is_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity = _client(tmp_path, monkeypatch)
+    declined = _update(
+        client,
+        "declined",
+        decision_reference="Customer declined the additional price.",
+    )
+    assert declined.status_code == 303
+    assert _update(client, "reviewing").status_code == 409
+    saved = TenantDealStore(tmp_path).load_or_empty(identity, PROSPECT_ID)
+    assert saved.change_requests[0].status is ChangeRequestStatus.declined

--- a/tests/test_agency_change_request_web.py
+++ b/tests/test_agency_change_request_web.py
@@ -28,7 +28,7 @@ def _identity() -> RequestIdentity:
         user_id="a" * 24,
         tenant_id="b" * 24,
         membership_role=TenantRole.sales,
-        session_id="change-request-session",
+        session_id="c" * 24,
         authenticated_at=NOW,
     )
 

--- a/tests/test_agency_change_request_web.py
+++ b/tests/test_agency_change_request_web.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi import Response as FastAPIResponse
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from veridra.agency_change_request_web import router as change_request_router
 from veridra.deal_lifecycle import ChangeRequestStatus
@@ -49,18 +50,20 @@ def _client(
 
     app.include_router(change_request_router)
     monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
-    prospect = Prospect(
-        business_name="Scope Change Test Dental",
-        website="https://example.com",
-        locality="Dublin",
-        country_code="IE",
+    prospect = Prospect.model_validate(
+        {
+            "business_name": "Scope Change Test Dental",
+            "website": "https://example.com",
+            "locality": "Dublin",
+            "country_code": "IE",
+        }
     )
     store = TenantProspectStore(tmp_path)
     prospect_id = store.save(identity, prospect)
     return TestClient(app), identity, prospect_id
 
 
-def _create_change(client: TestClient, prospect_id: str):
+def _create_change(client: TestClient, prospect_id: str) -> Response:
     return client.post(
         f"/agency/prospects/{prospect_id}/deal/change-requests",
         headers={"Origin": ORIGIN},
@@ -82,7 +85,7 @@ def _update(
     *,
     decision_reference: str = "",
     resulting_proposal_version: str = "",
-):
+) -> Response:
     return client.post(
         f"/agency/prospects/{prospect_id}/deal/change-requests/1/status",
         headers={"Origin": ORIGIN},

--- a/tests/test_agency_change_request_web.py
+++ b/tests/test_agency_change_request_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 from fastapi import FastAPI, Request
@@ -64,17 +65,20 @@ def _client(
 
 
 def _create_change(client: TestClient, prospect_id: str) -> Response:
-    return client.post(
-        f"/agency/prospects/{prospect_id}/deal/change-requests",
-        headers={"Origin": ORIGIN},
-        data={
-            "summary": "Add a second booking form to the agreed sprint.",
-            "requested_by": "customer",
-            "scope_impact": "Adds one form implementation and verification step.",
-            "price_impact": "+ EUR 150",
-            "timeline_impact": "+ 1 business day",
-        },
-        follow_redirects=False,
+    return cast(
+        Response,
+        client.post(
+            f"/agency/prospects/{prospect_id}/deal/change-requests",
+            headers={"Origin": ORIGIN},
+            data={
+                "summary": "Add a second booking form to the agreed sprint.",
+                "requested_by": "customer",
+                "scope_impact": "Adds one form implementation and verification step.",
+                "price_impact": "+ EUR 150",
+                "timeline_impact": "+ 1 business day",
+            },
+            follow_redirects=False,
+        ),
     )
 
 
@@ -86,15 +90,18 @@ def _update(
     decision_reference: str = "",
     resulting_proposal_version: str = "",
 ) -> Response:
-    return client.post(
-        f"/agency/prospects/{prospect_id}/deal/change-requests/1/status",
-        headers={"Origin": ORIGIN},
-        data={
-            "status": status,
-            "decision_reference": decision_reference,
-            "resulting_proposal_version": resulting_proposal_version,
-        },
-        follow_redirects=False,
+    return cast(
+        Response,
+        client.post(
+            f"/agency/prospects/{prospect_id}/deal/change-requests/1/status",
+            headers={"Origin": ORIGIN},
+            data={
+                "status": status,
+                "decision_reference": decision_reference,
+                "resulting_proposal_version": resulting_proposal_version,
+            },
+            follow_redirects=False,
+        ),
     )
 
 

--- a/tests/test_agency_change_request_web.py
+++ b/tests/test_agency_change_request_web.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi import Response as FastAPIResponse
+from fastapi.testclient import TestClient
+
+from veridra.agency_change_request_web import router as change_request_router
+from veridra.deal_lifecycle import ChangeRequestStatus
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.prospect import Prospect
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_deal_store import TenantDealStore
+from veridra.tenant_prospect_store import TenantProspectStore
+
+ORIGIN = "http://testserver"
+NOW = datetime(2026, 9, 3, 11, 0, tzinfo=UTC)
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id="b" * 24,
+        membership_role=TenantRole.sales,
+        session_id="change-request-session",
+        authenticated_at=NOW,
+    )
+
+
+def _client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TestClient, RequestIdentity, str]:
+    identity = _identity()
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path
+
+    @app.middleware("http")
+    async def bind_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[FastAPIResponse]],
+    ) -> FastAPIResponse:
+        bind_verified_request_identity(request, identity)
+        return await call_next(request)
+
+    app.include_router(change_request_router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    prospect = Prospect(
+        business_name="Scope Change Test Dental",
+        website="https://example.com",
+        locality="Dublin",
+        country_code="IE",
+    )
+    store = TenantProspectStore(tmp_path)
+    prospect_id = store.save(identity, prospect)
+    return TestClient(app), identity, prospect_id
+
+
+def _create_change(client: TestClient, prospect_id: str):
+    return client.post(
+        f"/agency/prospects/{prospect_id}/deal/change-requests",
+        headers={"Origin": ORIGIN},
+        data={
+            "summary": "Add a second booking form to the agreed sprint.",
+            "requested_by": "customer",
+            "scope_impact": "Adds one form implementation and verification step.",
+            "price_impact": "+ EUR 150",
+            "timeline_impact": "+ 1 business day",
+        },
+        follow_redirects=False,
+    )
+
+
+def _update(
+    client: TestClient,
+    prospect_id: str,
+    status: str,
+    *,
+    decision_reference: str = "",
+    resulting_proposal_version: str = "",
+):
+    return client.post(
+        f"/agency/prospects/{prospect_id}/deal/change-requests/1/status",
+        headers={"Origin": ORIGIN},
+        data={
+            "status": status,
+            "decision_reference": decision_reference,
+            "resulting_proposal_version": resulting_proposal_version,
+        },
+        follow_redirects=False,
+    )
+
+
+def test_change_request_records_scope_price_and_timeline_impact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity, prospect_id = _client(tmp_path, monkeypatch)
+
+    created = _create_change(client, prospect_id)
+    assert created.status_code == 303
+
+    deal = TenantDealStore(tmp_path).load_or_empty(identity, prospect_id)
+    assert len(deal.change_requests) == 1
+    change = deal.change_requests[0]
+    assert change.status is ChangeRequestStatus.requested
+    assert change.price_impact == "+ EUR 150"
+    assert change.timeline_impact == "+ 1 business day"
+    assert deal.next_action == "Review scope, price and timeline impact"
+
+    page = client.get(f"/agency/prospects/{prospect_id}/deal/change-requests")
+    assert page.status_code == 200
+    assert "Add a second booking form" in page.text
+    assert "new proposal version" in page.text
+
+
+def test_approved_change_requires_decision_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity, prospect_id = _client(tmp_path, monkeypatch)
+    assert _create_change(client, prospect_id).status_code == 303
+
+    missing = _update(client, prospect_id, "approved")
+    assert missing.status_code == 400
+
+    approved = _update(
+        client,
+        prospect_id,
+        "approved",
+        decision_reference="Customer approved +EUR150 scope change by email.",
+    )
+    assert approved.status_code == 303
+    saved = TenantDealStore(tmp_path).load_or_empty(identity, prospect_id)
+    assert saved.change_requests[0].status is ChangeRequestStatus.approved
+    assert "approved" in saved.change_requests[0].decision_reference.lower()
+
+
+def test_incorporated_change_requires_resulting_proposal_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity, prospect_id = _client(tmp_path, monkeypatch)
+    assert _create_change(client, prospect_id).status_code == 303
+
+    missing_version = _update(client, prospect_id, "incorporated")
+    assert missing_version.status_code == 400
+
+    incorporated = _update(
+        client,
+        prospect_id,
+        "incorporated",
+        resulting_proposal_version="2",
+    )
+    assert incorporated.status_code == 303
+    saved = TenantDealStore(tmp_path).load_or_empty(identity, prospect_id)
+    assert saved.change_requests[0].status is ChangeRequestStatus.incorporated
+    assert saved.change_requests[0].resulting_proposal_version == 2

--- a/tests/test_agency_deal_web.py
+++ b/tests/test_agency_deal_web.py
@@ -27,7 +27,7 @@ def _identity() -> RequestIdentity:
         user_id="a" * 24,
         tenant_id="b" * 24,
         membership_role=TenantRole.sales,
-        session_id="deal-workflow-session",
+        session_id="d" * 24,
         authenticated_at=NOW,
     )
 

--- a/tests/test_agency_deal_web.py
+++ b/tests/test_agency_deal_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 from fastapi import FastAPI, Request
@@ -67,7 +68,7 @@ def _create_prospect(client: TestClient) -> str:
         follow_redirects=False,
     )
     assert response.status_code == 303
-    return response.headers["location"].rsplit("/", 1)[-1]
+    return cast(str, response.headers["location"].rsplit("/", 1)[-1])
 
 
 def test_positive_reply_discovery_and_accepted_proposal_are_persistent(

--- a/tests/test_agency_deal_web.py
+++ b/tests/test_agency_deal_web.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi import Response as FastAPIResponse
+from fastapi.testclient import TestClient
+
+from veridra.agency_deal_web import router as agency_deal_router
+from veridra.agency_prospect_web import router as agency_prospect_router
+from veridra.deal_lifecycle import ProposalStatus, ReplyOutcome
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_deal_store import TenantDealStore
+from veridra.tenant_prospect_store import TenantProspectStore
+
+ORIGIN = "http://testserver"
+NOW = datetime(2026, 9, 3, 9, 0, tzinfo=UTC)
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id="b" * 24,
+        membership_role=TenantRole.sales,
+        session_id="deal-workflow-session",
+        authenticated_at=NOW,
+    )
+
+
+def _client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient, RequestIdentity]:
+    identity = _identity()
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path
+
+    @app.middleware("http")
+    async def bind_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[FastAPIResponse]],
+    ) -> FastAPIResponse:
+        bind_verified_request_identity(request, identity)
+        return await call_next(request)
+
+    app.include_router(agency_deal_router)
+    app.include_router(agency_prospect_router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    return TestClient(app), identity
+
+
+def _create_prospect(client: TestClient) -> str:
+    response = client.post(
+        "/agency/prospects/new",
+        headers={"Origin": ORIGIN},
+        data={
+            "business_name": "Lifecycle Test Dental",
+            "website": "https://example.com",
+            "sector": "Dental clinic",
+            "locality": "Dublin",
+            "administrative_area": "Dublin",
+            "country_code": "IE",
+            "contact_email": "owner@example.com",
+            "evidence_summary": "Synthetic sales lifecycle acceptance fixture.",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    return response.headers["location"].rsplit("/", 1)[-1]
+
+
+def test_positive_reply_discovery_and_accepted_proposal_are_persistent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity = _client(tmp_path, monkeypatch)
+    prospect_id = _create_prospect(client)
+
+    reply = client.post(
+        f"/agency/prospects/{prospect_id}/deal/reply",
+        headers={"Origin": ORIGIN},
+        data={
+            "reply_outcome": "positive",
+            "conversation_summary": "Owner asked for a clear scope and price.",
+            "next_action": "Run a 20-minute discovery call",
+        },
+        follow_redirects=False,
+    )
+    assert reply.status_code == 303
+
+    discovery = client.post(
+        f"/agency/prospects/{prospect_id}/deal/discovery",
+        headers={"Origin": ORIGIN},
+        data={
+            "goals": "Reduce mobile booking friction and improve trust.",
+            "current_platform": "WordPress",
+            "hosting": "External managed host",
+            "decision_maker": "Clinic owner",
+            "urgency": "This month",
+            "constraints": "No booking-platform replacement.",
+            "access_readiness": "Admin access can be provided after booking.",
+            "measurable_scope": "Fix agreed mobile and trust issues on current site.",
+            "deliverables": "Audit, bounded fixes, verification, final report.",
+            "exclusions": "Copywriting and booking-system replacement.",
+            "assumptions": "Existing hosting remains in place.",
+            "timeline": "5 business days after access",
+        },
+        follow_redirects=False,
+    )
+    assert discovery.status_code == 303
+
+    proposal = client.post(
+        f"/agency/prospects/{prospect_id}/deal/proposals",
+        headers={"Origin": ORIGIN},
+        data={
+            "title": "Website Improvement Sprint",
+            "scope": "Fix agreed mobile and trust issues on current site.",
+            "deliverables": "Audit, bounded fixes, verification, final report.",
+            "exclusions": "Copywriting and booking-system replacement.",
+            "assumptions": "Existing hosting remains in place.",
+            "timeline": "5 business days after access",
+            "price_amount": "650.00",
+            "currency": "EUR",
+            "recurring_amount": "99.00",
+            "recurring_cadence": "monthly",
+            "valid_until": "2026-09-17",
+        },
+        follow_redirects=False,
+    )
+    assert proposal.status_code == 303
+
+    missing_evidence = client.post(
+        f"/agency/prospects/{prospect_id}/deal/proposals/1/status",
+        headers={"Origin": ORIGIN},
+        data={"status": "accepted", "acceptance_reference": ""},
+        follow_redirects=False,
+    )
+    assert missing_evidence.status_code == 400
+
+    accepted = client.post(
+        f"/agency/prospects/{prospect_id}/deal/proposals/1/status",
+        headers={"Origin": ORIGIN},
+        data={
+            "status": "accepted",
+            "acceptance_reference": "Customer accepted proposal v1 by email on 2026-09-03",
+        },
+        follow_redirects=False,
+    )
+    assert accepted.status_code == 303
+
+    deal = TenantDealStore(tmp_path).load_or_empty(identity, prospect_id)
+    prospect_saved = TenantProspectStore(tmp_path).load(
+        identity,
+        TenantProspectStore.ref(identity, prospect_id),
+    )
+    assert deal.reply_outcome is ReplyOutcome.positive
+    assert deal.discovery is not None
+    assert deal.discovery.current_platform == "WordPress"
+    assert len(deal.proposals) == 1
+    assert deal.proposals[0].status is ProposalStatus.accepted
+    assert deal.has_accepted_proposal is True
+    assert prospect_saved.status.value == "proposal"
+    assert "agreement and payment" in prospect_saved.next_action.lower()
+
+    page = client.get(f"/agency/prospects/{prospect_id}/deal")
+    assert page.status_code == 200
+    assert "Sales / proposal" in page.text
+    assert "Proposal accepted" in page.text
+    assert "agreement and payment evidence before work starts" in page.text
+
+
+def test_proposal_requires_discovery_first(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = _client(tmp_path, monkeypatch)
+    prospect_id = _create_prospect(client)
+
+    response = client.post(
+        f"/agency/prospects/{prospect_id}/deal/proposals",
+        headers={"Origin": ORIGIN},
+        data={
+            "title": "Premature quote",
+            "scope": "Unknown",
+            "deliverables": "Unknown",
+            "timeline": "Unknown",
+            "price_amount": "650",
+            "currency": "EUR",
+            "valid_until": "2026-09-17",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 409

--- a/tests/test_agency_proposal_artifact_web.py
+++ b/tests/test_agency_proposal_artifact_web.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi import Response as FastAPIResponse
+from fastapi.testclient import TestClient
+
+from veridra.agency_proposal_artifact_web import router as proposal_artifact_router
+from veridra.deal_lifecycle import DealRecord, ProposalStatus, ProposalVersion
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.prospect import Prospect
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_deal_store import TenantDealStore
+from veridra.tenant_prospect_store import TenantProspectStore
+
+NOW = datetime(2026, 9, 3, 10, 0, tzinfo=UTC)
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id="b" * 24,
+        membership_role=TenantRole.sales,
+        session_id="proposal-artifact-session",
+        authenticated_at=NOW,
+    )
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, RequestIdentity, str]:
+    identity = _identity()
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path
+
+    @app.middleware("http")
+    async def bind_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[FastAPIResponse]],
+    ) -> FastAPIResponse:
+        bind_verified_request_identity(request, identity)
+        return await call_next(request)
+
+    app.include_router(proposal_artifact_router)
+    prospect = Prospect(
+        business_name="International Dental Test",
+        website="https://example.com",
+        locality="Dublin",
+        country_code="IE",
+    )
+    prospect_store = TenantProspectStore(tmp_path)
+    prospect_id = prospect_store.save(identity, prospect)
+    proposal = ProposalVersion(
+        version=1,
+        status=ProposalStatus.accepted,
+        title="Website Improvement Sprint",
+        scope="Fix agreed mobile booking and trust issues.",
+        deliverables="Bounded fixes, verification and final report.",
+        exclusions="Booking platform replacement.",
+        assumptions="Existing hosting remains in place.",
+        timeline="5 business days after access",
+        price_amount=650.0,
+        currency="EUR",
+        recurring_amount=99.0,
+        recurring_cadence="monthly",
+        valid_until=date(2026, 9, 17),
+        acceptance_reference="Accepted externally by email on 2026-09-03.",
+    )
+    TenantDealStore(tmp_path).save(
+        identity,
+        DealRecord(prospect_id=prospect_id, proposals=(proposal,)),
+    )
+    return TestClient(app), identity, prospect_id
+
+
+def test_proposal_preview_is_customer_readable_and_boundary_explicit(tmp_path: Path) -> None:
+    client, _, prospect_id = _client(tmp_path)
+    response = client.get(
+        f"/agency/prospects/{prospect_id}/deal/proposals/1/artifact"
+    )
+
+    assert response.status_code == 200
+    assert "Website Improvement Sprint" in response.text
+    assert "International Dental Test" in response.text
+    assert "EUR 650.00" in response.text
+    assert "EUR 99.00 monthly" in response.text
+    assert "Accepted externally by email" in response.text
+    assert "not an accounting invoice" in response.text
+    assert "payment receipt" in response.text
+
+
+def test_proposal_download_has_safe_attachment_filename(tmp_path: Path) -> None:
+    client, _, prospect_id = _client(tmp_path)
+    response = client.get(
+        f"/agency/prospects/{prospect_id}/deal/proposals/1/download"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    disposition = response.headers["content-disposition"]
+    assert "attachment" in disposition
+    assert "International-Dental-Test-proposal-v1.html" in disposition

--- a/tests/test_agency_proposal_artifact_web.py
+++ b/tests/test_agency_proposal_artifact_web.py
@@ -43,11 +43,13 @@ def _client(tmp_path: Path) -> tuple[TestClient, RequestIdentity, str]:
         return await call_next(request)
 
     app.include_router(proposal_artifact_router)
-    prospect = Prospect(
-        business_name="International Dental Test",
-        website="https://example.com",
-        locality="Dublin",
-        country_code="IE",
+    prospect = Prospect.model_validate(
+        {
+            "business_name": "International Dental Test",
+            "website": "https://example.com",
+            "locality": "Dublin",
+            "country_code": "IE",
+        }
     )
     prospect_store = TenantProspectStore(tmp_path)
     prospect_id = prospect_store.save(identity, prospect)

--- a/tests/test_agency_proposal_transition_web.py
+++ b/tests/test_agency_proposal_transition_web.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi import Response as FastAPIResponse
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from veridra.agency_proposal_transition_web import router as transition_router
 from veridra.deal_lifecycle import DealRecord, ProposalStatus, ProposalVersion
@@ -49,11 +50,13 @@ def _client(
 
     app.include_router(transition_router)
     monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
-    prospect = Prospect(
-        business_name="Transition Test Dental",
-        website="https://example.com",
-        locality="Dublin",
-        country_code="IE",
+    prospect = Prospect.model_validate(
+        {
+            "business_name": "Transition Test Dental",
+            "website": "https://example.com",
+            "locality": "Dublin",
+            "country_code": "IE",
+        }
     )
     prospect_store = TenantProspectStore(tmp_path)
     prospect_id = prospect_store.save(identity, prospect)
@@ -79,7 +82,7 @@ def _status(
     prospect_id: str,
     status: str,
     acceptance_reference: str = "",
-):
+) -> Response:
     return client.post(
         f"/agency/prospects/{prospect_id}/deal/proposals/1/status",
         headers={"Origin": ORIGIN},

--- a/tests/test_agency_proposal_transition_web.py
+++ b/tests/test_agency_proposal_transition_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from datetime import UTC, date, datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 from fastapi import FastAPI, Request
@@ -83,14 +84,17 @@ def _status(
     status: str,
     acceptance_reference: str = "",
 ) -> Response:
-    return client.post(
-        f"/agency/prospects/{prospect_id}/deal/proposals/1/status",
-        headers={"Origin": ORIGIN},
-        data={
-            "status": status,
-            "acceptance_reference": acceptance_reference,
-        },
-        follow_redirects=False,
+    return cast(
+        Response,
+        client.post(
+            f"/agency/prospects/{prospect_id}/deal/proposals/1/status",
+            headers={"Origin": ORIGIN},
+            data={
+                "status": status,
+                "acceptance_reference": acceptance_reference,
+            },
+            follow_redirects=False,
+        ),
     )
 
 

--- a/tests/test_agency_proposal_transition_web.py
+++ b/tests/test_agency_proposal_transition_web.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi import Response as FastAPIResponse
+from fastapi.testclient import TestClient
+
+from veridra.agency_proposal_transition_web import router as transition_router
+from veridra.deal_lifecycle import DealRecord, ProposalStatus, ProposalVersion
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.prospect import Prospect
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_deal_store import TenantDealStore
+from veridra.tenant_prospect_store import TenantProspectStore
+
+ORIGIN = "http://testserver"
+NOW = datetime(2026, 9, 3, 10, 30, tzinfo=UTC)
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id="b" * 24,
+        membership_role=TenantRole.sales,
+        session_id="proposal-transition-session",
+        authenticated_at=NOW,
+    )
+
+
+def _client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TestClient, RequestIdentity, str]:
+    identity = _identity()
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path
+
+    @app.middleware("http")
+    async def bind_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[FastAPIResponse]],
+    ) -> FastAPIResponse:
+        bind_verified_request_identity(request, identity)
+        return await call_next(request)
+
+    app.include_router(transition_router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    prospect = Prospect(
+        business_name="Transition Test Dental",
+        website="https://example.com",
+        locality="Dublin",
+        country_code="IE",
+    )
+    prospect_store = TenantProspectStore(tmp_path)
+    prospect_id = prospect_store.save(identity, prospect)
+    proposal = ProposalVersion(
+        version=1,
+        title="Website Improvement Sprint",
+        scope="Bounded website fixes.",
+        deliverables="Fixes and verification report.",
+        timeline="5 business days",
+        price_amount=650.0,
+        currency="EUR",
+        valid_until=date(2026, 9, 30),
+    )
+    TenantDealStore(tmp_path).save(
+        identity,
+        DealRecord(prospect_id=prospect_id, proposals=(proposal,)),
+    )
+    return TestClient(app), identity, prospect_id
+
+
+def _status(
+    client: TestClient,
+    prospect_id: str,
+    status: str,
+    acceptance_reference: str = "",
+):
+    return client.post(
+        f"/agency/prospects/{prospect_id}/deal/proposals/1/status",
+        headers={"Origin": ORIGIN},
+        data={
+            "status": status,
+            "acceptance_reference": acceptance_reference,
+        },
+        follow_redirects=False,
+    )
+
+
+def test_proposal_requires_sent_before_acceptance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity, prospect_id = _client(tmp_path, monkeypatch)
+
+    premature = _status(
+        client,
+        prospect_id,
+        "accepted",
+        "Accepted externally by email.",
+    )
+    assert premature.status_code == 409
+
+    sent = _status(client, prospect_id, "sent")
+    assert sent.status_code == 303
+    accepted = _status(
+        client,
+        prospect_id,
+        "accepted",
+        "Accepted externally by email.",
+    )
+    assert accepted.status_code == 303
+
+    saved = TenantDealStore(tmp_path).load_or_empty(identity, prospect_id)
+    assert saved.proposals[0].status is ProposalStatus.accepted
+    assert saved.proposals[0].acceptance_reference == "Accepted externally by email."
+
+
+def test_terminal_proposal_cannot_be_rewritten(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity, prospect_id = _client(tmp_path, monkeypatch)
+    assert _status(client, prospect_id, "sent").status_code == 303
+    assert _status(client, prospect_id, "declined").status_code == 303
+
+    reopened = _status(client, prospect_id, "sent")
+    assert reopened.status_code == 409
+    saved = TenantDealStore(tmp_path).load_or_empty(identity, prospect_id)
+    assert saved.proposals[0].status is ProposalStatus.declined
+
+
+def test_sent_proposal_can_expire_but_not_reopen(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, identity, prospect_id = _client(tmp_path, monkeypatch)
+    assert _status(client, prospect_id, "sent").status_code == 303
+    assert _status(client, prospect_id, "expired").status_code == 303
+    assert _status(client, prospect_id, "sent").status_code == 409
+
+    saved = TenantDealStore(tmp_path).load_or_empty(identity, prospect_id)
+    assert saved.proposals[0].status is ProposalStatus.expired

--- a/tests/test_agency_reply_transition_web.py
+++ b/tests/test_agency_reply_transition_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import pytest
 from fastapi import FastAPI, Request
@@ -64,15 +65,18 @@ def _client(
 
 
 def _reply(client: TestClient, prospect_id: str, outcome: str) -> Response:
-    return client.post(
-        f"/agency/prospects/{prospect_id}/deal/reply",
-        headers={"Origin": ORIGIN},
-        data={
-            "reply_outcome": outcome,
-            "conversation_summary": "Synthetic reply evidence.",
-            "next_action": "",
-        },
-        follow_redirects=False,
+    return cast(
+        Response,
+        client.post(
+            f"/agency/prospects/{prospect_id}/deal/reply",
+            headers={"Origin": ORIGIN},
+            data={
+                "reply_outcome": outcome,
+                "conversation_summary": "Synthetic reply evidence.",
+                "next_action": "",
+            },
+            follow_redirects=False,
+        ),
     )
 
 

--- a/tests/test_agency_reply_transition_web.py
+++ b/tests/test_agency_reply_transition_web.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi import Response as FastAPIResponse
+from fastapi.testclient import TestClient
+
+from veridra.agency_reply_transition_web import router as reply_router
+from veridra.deal_lifecycle import ReplyOutcome
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.prospect import Prospect, ProspectStatus
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_deal_store import TenantDealStore
+from veridra.tenant_prospect_store import TenantProspectStore
+
+ORIGIN = "http://testserver"
+NOW = datetime(2026, 9, 3, 11, 30, tzinfo=UTC)
+
+
+def _identity() -> RequestIdentity:
+    return RequestIdentity(
+        user_id="a" * 24,
+        tenant_id="b" * 24,
+        membership_role=TenantRole.sales,
+        session_id="reply-transition-session",
+        authenticated_at=NOW,
+    )
+
+
+def _client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TestClient, RequestIdentity, str]:
+    identity = _identity()
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = tmp_path
+
+    @app.middleware("http")
+    async def bind_identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[FastAPIResponse]],
+    ) -> FastAPIResponse:
+        bind_verified_request_identity(request, identity)
+        return await call_next(request)
+
+    app.include_router(reply_router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    store = TenantProspectStore(tmp_path)
+    prospect_id = store.save(
+        identity,
+        Prospect(
+            business_name="Reply Test Dental",
+            website="https://example.com",
+            locality="Dublin",
+            country_code="IE",
+        ),
+    )
+    return TestClient(app), identity, prospect_id
+
+
+def _reply(client: TestClient, prospect_id: str, outcome: str):
+    return client.post(
+        f"/agency/prospects/{prospect_id}/deal/reply",
+        headers={"Origin": ORIGIN},
+        data={
+            "reply_outcome": outcome,
+            "conversation_summary": "Synthetic reply evidence.",
+            "next_action": "",
+        },
+        follow_redirects=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected_fragment", "expected_status"),
+    [
+        ("positive", "complete discovery", ProspectStatus.responded),
+        ("negative", "loss reason", ProspectStatus.responded),
+        ("price_request", "before quoting", ProspectStatus.responded),
+        ("call_request", "discovery call", ProspectStatus.conversation),
+        ("different_scope", "assess fit", ProspectStatus.conversation),
+        ("no_response", "follow-up date", ProspectStatus.responded),
+    ],
+)
+def test_reply_outcomes_drive_specific_operator_next_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    outcome: str,
+    expected_fragment: str,
+    expected_status: ProspectStatus,
+) -> None:
+    client, identity, prospect_id = _client(tmp_path, monkeypatch)
+
+    response = _reply(client, prospect_id, outcome)
+    assert response.status_code == 303
+
+    deal = TenantDealStore(tmp_path).load_or_empty(identity, prospect_id)
+    prospect = TenantProspectStore(tmp_path).load(
+        identity,
+        TenantProspectStore.ref(identity, prospect_id),
+    )
+    assert deal.reply_outcome is ReplyOutcome(outcome)
+    assert expected_fragment in deal.next_action.lower()
+    assert prospect.status is expected_status
+    assert prospect.next_action == deal.next_action
+
+
+def test_reply_requires_observed_outcome(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _, prospect_id = _client(tmp_path, monkeypatch)
+    response = _reply(client, prospect_id, "")
+    assert response.status_code == 400

--- a/tests/test_agency_reply_transition_web.py
+++ b/tests/test_agency_reply_transition_web.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi import Response as FastAPIResponse
 from fastapi.testclient import TestClient
+from httpx import Response
 
 from veridra.agency_reply_transition_web import router as reply_router
 from veridra.deal_lifecycle import ReplyOutcome
@@ -50,19 +51,19 @@ def _client(
     app.include_router(reply_router)
     monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
     store = TenantProspectStore(tmp_path)
-    prospect_id = store.save(
-        identity,
-        Prospect(
-            business_name="Reply Test Dental",
-            website="https://example.com",
-            locality="Dublin",
-            country_code="IE",
-        ),
+    prospect = Prospect.model_validate(
+        {
+            "business_name": "Reply Test Dental",
+            "website": "https://example.com",
+            "locality": "Dublin",
+            "country_code": "IE",
+        }
     )
+    prospect_id = store.save(identity, prospect)
     return TestClient(app), identity, prospect_id
 
 
-def _reply(client: TestClient, prospect_id: str, outcome: str):
+def _reply(client: TestClient, prospect_id: str, outcome: str) -> Response:
     return client.post(
         f"/agency/prospects/{prospect_id}/deal/reply",
         headers={"Origin": ORIGIN},

--- a/tools/sales_contract_acceptance.py
+++ b/tools/sales_contract_acceptance.py
@@ -160,6 +160,9 @@ def _next_action(page: Page) -> str:
 
 def _discovery(page: Page, prospect_url: str) -> None:
     page.goto(f"{prospect_url}/deal", wait_until="domcontentloaded")
+    form = page.locator(f"form[action='{prospect_url.replace(page.url.split('/agency/prospects/')[0], '')}/deal/discovery']")
+    if form.count() != 1:
+        form = page.locator("form[action$='/deal/discovery']")
     values = {
         "goals": "Reduce mobile booking friction and improve trust.",
         "current_platform": "WordPress",
@@ -175,8 +178,8 @@ def _discovery(page: Page, prospect_url: str) -> None:
         "timeline": "5 business days after access",
     }
     for name, value in values.items():
-        page.locator(f"[name='{name}']").fill(value)
-    page.get_by_role("button", name="Save discovery").click()
+        form.locator(f"[name='{name}']").fill(value)
+    form.get_by_role("button", name="Save discovery").click()
     page.wait_for_url(f"{prospect_url}/deal")
 
 
@@ -274,7 +277,7 @@ def run() -> Path:
     output.mkdir(parents=True)
     report: dict[str, Any] = {
         "contract": "veridra_sales_contract_acceptance",
-        "version": "1.4",
+        "version": "1.5",
         "started_at": datetime.now(UTC).isoformat(),
         "passed": False,
         "steps": [],

--- a/tools/sales_contract_acceptance.py
+++ b/tools/sales_contract_acceptance.py
@@ -160,9 +160,7 @@ def _next_action(page: Page) -> str:
 
 def _discovery(page: Page, prospect_url: str) -> None:
     page.goto(f"{prospect_url}/deal", wait_until="domcontentloaded")
-    form = page.locator(f"form[action='{prospect_url.replace(page.url.split('/agency/prospects/')[0], '')}/deal/discovery']")
-    if form.count() != 1:
-        form = page.locator("form[action$='/deal/discovery']")
+    form = page.locator("form[action$='/deal/discovery']")
     values = {
         "goals": "Reduce mobile booking friction and improve trust.",
         "current_platform": "WordPress",
@@ -277,7 +275,7 @@ def run() -> Path:
     output.mkdir(parents=True)
     report: dict[str, Any] = {
         "contract": "veridra_sales_contract_acceptance",
-        "version": "1.5",
+        "version": "1.6",
         "started_at": datetime.now(UTC).isoformat(),
         "passed": False,
         "steps": [],

--- a/tools/sales_contract_acceptance.py
+++ b/tools/sales_contract_acceptance.py
@@ -133,7 +133,7 @@ def _create_and_qualify_prospect(
         "no_existing_web_team",
     ):
         page.locator(f"select[name='{name}']").select_option("2")
-    page.locator("textarea[name='qualification_reason']").fill(
+    page.locator("textarea[name='reason']").fill(
         "Synthetic acceptance prospect intentionally qualifies for the sales workflow."
     )
     page.get_by_role("button", name="Save qualification").click()
@@ -274,7 +274,7 @@ def run() -> Path:
     output.mkdir(parents=True)
     report: dict[str, Any] = {
         "contract": "veridra_sales_contract_acceptance",
-        "version": "1.3",
+        "version": "1.4",
         "started_at": datetime.now(UTC).isoformat(),
         "passed": False,
         "steps": [],

--- a/tools/sales_contract_acceptance.py
+++ b/tools/sales_contract_acceptance.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from playwright.sync_api import Page, sync_playwright
+
+import operator_e2e_acceptance as base
+
+
+def _capture(report: dict[str, Any], page: Page, evidence: Path, name: str) -> None:
+    screenshot = evidence / f"{name}.png"
+    text_path = evidence / f"{name}.txt"
+    page.screenshot(path=str(screenshot), full_page=True)
+    visible = page.locator("body").inner_text()
+    text_path.write_text(visible, encoding="utf-8")
+    report["steps"].append(
+        {
+            "name": name,
+            "url": page.url,
+            "title": page.title(),
+            "screenshot": screenshot.name,
+            "visible_text": text_path.name,
+        }
+    )
+
+
+def _set_reply(page: Page, prospect_url: str, outcome: str) -> None:
+    page.goto(f"{prospect_url}/deal", wait_until="networkidle")
+    page.locator("select[name='reply_outcome']").select_option(outcome)
+    page.locator("textarea[name='conversation_summary']").fill(
+        f"Synthetic {outcome} reply for #285 browser acceptance."
+    )
+    page.locator("input[name='next_action']").fill("")
+    page.get_by_role("button", name="Save reply context").click()
+    page.wait_for_url(f"{prospect_url}/deal")
+    page.wait_for_load_state("networkidle")
+
+
+def _discovery(page: Page, prospect_url: str) -> None:
+    page.goto(f"{prospect_url}/deal", wait_until="networkidle")
+    values = {
+        "goals": "Reduce mobile booking friction and improve trust.",
+        "current_platform": "WordPress",
+        "hosting": "External managed host",
+        "decision_maker": "Clinic owner",
+        "urgency": "This month",
+        "constraints": "No booking-platform replacement.",
+        "access_readiness": "Admin access available after booking.",
+        "measurable_scope": "Fix agreed mobile and trust issues on the current site.",
+        "deliverables": "Bounded fixes, verification and final report.",
+        "exclusions": "Copywriting and booking-system replacement.",
+        "assumptions": "Existing hosting remains in place.",
+        "timeline": "5 business days after access",
+    }
+    for name, value in values.items():
+        locator = page.locator(f"[name='{name}']")
+        locator.fill(value)
+    page.get_by_role("button", name="Save discovery").click()
+    page.wait_for_url(f"{prospect_url}/deal")
+    page.wait_for_load_state("networkidle")
+
+
+def _create_proposal(
+    page: Page,
+    prospect_url: str,
+    *,
+    title: str,
+    price: str,
+    recurring: bool = True,
+) -> int:
+    page.goto(f"{prospect_url}/deal", wait_until="networkidle")
+    before = page.locator("div.proposal").count()
+    page.locator("input[name='title']").fill(title)
+    page.locator("textarea[name='scope']").last.fill(
+        "Fix agreed mobile and trust issues on the current site."
+    )
+    page.locator("textarea[name='deliverables']").last.fill(
+        "Bounded fixes, verification and final report."
+    )
+    page.locator("textarea[name='exclusions']").last.fill(
+        "Copywriting and booking-system replacement."
+    )
+    page.locator("textarea[name='assumptions']").last.fill(
+        "Existing hosting remains in place."
+    )
+    page.locator("input[name='timeline']").last.fill("5 business days after access")
+    valid_until = (datetime.now(UTC).date() + timedelta(days=14)).isoformat()
+    page.locator("input[name='valid_until']").fill(valid_until)
+    page.locator("input[name='price_amount']").fill(price)
+    page.locator("input[name='currency']").fill("EUR")
+    if recurring:
+        page.locator("input[name='recurring_amount']").fill("99.00")
+        page.locator("input[name='recurring_cadence']").fill("monthly")
+    page.get_by_role("button", name="Create proposal version").click()
+    page.wait_for_url(f"{prospect_url}/deal")
+    page.wait_for_load_state("networkidle")
+    after = page.locator("div.proposal").count()
+    if after != before + 1:
+        raise AssertionError("Proposal version was not visibly created through the UI.")
+    return after
+
+
+def _proposal_status(
+    page: Page,
+    prospect_url: str,
+    version: int,
+    status: str,
+    acceptance_reference: str = "",
+) -> None:
+    page.goto(f"{prospect_url}/deal", wait_until="networkidle")
+    form = page.locator(
+        f"form[action$='/deal/proposals/{version}/status']"
+    )
+    form.locator("select[name='status']").select_option(status)
+    form.locator("input[name='acceptance_reference']").fill(acceptance_reference)
+    form.get_by_role("button", name="Update proposal status").click()
+    page.wait_for_url(f"{prospect_url}/deal")
+    page.wait_for_load_state("networkidle")
+
+
+def _scope_change(page: Page, prospect_url: str, resulting_version: int) -> None:
+    url = f"{prospect_url}/deal/change-requests"
+    page.goto(url, wait_until="networkidle")
+    page.locator("textarea[name='summary']").fill(
+        "Add a second booking form to the agreed sprint."
+    )
+    page.locator("textarea[name='scope_impact']").fill(
+        "Adds one form implementation and verification step."
+    )
+    page.locator("input[name='price_impact']").fill("+ EUR 150")
+    page.locator("input[name='timeline_impact']").fill("+ 1 business day")
+    page.get_by_role("button", name="Record change request").click()
+    page.wait_for_url(url)
+    page.wait_for_load_state("networkidle")
+
+    form = page.locator("form[action$='/change-requests/1/status']")
+    form.locator("select[name='status']").select_option("approved")
+    form.locator("input[name='decision_reference']").fill(
+        "Synthetic customer approval of scope change."
+    )
+    form.get_by_role("button", name="Update change request").click()
+    page.wait_for_url(url)
+    page.wait_for_load_state("networkidle")
+
+    form = page.locator("form[action$='/change-requests/1/status']")
+    form.locator("select[name='status']").select_option("incorporated")
+    form.locator("input[name='resulting_proposal_version']").fill(
+        str(resulting_version)
+    )
+    form.get_by_role("button", name="Update change request").click()
+    page.wait_for_url(url)
+    page.wait_for_load_state("networkidle")
+    base._assert_text(page, "incorporated")
+
+
+def run() -> Path:
+    if os.name != "nt":
+        raise SystemExit("#285 sales-contract acceptance must run on Windows.")
+    repo = Path(__file__).resolve().parents[1]
+    output = repo / "artifacts" / "sales-contract-acceptance"
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+    report: dict[str, Any] = {
+        "contract": "veridra_sales_contract_acceptance",
+        "version": "1.0",
+        "started_at": datetime.now(UTC).isoformat(),
+        "passed": False,
+        "steps": [],
+        "checks": {},
+    }
+
+    with tempfile.TemporaryDirectory(prefix="veridra-sales-contract-") as temporary:
+        temp = Path(temporary)
+        localapp = temp / "LocalAppData"
+        localapp.mkdir(parents=True)
+        port = base._free_port()
+        base_url = f"http://127.0.0.1:{port}"
+        env = os.environ.copy()
+        env["LOCALAPPDATA"] = str(localapp)
+        env["VERIDRA_LOCAL_PORT"] = str(port)
+        try:
+            base._run_launcher(repo, env, "start")
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch(headless=True)
+                context = browser.new_context(viewport={"width": 1440, "height": 1000})
+                page = context.new_page()
+                base._onboard(page, base_url)
+                base._enable_agency_plan(page, base_url)
+                prospect_url = base._create_and_qualify_prospect(page, base_url)
+                _capture(report, page, output, "01-qualified-prospect")
+
+                _set_reply(page, prospect_url, "price_request")
+                if "before quoting" not in page.locator("input[name='next_action']").input_value().lower():
+                    raise AssertionError("Price request did not produce a safe next action.")
+                _capture(report, page, output, "02-price-request")
+                report["checks"]["price_request_branch"] = True
+
+                _set_reply(page, prospect_url, "call_request")
+                if "discovery call" not in page.locator("input[name='next_action']").input_value().lower():
+                    raise AssertionError("Call request did not produce a discovery-call next action.")
+                _capture(report, page, output, "03-call-request")
+                report["checks"]["call_request_branch"] = True
+
+                _set_reply(page, prospect_url, "different_scope")
+                if "assess fit" not in page.locator("input[name='next_action']").input_value().lower():
+                    raise AssertionError("Different-scope reply did not produce fit assessment.")
+                _capture(report, page, output, "04-different-scope-request")
+                report["checks"]["different_scope_branch"] = True
+
+                _set_reply(page, prospect_url, "positive")
+                _capture(report, page, output, "05-positive-reply")
+                _discovery(page, prospect_url)
+                _capture(report, page, output, "06-discovery-complete")
+                report["checks"]["discovery_completed_in_ui"] = True
+
+                version1 = _create_proposal(
+                    page,
+                    prospect_url,
+                    title="Website Improvement Sprint",
+                    price="650.00",
+                )
+                _capture(report, page, output, "07-proposal-v1-draft")
+                _proposal_status(page, prospect_url, version1, "sent")
+                _capture(report, page, output, "08-proposal-v1-sent")
+                _proposal_status(
+                    page,
+                    prospect_url,
+                    version1,
+                    "accepted",
+                    "Synthetic customer accepted proposal v1 externally.",
+                )
+                base._assert_text(page, "Proposal accepted")
+                base._assert_text(page, "agreement and payment evidence before work starts")
+                _capture(report, page, output, "09-proposal-v1-accepted")
+                report["checks"]["accepted_proposal_stops_before_payment_gate"] = True
+
+                artifact_url = (
+                    f"{prospect_url}/deal/proposals/{version1}/artifact"
+                )
+                page.goto(artifact_url, wait_until="networkidle")
+                base._assert_text(page, "Webify Digital Solutions")
+                base._assert_text(page, "EUR 650.00")
+                base._assert_text(page, "not an accounting invoice")
+                _capture(report, page, output, "10-proposal-artifact")
+                report["checks"]["proposal_artifact_visible"] = True
+
+                page.goto(f"{prospect_url}/deal", wait_until="networkidle")
+                version2 = _create_proposal(
+                    page,
+                    prospect_url,
+                    title="Alternative Scope",
+                    price="500.00",
+                    recurring=False,
+                )
+                _proposal_status(page, prospect_url, version2, "sent")
+                _proposal_status(page, prospect_url, version2, "declined")
+                _capture(report, page, output, "11-proposal-v2-declined")
+                report["checks"]["decline_branch"] = True
+
+                version3 = _create_proposal(
+                    page,
+                    prospect_url,
+                    title="Scope Change Revision",
+                    price="800.00",
+                )
+                _scope_change(page, prospect_url, version3)
+                _capture(report, page, output, "12-scope-change-incorporated")
+                report["checks"]["scope_change_branch"] = True
+
+                page.goto(f"{base_url}/agency/deals", wait_until="networkidle")
+                base._assert_text(page, base.BUSINESS)
+                base._assert_text(page, "Sales / proposals")
+                _capture(report, page, output, "13-sales-workbench")
+                report["checks"]["sales_workbench_visible"] = True
+
+                context.close()
+                browser.close()
+
+            report["passed"] = True
+        finally:
+            try:
+                base._run_launcher(repo, env, "stop")
+            except Exception as exc:  # pragma: no cover - diagnostic cleanup path
+                report["cleanup_error"] = str(exc)
+
+    report["finished_at"] = datetime.now(UTC).isoformat()
+    (output / "acceptance.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    if not report["passed"]:
+        raise AssertionError("#285 sales-contract acceptance did not pass.")
+    print(f"[PASS] #285 sales-contract acceptance: {output}")
+    return output
+
+
+if __name__ == "__main__":
+    run()

--- a/tools/sales_contract_acceptance.py
+++ b/tools/sales_contract_acceptance.py
@@ -27,9 +27,32 @@ def _checkpoint(report: dict[str, Any], output: Path, name: str) -> None:
     print(f"[#285] {name}", flush=True)
 
 
-def _launcher(repo: Path, env: dict[str, str], command: str) -> str:
+def _copy_runtime_logs(env: dict[str, str], output: Path) -> None:
+    localapp = env.get("LOCALAPPDATA", "").strip()
+    if not localapp:
+        return
+    runtime = Path(localapp) / "Veridra" / "runtime"
+    if not runtime.exists():
+        return
+    for source in runtime.glob("*.log"):
+        try:
+            shutil.copy2(source, output / source.name)
+        except OSError:
+            continue
+
+
+def _launcher(repo: Path, env: dict[str, str], command: str) -> None:
+    """Run the supported launcher without inheritable stdout/stderr pipes.
+
+    On Windows, a captured pipe can remain open in descendants started by PowerShell,
+    which makes subprocess.run()/communicate wait even after the launcher has finished.
+    VERIDRA already writes managed-process output to its runtime log files, so the
+    acceptance runner deliberately discards the wrapper process streams and preserves
+    those authoritative runtime logs on failure instead.
+    """
     script = repo / "scripts" / "windows" / "veridra-local.ps1"
-    completed = subprocess.run(
+    creationflags = subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0
+    process = subprocess.Popen(
         [
             "powershell.exe",
             "-NoProfile",
@@ -41,18 +64,18 @@ def _launcher(repo: Path, env: dict[str, str], command: str) -> str:
         ],
         cwd=repo,
         env=env,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        timeout=60,
-        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        creationflags=creationflags,
     )
-    if completed.returncode != 0:
-        raise RuntimeError(
-            f"VERIDRA launcher {command!r} failed ({completed.returncode}):\n"
-            f"{completed.stdout}"
-        )
-    return completed.stdout
+    try:
+        returncode = process.wait(timeout=60)
+    except subprocess.TimeoutExpired as exc:
+        process.kill()
+        process.wait(timeout=10)
+        raise RuntimeError(f"VERIDRA launcher {command!r} timed out.") from exc
+    if returncode != 0:
+        raise RuntimeError(f"VERIDRA launcher {command!r} failed ({returncode}).")
 
 
 def _capture(report: dict[str, Any], page: Page, evidence: Path, name: str) -> None:
@@ -206,7 +229,7 @@ def run() -> Path:
     output.mkdir(parents=True)
     report: dict[str, Any] = {
         "contract": "veridra_sales_contract_acceptance",
-        "version": "1.1",
+        "version": "1.2",
         "started_at": datetime.now(UTC).isoformat(),
         "passed": False,
         "steps": [],
@@ -334,6 +357,7 @@ def run() -> Path:
             report["current_step"] = "complete"
         except Exception as exc:
             report["failure"] = f"{type(exc).__name__}: {exc}"
+            _copy_runtime_logs(env, output)
             _write_report(report, output)
             print(f"[#285][FAIL] {report['failure']}", flush=True)
             raise
@@ -344,6 +368,7 @@ def run() -> Path:
                     _launcher(repo, env, "stop")
                 except Exception as exc:  # pragma: no cover - diagnostic cleanup path
                     report["cleanup_error"] = str(exc)
+                    _copy_runtime_logs(env, output)
 
     report["finished_at"] = datetime.now(UTC).isoformat()
     _write_report(report, output)

--- a/tools/sales_contract_acceptance.py
+++ b/tools/sales_contract_acceptance.py
@@ -3,14 +3,56 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+import operator_e2e_acceptance as base
 from playwright.sync_api import Page, sync_playwright
 
-import operator_e2e_acceptance as base
+
+def _write_report(report: dict[str, Any], output: Path) -> None:
+    report["checkpoint_at"] = datetime.now(UTC).isoformat()
+    (output / "acceptance.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _checkpoint(report: dict[str, Any], output: Path, name: str) -> None:
+    report["current_step"] = name
+    _write_report(report, output)
+    print(f"[#285] {name}", flush=True)
+
+
+def _launcher(repo: Path, env: dict[str, str], command: str) -> str:
+    script = repo / "scripts" / "windows" / "veridra-local.ps1"
+    completed = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script),
+            command,
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=60,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"VERIDRA launcher {command!r} failed ({completed.returncode}):\n"
+            f"{completed.stdout}"
+        )
+    return completed.stdout
 
 
 def _capture(report: dict[str, Any], page: Page, evidence: Path, name: str) -> None:
@@ -28,10 +70,11 @@ def _capture(report: dict[str, Any], page: Page, evidence: Path, name: str) -> N
             "visible_text": text_path.name,
         }
     )
+    _write_report(report, evidence)
 
 
 def _set_reply(page: Page, prospect_url: str, outcome: str) -> None:
-    page.goto(f"{prospect_url}/deal", wait_until="networkidle")
+    page.goto(f"{prospect_url}/deal", wait_until="domcontentloaded")
     page.locator("select[name='reply_outcome']").select_option(outcome)
     page.locator("textarea[name='conversation_summary']").fill(
         f"Synthetic {outcome} reply for #285 browser acceptance."
@@ -39,11 +82,14 @@ def _set_reply(page: Page, prospect_url: str, outcome: str) -> None:
     page.locator("input[name='next_action']").fill("")
     page.get_by_role("button", name="Save reply context").click()
     page.wait_for_url(f"{prospect_url}/deal")
-    page.wait_for_load_state("networkidle")
+
+
+def _next_action(page: Page) -> str:
+    return page.locator("input[name='next_action']").input_value().lower()
 
 
 def _discovery(page: Page, prospect_url: str) -> None:
-    page.goto(f"{prospect_url}/deal", wait_until="networkidle")
+    page.goto(f"{prospect_url}/deal", wait_until="domcontentloaded")
     values = {
         "goals": "Reduce mobile booking friction and improve trust.",
         "current_platform": "WordPress",
@@ -59,11 +105,9 @@ def _discovery(page: Page, prospect_url: str) -> None:
         "timeline": "5 business days after access",
     }
     for name, value in values.items():
-        locator = page.locator(f"[name='{name}']")
-        locator.fill(value)
+        page.locator(f"[name='{name}']").fill(value)
     page.get_by_role("button", name="Save discovery").click()
     page.wait_for_url(f"{prospect_url}/deal")
-    page.wait_for_load_state("networkidle")
 
 
 def _create_proposal(
@@ -74,7 +118,7 @@ def _create_proposal(
     price: str,
     recurring: bool = True,
 ) -> int:
-    page.goto(f"{prospect_url}/deal", wait_until="networkidle")
+    page.goto(f"{prospect_url}/deal", wait_until="domcontentloaded")
     before = page.locator("div.proposal").count()
     page.locator("input[name='title']").fill(title)
     page.locator("textarea[name='scope']").last.fill(
@@ -99,7 +143,6 @@ def _create_proposal(
         page.locator("input[name='recurring_cadence']").fill("monthly")
     page.get_by_role("button", name="Create proposal version").click()
     page.wait_for_url(f"{prospect_url}/deal")
-    page.wait_for_load_state("networkidle")
     after = page.locator("div.proposal").count()
     if after != before + 1:
         raise AssertionError("Proposal version was not visibly created through the UI.")
@@ -113,20 +156,17 @@ def _proposal_status(
     status: str,
     acceptance_reference: str = "",
 ) -> None:
-    page.goto(f"{prospect_url}/deal", wait_until="networkidle")
-    form = page.locator(
-        f"form[action$='/deal/proposals/{version}/status']"
-    )
+    page.goto(f"{prospect_url}/deal", wait_until="domcontentloaded")
+    form = page.locator(f"form[action$='/deal/proposals/{version}/status']")
     form.locator("select[name='status']").select_option(status)
     form.locator("input[name='acceptance_reference']").fill(acceptance_reference)
     form.get_by_role("button", name="Update proposal status").click()
     page.wait_for_url(f"{prospect_url}/deal")
-    page.wait_for_load_state("networkidle")
 
 
 def _scope_change(page: Page, prospect_url: str, resulting_version: int) -> None:
     url = f"{prospect_url}/deal/change-requests"
-    page.goto(url, wait_until="networkidle")
+    page.goto(url, wait_until="domcontentloaded")
     page.locator("textarea[name='summary']").fill(
         "Add a second booking form to the agreed sprint."
     )
@@ -137,7 +177,6 @@ def _scope_change(page: Page, prospect_url: str, resulting_version: int) -> None
     page.locator("input[name='timeline_impact']").fill("+ 1 business day")
     page.get_by_role("button", name="Record change request").click()
     page.wait_for_url(url)
-    page.wait_for_load_state("networkidle")
 
     form = page.locator("form[action$='/change-requests/1/status']")
     form.locator("select[name='status']").select_option("approved")
@@ -146,7 +185,6 @@ def _scope_change(page: Page, prospect_url: str, resulting_version: int) -> None
     )
     form.get_by_role("button", name="Update change request").click()
     page.wait_for_url(url)
-    page.wait_for_load_state("networkidle")
 
     form = page.locator("form[action$='/change-requests/1/status']")
     form.locator("select[name='status']").select_option("incorporated")
@@ -155,7 +193,6 @@ def _scope_change(page: Page, prospect_url: str, resulting_version: int) -> None
     )
     form.get_by_role("button", name="Update change request").click()
     page.wait_for_url(url)
-    page.wait_for_load_state("networkidle")
     base._assert_text(page, "incorporated")
 
 
@@ -169,12 +206,13 @@ def run() -> Path:
     output.mkdir(parents=True)
     report: dict[str, Any] = {
         "contract": "veridra_sales_contract_acceptance",
-        "version": "1.0",
+        "version": "1.1",
         "started_at": datetime.now(UTC).isoformat(),
         "passed": False,
         "steps": [],
         "checks": {},
     }
+    _checkpoint(report, output, "initialised")
 
     with tempfile.TemporaryDirectory(prefix="veridra-sales-contract-") as temporary:
         temp = Path(temporary)
@@ -185,32 +223,44 @@ def run() -> Path:
         env = os.environ.copy()
         env["LOCALAPPDATA"] = str(localapp)
         env["VERIDRA_LOCAL_PORT"] = str(port)
+        started = False
         try:
-            base._run_launcher(repo, env, "start")
+            _checkpoint(report, output, "starting supported launcher")
+            _launcher(repo, env, "start")
+            started = True
+            _checkpoint(report, output, "launcher started")
             with sync_playwright() as playwright:
                 browser = playwright.chromium.launch(headless=True)
                 context = browser.new_context(viewport={"width": 1440, "height": 1000})
                 page = context.new_page()
+                page.set_default_timeout(15_000)
+                page.set_default_navigation_timeout(20_000)
+
+                _checkpoint(report, output, "onboarding")
                 base._onboard(page, base_url)
                 base._enable_agency_plan(page, base_url)
                 prospect_url = base._create_and_qualify_prospect(page, base_url)
                 _capture(report, page, output, "01-qualified-prospect")
 
                 _set_reply(page, prospect_url, "price_request")
-                if "before quoting" not in page.locator("input[name='next_action']").input_value().lower():
+                if "before quoting" not in _next_action(page):
                     raise AssertionError("Price request did not produce a safe next action.")
                 _capture(report, page, output, "02-price-request")
                 report["checks"]["price_request_branch"] = True
 
                 _set_reply(page, prospect_url, "call_request")
-                if "discovery call" not in page.locator("input[name='next_action']").input_value().lower():
-                    raise AssertionError("Call request did not produce a discovery-call next action.")
+                if "discovery call" not in _next_action(page):
+                    raise AssertionError(
+                        "Call request did not produce a discovery-call next action."
+                    )
                 _capture(report, page, output, "03-call-request")
                 report["checks"]["call_request_branch"] = True
 
                 _set_reply(page, prospect_url, "different_scope")
-                if "assess fit" not in page.locator("input[name='next_action']").input_value().lower():
-                    raise AssertionError("Different-scope reply did not produce fit assessment.")
+                if "assess fit" not in _next_action(page):
+                    raise AssertionError(
+                        "Different-scope reply did not produce fit assessment."
+                    )
                 _capture(report, page, output, "04-different-scope-request")
                 report["checks"]["different_scope_branch"] = True
 
@@ -241,17 +291,14 @@ def run() -> Path:
                 _capture(report, page, output, "09-proposal-v1-accepted")
                 report["checks"]["accepted_proposal_stops_before_payment_gate"] = True
 
-                artifact_url = (
-                    f"{prospect_url}/deal/proposals/{version1}/artifact"
-                )
-                page.goto(artifact_url, wait_until="networkidle")
+                artifact_url = f"{prospect_url}/deal/proposals/{version1}/artifact"
+                page.goto(artifact_url, wait_until="domcontentloaded")
                 base._assert_text(page, "Webify Digital Solutions")
                 base._assert_text(page, "EUR 650.00")
                 base._assert_text(page, "not an accounting invoice")
                 _capture(report, page, output, "10-proposal-artifact")
                 report["checks"]["proposal_artifact_visible"] = True
 
-                page.goto(f"{prospect_url}/deal", wait_until="networkidle")
                 version2 = _create_proposal(
                     page,
                     prospect_url,
@@ -274,7 +321,7 @@ def run() -> Path:
                 _capture(report, page, output, "12-scope-change-incorporated")
                 report["checks"]["scope_change_branch"] = True
 
-                page.goto(f"{base_url}/agency/deals", wait_until="networkidle")
+                page.goto(f"{base_url}/agency/deals", wait_until="domcontentloaded")
                 base._assert_text(page, base.BUSINESS)
                 base._assert_text(page, "Sales / proposals")
                 _capture(report, page, output, "13-sales-workbench")
@@ -284,20 +331,23 @@ def run() -> Path:
                 browser.close()
 
             report["passed"] = True
+            report["current_step"] = "complete"
+        except Exception as exc:
+            report["failure"] = f"{type(exc).__name__}: {exc}"
+            _write_report(report, output)
+            print(f"[#285][FAIL] {report['failure']}", flush=True)
+            raise
         finally:
-            try:
-                base._run_launcher(repo, env, "stop")
-            except Exception as exc:  # pragma: no cover - diagnostic cleanup path
-                report["cleanup_error"] = str(exc)
+            if started:
+                try:
+                    _checkpoint(report, output, "stopping supported launcher")
+                    _launcher(repo, env, "stop")
+                except Exception as exc:  # pragma: no cover - diagnostic cleanup path
+                    report["cleanup_error"] = str(exc)
 
     report["finished_at"] = datetime.now(UTC).isoformat()
-    (output / "acceptance.json").write_text(
-        json.dumps(report, indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-    if not report["passed"]:
-        raise AssertionError("#285 sales-contract acceptance did not pass.")
-    print(f"[PASS] #285 sales-contract acceptance: {output}")
+    _write_report(report, output)
+    print(f"[PASS] #285 sales-contract acceptance: {output}", flush=True)
     return output
 
 

--- a/tools/sales_contract_acceptance.py
+++ b/tools/sales_contract_acceptance.py
@@ -96,6 +96,53 @@ def _capture(report: dict[str, Any], page: Page, evidence: Path, name: str) -> N
     _write_report(report, evidence)
 
 
+def _create_and_qualify_prospect(
+    page: Page,
+    base_url: str,
+    report: dict[str, Any],
+    evidence: Path,
+) -> str:
+    page.goto(f"{base_url}/agency/prospects/new", wait_until="domcontentloaded")
+    _capture(report, page, evidence, "00-add-prospect-form")
+    base._assert_text(page, "Add prospect")
+    values = {
+        "business_name": base.BUSINESS,
+        "website": base.TARGET,
+        "sector": "Dental clinic",
+        "phone": "+35315550100",
+        "locality": "Dublin",
+        "administrative_area": "Dublin",
+        "country_code": "IE",
+        "contact_email": "acceptance@example.com",
+        "evidence_summary": "Synthetic #285 sales-contract acceptance fixture. No real outreach.",
+    }
+    for name, value in values.items():
+        page.locator(f"[name='{name}']").fill(value)
+    page.get_by_role("button", name="Create prospect").click()
+    page.wait_for_url("**/agency/prospects/*")
+    prospect_url = page.url
+    base._assert_text(page, base.BUSINESS)
+
+    for name in (
+        "active_real_business",
+        "website_commercial_importance",
+        "business_economic_value",
+        "business_size_fit",
+        "decision_maker_reachability",
+        "website_manageability",
+        "no_existing_web_team",
+    ):
+        page.locator(f"select[name='{name}']").select_option("2")
+    page.locator("textarea[name='qualification_reason']").fill(
+        "Synthetic acceptance prospect intentionally qualifies for the sales workflow."
+    )
+    page.get_by_role("button", name="Save qualification").click()
+    page.wait_for_url(prospect_url)
+    page.wait_for_load_state("domcontentloaded")
+    base._assert_text(page, "14/14")
+    return prospect_url
+
+
 def _set_reply(page: Page, prospect_url: str, outcome: str) -> None:
     page.goto(f"{prospect_url}/deal", wait_until="domcontentloaded")
     page.locator("select[name='reply_outcome']").select_option(outcome)
@@ -211,9 +258,7 @@ def _scope_change(page: Page, prospect_url: str, resulting_version: int) -> None
 
     form = page.locator("form[action$='/change-requests/1/status']")
     form.locator("select[name='status']").select_option("incorporated")
-    form.locator("input[name='resulting_proposal_version']").fill(
-        str(resulting_version)
-    )
+    form.locator("input[name='resulting_proposal_version']").fill(str(resulting_version))
     form.get_by_role("button", name="Update change request").click()
     page.wait_for_url(url)
     base._assert_text(page, "incorporated")
@@ -229,7 +274,7 @@ def run() -> Path:
     output.mkdir(parents=True)
     report: dict[str, Any] = {
         "contract": "veridra_sales_contract_acceptance",
-        "version": "1.2",
+        "version": "1.3",
         "started_at": datetime.now(UTC).isoformat(),
         "passed": False,
         "steps": [],
@@ -262,7 +307,7 @@ def run() -> Path:
                 _checkpoint(report, output, "onboarding")
                 base._onboard(page, base_url)
                 base._enable_agency_plan(page, base_url)
-                prospect_url = base._create_and_qualify_prospect(page, base_url)
+                prospect_url = _create_and_qualify_prospect(page, base_url, report, output)
                 _capture(report, page, output, "01-qualified-prospect")
 
                 _set_reply(page, prospect_url, "price_request")


### PR DESCRIPTION
Implements the #285 sales-to-contract workflow before any real outreach.

Implemented:
- tenant-isolated deal records attached to prospects, preserving legacy prospect compatibility;
- reply outcomes with specific operator next actions: positive, negative, price request, call request, different scope, no response;
- conversation summary and next action without pretending VERIDRA is the inbox;
- discovery/requirements capture: goals, current platform, hosting, decision maker, urgency, constraints, access readiness, measurable scope, deliverables, exclusions, assumptions and timeline;
- versioned proposals with one-off/recurring pricing, validity, draft/sent/accepted/declined/expired status and acceptance evidence;
- strict proposal transitions: draft -> sent -> accepted/declined/expired; terminal versions cannot be silently reopened or rewritten;
- expired proposal validity cannot be accepted; changed scope requires a new version;
- customer-readable tenant-bound proposal preview/download with explicit boundary that it is not an invoice, payment receipt or e-signature record;
- scope change request workflow with scope/price/timeline impact, decision evidence and resulting proposal-version reference;
- Sales / proposals workbench and shared navigation entry;
- regression coverage for reply branches, discovery/proposal persistence, proposal artifacts, strict transitions and scope changes;
- no real outreach or automatic customer conversion.

Boundary: proposal acceptance intentionally stops at the next P0 gate, #286 agreement/payment. A prospect is not considered safely booked for delivery until #286 establishes accepted terms plus required payment evidence.

Closes most of #285. Final completion depends on green CI for this exact head and final operator review of the sales workflow; real outreach remains blocked by #284.