### PR TITLE
#286 Gate commercial work on agreement and upfront payment

### DIFF
--- a/src/veridra/agency_customer_project_web.py
+++ b/src/veridra/agency_customer_project_web.py
@@ -54,6 +54,17 @@ def _load_customer(request: Request, identity: RequestIdentity, customer_id: str
         raise HTTPException(status_code=404, detail="Customer not found.") from exc
 
 
+def _require_work_gate(customer: CustomerRecord) -> None:
+    if customer.booking_gate_required and not customer.work_may_start:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Commercial work is blocked until accepted terms and required payment evidence "
+                "are recorded on the customer."
+            ),
+        )
+
+
 def _replace_customer(
     request: Request,
     identity: RequestIdentity,
@@ -77,12 +88,20 @@ def _replace_customer(
 def _project_section(request: Request, identity: RequestIdentity, customer_id: str, customer: CustomerRecord) -> str:
     projects = TenantProjectStore(_root(request)).list(identity)
     linked = set(customer.project_ids)
-    available = [entry for entry in projects if entry.id not in linked]
     linked_rows = "".join(
         f"<li><a href='/agency/projects/{html.escape(entry.id, quote=True)}'>{html.escape(entry.name)}</a> — {html.escape(entry.target_url)}</li>"
         for entry in projects
         if entry.id in linked
     ) or "<li>No linked delivery projects yet.</li>"
+    if customer.booking_gate_required and not customer.work_may_start:
+        return f"""
+        <section>
+          <h2>Delivery projects</h2>
+          <p class='notice warning'><strong>Delivery work is blocked.</strong> {html.escape(customer.booking_next_action)} Creating or linking a delivery project becomes available after the work-start gate opens.</p>
+          <ul>{linked_rows}</ul>
+        </section>
+        """
+    available = [entry for entry in projects if entry.id not in linked]
     options = "".join(
         f"<option value='{html.escape(entry.id, quote=True)}'>{html.escape(entry.name)} — {html.escape(entry.target_url)}</option>"
         for entry in available
@@ -109,7 +128,7 @@ def _project_section(request: Request, identity: RequestIdentity, customer_id: s
     return f"""
     <section>
       <h2>Delivery projects</h2>
-      <p class='muted'>Customer/project linkage is persisted explicitly. Creating or linking here is the supported operator path.</p>
+      <p class='muted'>Customer/project linkage is persisted explicitly. Creating or linking here is the supported operator path after the commercial work-start gate is open.</p>
       <ul>{linked_rows}</ul>
       <div class='row'><div><h3>Create project</h3>{create_form}</div><div><h3>Link existing project</h3>{link_form}</div></div>
     </section>
@@ -134,6 +153,7 @@ def customer_detail_with_projects(customer_id: str, request: Request) -> str:
 async def create_customer_project(customer_id: str, request: Request) -> RedirectResponse:
     identity = _manage_identity(request)
     customer = _load_customer(request, identity, customer_id)
+    _require_work_gate(customer)
     body = await request.body()
     project_name = _one(body, "project_name")
     target_url = _one(body, "target_url")
@@ -169,6 +189,7 @@ async def create_customer_project(customer_id: str, request: Request) -> Redirec
 async def link_customer_project(customer_id: str, request: Request) -> RedirectResponse:
     identity = _manage_identity(request)
     customer = _load_customer(request, identity, customer_id)
+    _require_work_gate(customer)
     project_id = _one(await request.body(), "project_id")
     projects = TenantProjectStore(_root(request))
     try:

--- a/src/veridra/agency_customer_web.py
+++ b/src/veridra/agency_customer_web.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qs
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from pydantic import ValidationError
+from pydantic import HttpUrl, ValidationError
 
 from .agency_navigation import agency_navigation
 from .customer_store import (
@@ -107,6 +107,10 @@ def _optional_datetime(value: str) -> datetime | None:
         return None
     parsed = datetime.fromisoformat(value)
     return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+def _optional_http_url(value: str) -> HttpUrl | None:
+    return HttpUrl(value) if value else None
 
 
 @router.get("", response_class=HTMLResponse)
@@ -218,7 +222,7 @@ async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
         billing = CustomerBillingState(
             status=next_billing_status,
             invoice_reference=_one(values, "invoice_reference"),
-            invoice_external_url=_one(values, "invoice_external_url") or None,
+            invoice_external_url=_optional_http_url(_one(values, "invoice_external_url")),
             invoice_amount=_optional_decimal(_one(values, "invoice_amount")),
             currency=(_one(values, "billing_currency") or "EUR").upper(),
             issued_on=_optional_date(_one(values, "issued_on")),

--- a/src/veridra/agency_customer_web.py
+++ b/src/veridra/agency_customer_web.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 
 from .agency_navigation import agency_navigation
 from .customer_store import (
+    CustomerAgreementState,
     CustomerBillingState,
     CustomerBillingStatus,
     CustomerOnboardingChecklist,
@@ -31,7 +32,7 @@ from .tenant_customer_store import TenantCustomerStore, TenantCustomerStoreError
 router = APIRouter(prefix="/agency/customers", tags=["agency-customers"])
 
 _STYLE = """
-*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1100px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.card{border:1px solid #dfe3e8;border-radius:9px;padding:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:110px}.check{display:flex;gap:9px;align-items:center;margin:12px 0}.check input{width:auto}.actions{display:flex;gap:8px;flex-wrap:wrap}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:760px){.cards,.row{grid-template-columns:1fr}}
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1100px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:24px;margin-bottom:18px}.cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.card{border:1px solid #dfe3e8;border-radius:9px;padding:18px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.warning{border-left-color:#b7791f;background:#fff8e6}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}label{display:block;font-weight:700;margin:12px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:110px}.check{display:flex;gap:9px;align-items:center;margin:12px 0}.check input{width:auto}.actions{display:flex;gap:8px;flex-wrap:wrap}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}@media(max-width:760px){.cards,.row{grid-template-columns:1fr}}
 """
 
 
@@ -83,6 +84,12 @@ def _date_value(value: object) -> str:
     return "" if value is None else str(value)
 
 
+def _datetime_value(value: datetime | None) -> str:
+    if value is None:
+        return ""
+    return value.astimezone(UTC).replace(tzinfo=None).isoformat(timespec="minutes")
+
+
 def _money(value: object) -> str:
     return "" if value is None else str(value)
 
@@ -95,24 +102,32 @@ def _optional_date(value: str) -> date | None:
     return date.fromisoformat(value) if value else None
 
 
+def _optional_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value)
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
 @router.get("", response_class=HTMLResponse)
 def customers(request: Request) -> str:
     identity = _identity(request)
     entries = TenantCustomerStore(_root(request)).list(identity)
     cards = "".join(
-        "<article class='card'><p class='muted'>{status} · onboarding {progress}</p><h2>{name}</h2><p><strong>Website:</strong> {website}<br><strong>Offer:</strong> {offer}<br><strong>Billing:</strong> {billing}<br><strong>Projects:</strong> {projects}</p><a class='button' href='/agency/customers/{customer_id}'>Open customer</a></article>".format(
+        "<article class='card'><p class='muted'>{status} · onboarding {progress}</p><h2>{name}</h2><p><strong>Website:</strong> {website}<br><strong>Offer:</strong> {offer}<br><strong>Billing:</strong> {billing}<br><strong>Work gate:</strong> {gate}<br><strong>Projects:</strong> {projects}</p><a class='button' href='/agency/customers/{customer_id}'>Open customer</a></article>".format(
             status=html.escape(customer.status.value.title()),
             progress=html.escape(_progress(customer.onboarding)),
             name=html.escape(customer.business_name),
             website=html.escape(str(customer.website) if customer.website is not None else "No website yet"),
             offer=html.escape(customer.offer_service or "Not recorded"),
             billing=html.escape(customer.billing.status.value.replace("_", " ").title()),
+            gate="Open" if customer.work_may_start else "Blocked",
             projects=len(customer.project_ids),
             customer_id=html.escape(customer_id, quote=True),
         )
         for customer_id, customer in entries
     ) or "<p class='notice'>No customers yet. A won inbound lead or an outbound prospect marked Customer will create the first onboarding record.</p>"
-    body = f"{agency_navigation(identity, current='customers')}<section><h1>Customers</h1><p class='muted'>Won business relationships, onboarding state, billing state and linked delivery projects.</p></section><section><div class='cards'>{cards}</div></section>"
+    body = f"{agency_navigation(identity, current='customers')}<section><h1>Customers</h1><p class='muted'>Won business relationships, commercial booking state, onboarding, billing and linked delivery projects.</p></section><section><div class='cards'>{cards}</div></section>"
     return _page("Customers", body)
 
 
@@ -135,7 +150,7 @@ def customer_detail(customer_id: str, request: Request) -> str:
     project_links = "".join(
         f"<a class='button secondary' href='/agency/projects/{html.escape(project_id, quote=True)}'>Open project {html.escape(project_id[:8])}</a>"
         for project_id in customer.project_ids
-    ) or "<span class='muted'>No delivery project yet. This is valid for a no-website customer during onboarding.</span>"
+    ) or "<span class='muted'>No delivery project yet.</span>"
     status_options = "".join(
         f"<option value='{item.value}'{' selected' if item is customer.status else ''}>{item.value.title()}</option>"
         for item in CustomerStatus
@@ -154,8 +169,12 @@ def customer_detail(customer_id: str, request: Request) -> str:
             ("kickoff_completed", "Kickoff completed", customer.onboarding.kickoff_completed),
         )
     )
-    paid = customer.billing.paid_at.isoformat() if customer.billing.paid_at is not None else "Not paid"
-    body = f"""{agency_navigation(identity, current='customers')}<section><p><a href='/agency/customers'>← Customers</a></p><h1>{html.escape(customer.business_name)}</h1><p><strong>Status:</strong> {html.escape(customer.status.value.title())}<br><strong>Contact:</strong> {html.escape(customer.contact_name or 'Not recorded')} · {html.escape(customer.contact_email or 'No email')} · {html.escape(customer.phone or 'No phone')}<br><strong>Website:</strong> {html.escape(str(customer.website) if customer.website is not None else 'No website yet')}<br><strong>Offer:</strong> {html.escape(customer.offer_service or 'Not recorded')}<br><strong>Quoted:</strong> {html.escape(f'{customer.currency} {customer.quoted_value}' if customer.quoted_value is not None else 'Not recorded')}<br><strong>Onboarding:</strong> {html.escape(_progress(customer.onboarding))}<br><strong>Billing:</strong> {html.escape(customer.billing.status.value.replace('_', ' ').title())}<br><strong>Paid at:</strong> {html.escape(paid)}</p><div class='actions'>{source_link}{project_links}</div></section><section><h2>Customer onboarding</h2><p class='muted'>A customer cannot become Active until all five required onboarding checks are complete.</p><form method='post' action='/agency/customers/{html.escape(customer_id, quote=True)}'><div class='row'><div><label for='status'>Customer status</label><select id='status' name='status'>{status_options}</select></div><div><label for='commercial_notes'>Commercial / onboarding notes</label><textarea id='commercial_notes' name='commercial_notes' maxlength='5000'>{html.escape(customer.commercial_notes)}</textarea></div></div>{checks}<h2>Invoice and payment</h2><p class='muted'>This tracks Webify client billing only. It does not charge the customer or change VERIDRA SaaS subscription billing.</p><div class='row'><div><label for='billing_status'>Billing status</label><select id='billing_status' name='billing_status'>{billing_options}</select></div><div><label for='invoice_reference'>Invoice reference</label><input id='invoice_reference' name='invoice_reference' maxlength='120' value='{html.escape(customer.billing.invoice_reference, quote=True)}'></div><div><label for='invoice_amount'>Invoice amount</label><input id='invoice_amount' name='invoice_amount' type='number' min='0' step='0.01' value='{html.escape(_money(customer.billing.invoice_amount), quote=True)}'></div><div><label for='billing_currency'>Currency</label><input id='billing_currency' name='billing_currency' minlength='3' maxlength='3' value='{html.escape(customer.billing.currency, quote=True)}'></div><div><label for='issued_on'>Issued on</label><input id='issued_on' name='issued_on' type='date' value='{html.escape(_date_value(customer.billing.issued_on), quote=True)}'></div><div><label for='due_on'>Due on</label><input id='due_on' name='due_on' type='date' value='{html.escape(_date_value(customer.billing.due_on), quote=True)}'></div></div><label for='billing_note'>Billing note</label><textarea id='billing_note' name='billing_note' maxlength='2000'>{html.escape(customer.billing.note)}</textarea><p><button type='submit'>Save customer</button></p></form></section>"""
+    paid = customer.billing.paid_at.isoformat() if customer.billing.paid_at is not None else "Not fully paid"
+    gate_class = "success" if customer.work_may_start else "warning"
+    gate_title = "Work may start" if customer.work_may_start else "Work blocked"
+    invoice_url = str(customer.billing.invoice_external_url) if customer.billing.invoice_external_url is not None else ""
+    deposit_checked = " checked" if customer.billing.deposit_required else ""
+    body = f"""{agency_navigation(identity, current='customers')}<section><p><a href='/agency/customers'>← Customers</a></p><h1>{html.escape(customer.business_name)}</h1><p><strong>Status:</strong> {html.escape(customer.status.value.title())}<br><strong>Contact:</strong> {html.escape(customer.contact_name or 'Not recorded')} · {html.escape(customer.contact_email or 'No email')} · {html.escape(customer.phone or 'No phone')}<br><strong>Website:</strong> {html.escape(str(customer.website) if customer.website is not None else 'No website yet')}<br><strong>Offer:</strong> {html.escape(customer.offer_service or 'Not recorded')}<br><strong>Quoted:</strong> {html.escape(f'{customer.currency} {customer.quoted_value}' if customer.quoted_value is not None else 'Not recorded')}<br><strong>Onboarding:</strong> {html.escape(_progress(customer.onboarding))}<br><strong>Billing:</strong> {html.escape(customer.billing.status.value.replace('_', ' ').title())}<br><strong>Paid at:</strong> {html.escape(paid)}</p><p class='notice {gate_class}'><strong>{gate_title}.</strong> {html.escape(customer.booking_next_action)}</p><div class='actions'>{source_link}{project_links}</div></section><section><h2>Commercial booking and onboarding</h2><p class='muted'>VERIDRA records references and evidence. It is not the accounting, payment-processing or e-signature system of record.</p><form method='post' action='/agency/customers/{html.escape(customer_id, quote=True)}'><h3>Agreement / terms</h3><div class='row'><div><label for='terms_reference'>Terms / agreement reference</label><input id='terms_reference' name='terms_reference' maxlength='240' value='{html.escape(customer.agreement.terms_reference, quote=True)}'></div><div><label for='terms_version'>Terms version</label><input id='terms_version' name='terms_version' maxlength='80' value='{html.escape(customer.agreement.terms_version, quote=True)}'></div><div><label for='terms_accepted_at'>Accepted at</label><input id='terms_accepted_at' name='terms_accepted_at' type='datetime-local' value='{html.escape(_datetime_value(customer.agreement.accepted_at), quote=True)}'></div><div><label for='signature_reference'>External signature reference</label><input id='signature_reference' name='signature_reference' maxlength='240' value='{html.escape(customer.agreement.signature_reference, quote=True)}'></div></div><label for='acceptance_evidence'>Acceptance evidence</label><textarea id='acceptance_evidence' name='acceptance_evidence' maxlength='2000' placeholder='External email, signed-document reference or other evidence. Do not store sensitive signature data.'>{html.escape(customer.agreement.acceptance_evidence)}</textarea><h3>Invoice, deposit and payment evidence</h3><p class='muted'>Capture external accounting/payment references only. VERIDRA does not create a legally binding invoice or process card/bank details here.</p><div class='row'><div><label for='billing_status'>Billing status</label><select id='billing_status' name='billing_status'>{billing_options}</select></div><div><label for='invoice_reference'>External invoice reference</label><input id='invoice_reference' name='invoice_reference' maxlength='120' value='{html.escape(customer.billing.invoice_reference, quote=True)}'></div><div><label for='invoice_external_url'>External invoice link</label><input id='invoice_external_url' name='invoice_external_url' type='url' maxlength='2048' value='{html.escape(invoice_url, quote=True)}'></div><div><label for='invoice_amount'>Invoice amount</label><input id='invoice_amount' name='invoice_amount' type='number' min='0' step='0.01' value='{html.escape(_money(customer.billing.invoice_amount), quote=True)}'></div><div><label for='billing_currency'>Currency</label><input id='billing_currency' name='billing_currency' minlength='3' maxlength='3' value='{html.escape(customer.billing.currency, quote=True)}'></div><div><label for='issued_on'>Issued on</label><input id='issued_on' name='issued_on' type='date' value='{html.escape(_date_value(customer.billing.issued_on), quote=True)}'></div><div><label for='due_on'>Due on</label><input id='due_on' name='due_on' type='date' value='{html.escape(_date_value(customer.billing.due_on), quote=True)}'></div><div><label class='check'><input type='checkbox' name='deposit_required'{deposit_checked}>Deposit / upfront payment required before work</label><label for='deposit_amount'>Required upfront amount</label><input id='deposit_amount' name='deposit_amount' type='number' min='0' step='0.01' value='{html.escape(_money(customer.billing.deposit_amount), quote=True)}'></div><div><label for='amount_paid'>Amount paid</label><input id='amount_paid' name='amount_paid' type='number' min='0' step='0.01' value='{html.escape(_money(customer.billing.amount_paid), quote=True)}'><label for='payment_reference'>Payment evidence reference</label><input id='payment_reference' name='payment_reference' maxlength='240' value='{html.escape(customer.billing.payment_reference, quote=True)}'></div><div><label for='payment_method_reference'>Payment method reference</label><input id='payment_method_reference' name='payment_method_reference' maxlength='160' placeholder='e.g. bank transfer' value='{html.escape(customer.billing.payment_method_reference, quote=True)}'></div><div><label for='payment_provider_reference'>Provider transaction reference</label><input id='payment_provider_reference' name='payment_provider_reference' maxlength='240' value='{html.escape(customer.billing.payment_provider_reference, quote=True)}'></div></div><label for='billing_note'>Billing note</label><textarea id='billing_note' name='billing_note' maxlength='2000'>{html.escape(customer.billing.note)}</textarea><h3>Onboarding</h3><p class='muted'>Contact, scope and access preparation may be recorded while waiting. Kickoff and Active status remain blocked until the commercial work-start gate is open.</p><div class='row'><div><label for='status'>Customer status</label><select id='status' name='status'>{status_options}</select></div><div><label for='commercial_notes'>Commercial / onboarding notes</label><textarea id='commercial_notes' name='commercial_notes' maxlength='5000'>{html.escape(customer.commercial_notes)}</textarea></div></div>{checks}<p><button type='submit'>Save customer</button></p></form></section>"""
     return _page(customer.business_name, body)
 
 
@@ -178,21 +197,38 @@ async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
             access_requirements_confirmed=_checked(values, "access_requirements_confirmed"),
             kickoff_completed=_checked(values, "kickoff_completed"),
         )
+        agreement = CustomerAgreementState(
+            terms_reference=_one(values, "terms_reference"),
+            terms_version=_one(values, "terms_version"),
+            accepted_at=_optional_datetime(_one(values, "terms_accepted_at")),
+            acceptance_evidence=_one(values, "acceptance_evidence"),
+            signature_reference=_one(values, "signature_reference"),
+        )
         activated_at = customer.activated_at
         if next_status is CustomerStatus.active and activated_at is None:
             activated_at = datetime.now(UTC)
         paid_at = customer.billing.paid_at
         if next_billing_status is CustomerBillingStatus.paid and paid_at is None:
             paid_at = datetime.now(UTC)
-        elif next_billing_status is not CustomerBillingStatus.paid:
+        elif next_billing_status not in {
+            CustomerBillingStatus.paid,
+            CustomerBillingStatus.refunded,
+        }:
             paid_at = None
         billing = CustomerBillingState(
             status=next_billing_status,
             invoice_reference=_one(values, "invoice_reference"),
+            invoice_external_url=_one(values, "invoice_external_url") or None,
             invoice_amount=_optional_decimal(_one(values, "invoice_amount")),
             currency=(_one(values, "billing_currency") or "EUR").upper(),
             issued_on=_optional_date(_one(values, "issued_on")),
             due_on=_optional_date(_one(values, "due_on")),
+            deposit_required=_checked(values, "deposit_required"),
+            deposit_amount=_optional_decimal(_one(values, "deposit_amount")),
+            amount_paid=_optional_decimal(_one(values, "amount_paid")),
+            payment_reference=_one(values, "payment_reference"),
+            payment_method_reference=_one(values, "payment_method_reference"),
+            payment_provider_reference=_one(values, "payment_provider_reference"),
             paid_at=paid_at,
             note=_one(values, "billing_note"),
         )
@@ -201,6 +237,7 @@ async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
                 **customer.model_dump(mode="json"),
                 "status": next_status.value,
                 "onboarding": checklist.model_dump(mode="json"),
+                "agreement": agreement.model_dump(mode="json"),
                 "billing": billing.model_dump(mode="json"),
                 "commercial_notes": _one(values, "commercial_notes"),
                 "updated_at": datetime.now(UTC),
@@ -212,8 +249,9 @@ async def save_customer(customer_id: str, request: Request) -> RedirectResponse:
         raise HTTPException(
             status_code=400,
             detail=(
-                "Customer update is invalid. Complete onboarding before activation and "
-                "provide valid invoice details for invoiced billing states."
+                "Customer update is invalid. Accepted terms and any required upfront payment "
+                "must be evidenced before kickoff or Active status. Invoiced states require "
+                "valid external invoice details."
             ),
         ) from exc
     return RedirectResponse(f"/agency/customers/{customer_id}", status_code=303)

--- a/src/veridra/customer_lifecycle.py
+++ b/src/veridra/customer_lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from .customer_store import (
+    CustomerAgreementState,
     CustomerBillingState,
     CustomerOnboardingChecklist,
     CustomerRecord,
@@ -64,7 +65,13 @@ def upsert_customer_from_lead(
         onboarding=(
             current.onboarding if current is not None else CustomerOnboardingChecklist()
         ),
+        agreement=(
+            current.agreement if current is not None else CustomerAgreementState()
+        ),
         billing=current.billing if current is not None else CustomerBillingState(),
+        booking_gate_required=(
+            current.booking_gate_required if current is not None else True
+        ),
         created_at=current.created_at if current is not None else datetime.now(UTC),
         updated_at=datetime.now(UTC),
         activated_at=current.activated_at if current is not None else None,
@@ -105,7 +112,13 @@ def upsert_customer_from_prospect(
         onboarding=(
             current.onboarding if current is not None else CustomerOnboardingChecklist()
         ),
+        agreement=(
+            current.agreement if current is not None else CustomerAgreementState()
+        ),
         billing=current.billing if current is not None else CustomerBillingState(),
+        booking_gate_required=(
+            current.booking_gate_required if current is not None else True
+        ),
         created_at=current.created_at if current is not None else datetime.now(UTC),
         updated_at=datetime.now(UTC),
         activated_at=current.activated_at if current is not None else None,

--- a/src/veridra/customer_store.py
+++ b/src/veridra/customer_store.py
@@ -241,7 +241,8 @@ class CustomerRecord(BaseModel):
         if self.booking_gate_required and not self.work_may_start:
             if self.onboarding.kickoff_completed:
                 raise ValueError(
-                    "Kickoff cannot be completed until accepted terms and required payment evidence are recorded."
+                    "Kickoff cannot be completed until accepted terms and required "
+                    "payment evidence are recorded."
                 )
             if self.status is CustomerStatus.active:
                 raise ValueError(

--- a/src/veridra/customer_store.py
+++ b/src/veridra/customer_store.py
@@ -31,11 +31,16 @@ class CustomerStatus(StrEnum):
 
 class CustomerBillingStatus(StrEnum):
     unbilled = "unbilled"
+    reference_pending = "reference_pending"
     invoice_prepared = "invoice_prepared"
+    issued = "issued"
     invoice_sent = "invoice_sent"
+    due = "due"
+    partially_paid = "partially_paid"
     paid = "paid"
     overdue = "overdue"
     cancelled = "cancelled"
+    refunded = "refunded"
 
 
 class CustomerOnboardingChecklist(BaseModel):
@@ -60,33 +65,118 @@ class CustomerOnboardingChecklist(BaseModel):
         )
 
 
+class CustomerAgreementState(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    terms_reference: str = Field(default="", max_length=240)
+    terms_version: str = Field(default="", max_length=80)
+    accepted_at: datetime | None = None
+    acceptance_evidence: str = Field(default="", max_length=2000)
+    signature_reference: str = Field(default="", max_length=240)
+
+    @property
+    def accepted(self) -> bool:
+        return bool(
+            self.terms_reference
+            and self.terms_version
+            and self.accepted_at is not None
+            and self.acceptance_evidence
+        )
+
+    @model_validator(mode="after")
+    def validate_acceptance(self) -> CustomerAgreementState:
+        acceptance_started = bool(
+            self.accepted_at is not None
+            or self.acceptance_evidence
+            or self.signature_reference
+        )
+        if acceptance_started and not (
+            self.terms_reference and self.terms_version and self.accepted_at is not None
+        ):
+            raise ValueError(
+                "Accepted terms require a terms reference, version and accepted-at timestamp."
+            )
+        if self.accepted_at is not None and not self.acceptance_evidence:
+            raise ValueError("Accepted terms require acceptance evidence.")
+        return self
+
+
 class CustomerBillingState(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
 
     status: CustomerBillingStatus = CustomerBillingStatus.unbilled
     invoice_reference: str = Field(default="", max_length=120)
+    invoice_external_url: HttpUrl | None = None
     invoice_amount: Decimal | None = Field(default=None, ge=0, decimal_places=2)
     currency: str = Field(default="EUR", min_length=3, max_length=3, pattern=r"^[A-Z]{3}$")
     issued_on: date | None = None
     due_on: date | None = None
+    deposit_required: bool = False
+    deposit_amount: Decimal | None = Field(default=None, ge=0, decimal_places=2)
+    amount_paid: Decimal | None = Field(default=None, ge=0, decimal_places=2)
+    payment_reference: str = Field(default="", max_length=240)
+    payment_method_reference: str = Field(default="", max_length=160)
+    payment_provider_reference: str = Field(default="", max_length=240)
     paid_at: datetime | None = None
     note: str = Field(default="", max_length=2000)
 
+    @property
+    def payment_evidence_recorded(self) -> bool:
+        return bool(
+            self.payment_reference
+            and self.amount_paid is not None
+            and self.amount_paid > Decimal("0")
+        )
+
+    @property
+    def required_upfront_payment_satisfied(self) -> bool:
+        if not self.deposit_required:
+            return True
+        if self.deposit_amount is None or self.deposit_amount <= Decimal("0"):
+            return False
+        return bool(
+            self.invoice_reference
+            and self.payment_evidence_recorded
+            and self.amount_paid is not None
+            and self.amount_paid >= self.deposit_amount
+            and self.status
+            in {
+                CustomerBillingStatus.partially_paid,
+                CustomerBillingStatus.paid,
+            }
+        )
+
     @model_validator(mode="after")
     def validate_billing_state(self) -> CustomerBillingState:
-        if self.issued_on is not None and self.due_on is not None and self.due_on < self.issued_on:
+        if (
+            self.issued_on is not None
+            and self.due_on is not None
+            and self.due_on < self.issued_on
+        ):
             raise ValueError("Invoice due date cannot be before the issue date.")
         invoiced_states = {
             CustomerBillingStatus.invoice_prepared,
+            CustomerBillingStatus.issued,
             CustomerBillingStatus.invoice_sent,
+            CustomerBillingStatus.due,
+            CustomerBillingStatus.partially_paid,
             CustomerBillingStatus.paid,
             CustomerBillingStatus.overdue,
+            CustomerBillingStatus.cancelled,
+            CustomerBillingStatus.refunded,
         }
         if self.status in invoiced_states:
             if not self.invoice_reference:
                 raise ValueError("Invoiced billing states require an invoice reference.")
             if self.invoice_amount is None:
                 raise ValueError("Invoiced billing states require an invoice amount.")
+        if self.deposit_required and (
+            self.deposit_amount is None or self.deposit_amount <= Decimal("0")
+        ):
+            raise ValueError("A required deposit must have a positive required amount.")
+        if self.status is CustomerBillingStatus.partially_paid:
+            if not self.payment_evidence_recorded:
+                raise ValueError("Partially paid billing requires payment evidence.")
         if self.status is CustomerBillingStatus.paid and self.paid_at is None:
             raise ValueError("Paid billing state requires a payment timestamp.")
         return self
@@ -109,10 +199,32 @@ class CustomerRecord(BaseModel):
     commercial_notes: str = Field(default="", max_length=5000)
     status: CustomerStatus = CustomerStatus.onboarding
     onboarding: CustomerOnboardingChecklist = Field(default_factory=CustomerOnboardingChecklist)
+    agreement: CustomerAgreementState = Field(default_factory=CustomerAgreementState)
     billing: CustomerBillingState = Field(default_factory=CustomerBillingState)
+    booking_gate_required: bool = False
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     activated_at: datetime | None = None
+
+    @property
+    def work_may_start(self) -> bool:
+        if not self.booking_gate_required:
+            return True
+        return bool(
+            self.agreement.accepted and self.billing.required_upfront_payment_satisfied
+        )
+
+    @property
+    def booking_next_action(self) -> str:
+        if not self.booking_gate_required:
+            return "Commercial booking gate is not required for this record."
+        if not self.agreement.accepted:
+            return "Capture accepted terms and acceptance evidence before work starts."
+        if self.billing.deposit_required and not self.billing.required_upfront_payment_satisfied:
+            if not self.billing.invoice_reference:
+                return "Capture the external invoice reference before requesting the deposit."
+            return "Waiting for required payment evidence before work starts."
+        return "Work may start. Continue onboarding and delivery."
 
     @model_validator(mode="after")
     def validate_relationships(self) -> CustomerRecord:
@@ -126,6 +238,15 @@ class CustomerRecord(BaseModel):
                 )
         if self.status is CustomerStatus.active and not self.onboarding.complete:
             raise ValueError("Customer onboarding must be complete before activation.")
+        if self.booking_gate_required and not self.work_may_start:
+            if self.onboarding.kickoff_completed:
+                raise ValueError(
+                    "Kickoff cannot be completed until accepted terms and required payment evidence are recorded."
+                )
+            if self.status is CustomerStatus.active:
+                raise ValueError(
+                    "Customer cannot become active until the commercial work-start gate is open."
+                )
         return self
 
 

--- a/tests/test_customer_billing.py
+++ b/tests/test_customer_billing.py
@@ -9,10 +9,13 @@ from pydantic import ValidationError
 
 from veridra.customer_lifecycle import upsert_customer_from_prospect
 from veridra.customer_store import (
+    CustomerAgreementState,
     CustomerBillingState,
     CustomerBillingStatus,
+    CustomerOnboardingChecklist,
     CustomerRecord,
     CustomerSourceType,
+    CustomerStatus,
 )
 from veridra.identity_tenancy import RequestIdentity, TenantRole
 from veridra.prospect import Prospect, ProspectStatus
@@ -29,6 +32,16 @@ def _identity() -> RequestIdentity:
     )
 
 
+def _accepted_agreement() -> CustomerAgreementState:
+    return CustomerAgreementState(
+        terms_reference="WEBIFY-MSA-001",
+        terms_version="2026-09",
+        accepted_at=datetime.now(UTC),
+        acceptance_evidence="Synthetic acceptance email reference.",
+        signature_reference="SIGN-SYNTHETIC-001",
+    )
+
+
 def test_new_customer_defaults_to_unbilled() -> None:
     customer = CustomerRecord(
         business_name="Example Ltd",
@@ -40,6 +53,8 @@ def test_new_customer_defaults_to_unbilled() -> None:
     assert customer.billing.invoice_reference == ""
     assert customer.billing.invoice_amount is None
     assert customer.billing.paid_at is None
+    assert customer.booking_gate_required is False
+    assert customer.work_may_start is True
 
 
 def test_invoiced_states_require_reference_and_amount() -> None:
@@ -87,6 +102,106 @@ def test_due_date_cannot_precede_issue_date() -> None:
         )
 
 
+def test_commercial_work_gate_requires_terms_before_work() -> None:
+    customer = CustomerRecord(
+        business_name="Booked Example Ltd",
+        source_type=CustomerSourceType.prospect,
+        source_id="e" * 24,
+        booking_gate_required=True,
+    )
+
+    assert customer.work_may_start is False
+    assert "accepted terms" in customer.booking_next_action.lower()
+
+    accepted = customer.model_copy(update={"agreement": _accepted_agreement()})
+    assert accepted.work_may_start is True
+    assert accepted.booking_next_action == "Work may start. Continue onboarding and delivery."
+
+
+def test_required_deposit_blocks_until_payment_evidence_satisfies_amount() -> None:
+    customer = CustomerRecord(
+        business_name="Deposit Example Ltd",
+        source_type=CustomerSourceType.prospect,
+        source_id="e" * 24,
+        booking_gate_required=True,
+        agreement=_accepted_agreement(),
+        billing=CustomerBillingState(
+            status=CustomerBillingStatus.invoice_sent,
+            invoice_reference="WEB-2026-002",
+            invoice_amount=Decimal("650.00"),
+            deposit_required=True,
+            deposit_amount=Decimal("325.00"),
+        ),
+    )
+    assert customer.work_may_start is False
+    assert "payment evidence" in customer.booking_next_action.lower()
+
+    underpaid = customer.model_copy(
+        update={
+            "billing": CustomerBillingState(
+                status=CustomerBillingStatus.partially_paid,
+                invoice_reference="WEB-2026-002",
+                invoice_amount=Decimal("650.00"),
+                deposit_required=True,
+                deposit_amount=Decimal("325.00"),
+                amount_paid=Decimal("100.00"),
+                payment_reference="PAY-SYNTHETIC-UNDER",
+            )
+        }
+    )
+    assert underpaid.work_may_start is False
+
+    satisfied = customer.model_copy(
+        update={
+            "billing": CustomerBillingState(
+                status=CustomerBillingStatus.partially_paid,
+                invoice_reference="WEB-2026-002",
+                invoice_amount=Decimal("650.00"),
+                deposit_required=True,
+                deposit_amount=Decimal("325.00"),
+                amount_paid=Decimal("325.00"),
+                payment_reference="PAY-SYNTHETIC-OK",
+                payment_method_reference="bank transfer",
+                payment_provider_reference="BANK-SYNTHETIC-001",
+            )
+        }
+    )
+    assert satisfied.work_may_start is True
+
+
+def test_commercial_gate_rejects_kickoff_or_active_while_blocked() -> None:
+    completed = CustomerOnboardingChecklist(
+        contact_confirmed=True,
+        scope_confirmed=True,
+        commercial_terms_confirmed=True,
+        access_requirements_confirmed=True,
+        kickoff_completed=True,
+    )
+    base = CustomerRecord(
+        business_name="Blocked Example Ltd",
+        source_type=CustomerSourceType.prospect,
+        source_id="f" * 24,
+        booking_gate_required=True,
+    )
+
+    with pytest.raises(ValidationError):
+        CustomerRecord.model_validate(
+            {
+                **base.model_dump(mode="json"),
+                "onboarding": completed.model_dump(mode="json"),
+            }
+        )
+    with pytest.raises(ValidationError):
+        CustomerRecord.model_validate(
+            {
+                **base.model_dump(mode="json"),
+                "status": CustomerStatus.active.value,
+                "onboarding": completed.model_dump(mode="json"),
+                "activated_at": datetime.now(UTC),
+            }
+        )
+
+
 def test_prospect_refresh_preserves_existing_billing_state(tmp_path: Path) -> None:
     identity = _identity()
     store = TenantCustomerStore(tmp_path)
@@ -129,3 +244,4 @@ def test_prospect_refresh_preserves_existing_billing_state(tmp_path: Path) -> No
     after = store.load(identity, store.ref(identity, customer_id))
 
     assert after.billing == billing
+    assert after.booking_gate_required is True

--- a/tests/test_customer_onboarding.py
+++ b/tests/test_customer_onboarding.py
@@ -58,6 +58,8 @@ def test_no_website_outbound_customer_is_created_without_project(tmp_path: Path)
     assert customer.website is None
     assert customer.project_ids == ()
     assert customer.status is CustomerStatus.onboarding
+    assert customer.booking_gate_required is True
+    assert customer.work_may_start is False
 
     prospects.replace(identity, prospects.ref(identity, prospect_id), won)
     assert len(TenantCustomerStore(tmp_path).list(identity)) == 1
@@ -95,6 +97,8 @@ def test_customer_activation_requires_complete_onboarding() -> None:
     )
     assert active.status is CustomerStatus.active
     assert active.onboarding.complete is True
+    assert active.booking_gate_required is False
+    assert active.work_may_start is True
 
 
 def test_won_inbound_lead_customer_keeps_project_and_commercial_value(tmp_path: Path) -> None:
@@ -130,6 +134,8 @@ def test_won_inbound_lead_customer_keeps_project_and_commercial_value(tmp_path: 
     assert customer.project_ids == ("1" * 24,)
     assert customer.quoted_value == Decimal("650.00")
     assert customer.offer_service == "Website Improvement Sprint"
+    assert customer.booking_gate_required is True
+    assert customer.work_may_start is False
 
 
 def test_customers_are_tenant_isolated(tmp_path: Path) -> None:

--- a/tests/test_first_customer_acceptance.py
+++ b/tests/test_first_customer_acceptance.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from veridra.commercial_dashboard import build_commercial_snapshot
 from veridra.customer_store import (
+    CustomerAgreementState,
     CustomerBillingState,
     CustomerBillingStatus,
     CustomerOnboardingChecklist,
@@ -64,6 +65,8 @@ def test_no_site_prospect_can_become_onboarded_paid_customer(tmp_path: Path) -> 
     assert customer.status is CustomerStatus.onboarding
     assert customer.project_ids == ()
     assert customer.offer_service == "Website Improvement Sprint"
+    assert customer.booking_gate_required is True
+    assert customer.work_may_start is False
     assert customers.list(other_tenant) == []
 
     # Replaying the won/customer source transition must not create a duplicate.
@@ -77,16 +80,30 @@ def test_no_site_prospect_can_become_onboarded_paid_customer(tmp_path: Path) -> 
         access_requirements_confirmed=True,
         kickoff_completed=True,
     )
+    accepted_at = datetime.now(UTC)
     paid_at = datetime.now(UTC)
     paid = customer.model_copy(
         update={
             "status": CustomerStatus.active,
             "onboarding": completed,
+            "agreement": CustomerAgreementState(
+                terms_reference="WEBIFY-MSA-E2E",
+                terms_version="2026-09",
+                accepted_at=accepted_at,
+                acceptance_evidence="Synthetic acceptance email reference.",
+                signature_reference="SIGN-E2E-001",
+            ),
             "billing": CustomerBillingState(
                 status=CustomerBillingStatus.paid,
                 invoice_reference="WEB-2026-001",
                 invoice_amount=Decimal("650.00"),
                 currency="EUR",
+                deposit_required=True,
+                deposit_amount=Decimal("325.00"),
+                amount_paid=Decimal("650.00"),
+                payment_reference="PAY-E2E-001",
+                payment_method_reference="bank transfer",
+                payment_provider_reference="BANK-E2E-001",
                 paid_at=paid_at,
                 note="Synthetic acceptance payment.",
             ),
@@ -94,9 +111,10 @@ def test_no_site_prospect_can_become_onboarded_paid_customer(tmp_path: Path) -> 
             "updated_at": datetime.now(UTC),
         }
     )
+    assert paid.work_may_start is True
     customers.replace(identity, customers.ref(identity, customer_id), paid)
 
-    # A later source refresh must preserve onboarding, active state and payment history.
+    # A later source refresh must preserve agreement, onboarding, active state and payment history.
     refreshed_prospect = won.model_copy(
         update={
             "commercial_note": "Post-sale source note refreshed.",
@@ -112,10 +130,13 @@ def test_no_site_prospect_can_become_onboarded_paid_customer(tmp_path: Path) -> 
 
     assert after_refresh.status is CustomerStatus.active
     assert after_refresh.onboarding.complete is True
+    assert after_refresh.agreement.accepted is True
+    assert after_refresh.agreement.accepted_at == accepted_at
     assert after_refresh.billing.status is CustomerBillingStatus.paid
     assert after_refresh.billing.invoice_reference == "WEB-2026-001"
     assert after_refresh.billing.invoice_amount == Decimal("650.00")
     assert after_refresh.billing.paid_at == paid_at
+    assert after_refresh.work_may_start is True
     assert after_refresh.website is None
     assert after_refresh.project_ids == ()
 

--- a/tests/test_full_first_customer_delivery_acceptance.py
+++ b/tests/test_full_first_customer_delivery_acceptance.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from veridra.commercial_dashboard import build_commercial_snapshot
 from veridra.core import Assessment, Finding, Status
 from veridra.customer_store import (
+    CustomerAgreementState,
     CustomerBillingState,
     CustomerBillingStatus,
     CustomerOnboardingChecklist,
@@ -76,6 +77,8 @@ def test_full_first_customer_delivery_survives_restart(tmp_path: Path) -> None:
     )
     prospects.replace(identity, prospects.ref(identity, prospect_id), won)
     customer_id, customer = customers.list(identity)[0]
+    assert customer.booking_gate_required is True
+    assert customer.work_may_start is False
 
     project = ClientProject.build(
         name="First Customer Dental website",
@@ -105,11 +108,24 @@ def test_full_first_customer_delivery_survives_restart(tmp_path: Path) -> None:
             "status": CustomerStatus.active,
             "project_ids": (project_id,),
             "onboarding": completed,
+            "agreement": CustomerAgreementState(
+                terms_reference="WEBIFY-MSA-001",
+                terms_version="2026-09",
+                accepted_at=NOW,
+                acceptance_evidence="Synthetic acceptance evidence.",
+                signature_reference="SIGN-SYNTHETIC-001",
+            ),
             "billing": CustomerBillingState(
                 status=CustomerBillingStatus.paid,
                 invoice_reference="WEB-2026-001",
                 invoice_amount=Decimal("650.00"),
                 currency="EUR",
+                deposit_required=True,
+                deposit_amount=Decimal("325.00"),
+                amount_paid=Decimal("650.00"),
+                payment_reference="PAY-SYNTHETIC-001",
+                payment_method_reference="bank transfer",
+                payment_provider_reference="BANK-SYNTHETIC-001",
                 paid_at=paid_at,
                 note="Synthetic acceptance payment.",
             ),
@@ -117,6 +133,7 @@ def test_full_first_customer_delivery_survives_restart(tmp_path: Path) -> None:
             "updated_at": NOW,
         }
     )
+    assert active_customer.work_may_start is True
     customers.replace(identity, customers.ref(identity, customer_id), active_customer)
 
     finding = Finding(
@@ -207,9 +224,13 @@ def test_full_first_customer_delivery_survives_restart(tmp_path: Path) -> None:
     assert reloaded_prospect.status is ProspectStatus.customer
     assert reloaded_customer.status is CustomerStatus.active
     assert reloaded_customer.onboarding.complete is True
+    assert reloaded_customer.agreement.accepted is True
+    assert reloaded_customer.work_may_start is True
     assert reloaded_customer.project_ids == (project_id,)
     assert reloaded_customer.billing.status is CustomerBillingStatus.paid
     assert reloaded_customer.billing.invoice_amount == Decimal("650.00")
+    assert reloaded_customer.billing.deposit_amount == Decimal("325.00")
+    assert reloaded_customer.billing.payment_reference == "PAY-SYNTHETIC-001"
     assert reloaded_customer.billing.paid_at == paid_at
     assert reloaded_project.monitoring_schedule.cadence is MonitoringCadence.weekly
     assert reloaded_project.monitoring_schedule.timezone == "Europe/Dublin"

--- a/tools/operator_e2e_acceptance_entry.py
+++ b/tools/operator_e2e_acceptance_entry.py
@@ -99,6 +99,44 @@ def _create_and_qualify_prospect(page: Page, base_url: str) -> str:
     return prospect_url
 
 
+def _complete_onboarding_with_booking_gate(page: Page, customer_url: str) -> None:
+    """Prove commercial work stays blocked until terms and required payment are evidenced."""
+    page.goto(customer_url, wait_until="networkidle")
+    acceptance._assert_text(page, "Work blocked")
+    acceptance._assert_text(page, "Capture accepted terms")
+    if page.get_by_role("button", name="Create and link project").count() != 0:
+        raise AssertionError("Delivery project creation was exposed while work gate was blocked.")
+
+    page.get_by_label("Terms / agreement reference").fill("WEBIFY-MSA-E2E")
+    page.get_by_label("Terms version").fill("2026-09")
+    page.get_by_label("Accepted at").fill("2026-09-03T10:00")
+    page.get_by_label("External signature reference").fill("SIGN-E2E-001")
+    page.get_by_label("Acceptance evidence").fill(
+        "Synthetic accepted-terms evidence for Playwright operator acceptance."
+    )
+    page.get_by_label("Billing status").select_option("partially_paid")
+    page.get_by_label("External invoice reference").fill(acceptance.INVOICE)
+    page.get_by_label("Invoice amount").fill("650.00")
+    page.get_by_label("Currency").fill("EUR")
+    page.get_by_label("Issued on").fill("2026-09-03")
+    page.get_by_label("Due on").fill("2026-09-17")
+    page.get_by_label("Deposit / upfront payment required before work").check()
+    page.get_by_label("Required upfront amount").fill("325.00")
+    page.get_by_label("Amount paid").fill("325.00")
+    page.get_by_label("Payment evidence reference").fill("PAY-E2E-DEPOSIT-001")
+    page.get_by_label("Payment method reference").fill("bank transfer")
+    page.get_by_label("Provider transaction reference").fill("BANK-E2E-001")
+    page.get_by_role("button", name="Save customer").click()
+    page.wait_for_url(customer_url)
+    page.wait_for_load_state("networkidle")
+    acceptance._assert_text(page, "Work may start")
+    page.get_by_role("button", name="Create and link project").wait_for(
+        state="visible", timeout=10_000
+    )
+
+    _ORIGINAL_COMPLETE_ONBOARDING(page, customer_url)
+
+
 def _manual_assessment(page: Page, project_url: str) -> str:
     """Run the established assessment, then prove the JSON AI exchange through the browser."""
     monitoring_url = _ORIGINAL_MANUAL_ASSESSMENT(page, project_url)
@@ -267,10 +305,12 @@ def _preserve_playwright_browser_cache() -> None:
         print(f"[E2E] Reusing Playwright browser cache: {browser_cache}", flush=True)
 
 
+_ORIGINAL_COMPLETE_ONBOARDING = acceptance._complete_onboarding
 _ORIGINAL_MANUAL_ASSESSMENT = acceptance._manual_assessment
 _ORIGINAL_WAIT_AUTONOMOUS_MONITORING = acceptance._wait_autonomous_monitoring
 acceptance._run_launcher = _run_launcher
 acceptance._create_and_qualify_prospect = _create_and_qualify_prospect
+acceptance._complete_onboarding = _complete_onboarding_with_booking_gate
 acceptance._manual_assessment = _manual_assessment
 acceptance._report = _report
 acceptance._wait_autonomous_monitoring = _wait_autonomous_monitoring


### PR DESCRIPTION
Implements #286.

- adds explicit agreement/terms acceptance evidence to customer records
- records external invoice/payment references without turning VERIDRA into an accounting or payment processor
- adds deterministic commercial work-start gate
- blocks kickoff/Active and customer delivery project create/link until the gate is open
- preserves legacy/manual record compatibility and generic audit behavior
- adds focused model/lifecycle regressions
- updates the Windows full operator E2E to prove blocked -> accepted terms/deposit evidence -> work may start -> onboarding/delivery

Synthetic/internal acceptance only. No real outreach.