### PR TITLE
#288 recurring customer lifecycle

### DIFF
--- a/VERIDRA_OPERATOR_E2E_ACCEPTANCE.bat
+++ b/VERIDRA_OPERATOR_E2E_ACCEPTANCE.bat
@@ -5,6 +5,6 @@ if not exist ".venv\Scripts\python.exe" (
   call "%~dp0VERIDRA_SETUP.bat"
   if errorlevel 1 exit /b %ERRORLEVEL%
 )
-echo [Veridra] Running true Playwright first-customer operator + visual acceptance...
-".venv\Scripts\python.exe" -u "%~dp0tools\operator_visual_acceptance_entry.py"
+echo [Veridra] Running true Playwright first-customer + recurring operator acceptance...
+".venv\Scripts\python.exe" -u "%~dp0tools\operator_recurring_visual_acceptance_entry.py"
 exit /b %ERRORLEVEL%

--- a/src/veridra/agency_navigation.py
+++ b/src/veridra/agency_navigation.py
@@ -12,6 +12,7 @@ def agency_navigation(identity: RequestIdentity, *, current: str | None = None) 
         ("commercial", "/agency/commercial", "Commercial"),
         ("customers", "/agency/customers", "Customers"),
         ("projects", "/agency/projects", "Client projects"),
+        ("recurring", "/agency/recurring-services", "Recurring revenue"),
     ]
     if TenantCapability.manage_leads in capabilities:
         destinations.append(("prospects", "/agency/prospects", "Prospects"))

--- a/src/veridra/agency_recurring_service_web.py
+++ b/src/veridra/agency_recurring_service_web.py
@@ -1,0 +1,446 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import html
+import os
+from datetime import UTC, date, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
+
+from .agency_navigation import agency_navigation
+from .customer_store import CustomerRecord, CustomerSourceType
+from .identity_tenancy import (
+    IdentityBoundaryError,
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .recurring_service import (
+    BillingCadence,
+    RecurringServiceEvent,
+    RecurringServiceRecord,
+    RecurringServiceStatus,
+    RecurringServiceVersion,
+    RenewalBehavior,
+)
+from .request_security import require_request_identity
+from .same_origin import SameOriginRequestError, TrustedSameOriginPolicy
+from .tenant_customer_store import TenantCustomerStore
+from .tenant_project_store import TenantProjectStore, TenantProjectStoreError
+from .tenant_recurring_service_store import TenantRecurringServiceStore
+
+router = APIRouter(prefix="/agency", tags=["agency-recurring-service"])
+
+_STYLE = """
+*{box-sizing:border-box}body{margin:0;background:#f7f8fa;color:#17191c;font:14px Arial,sans-serif}main{max-width:1040px;margin:36px auto;padding:0 20px}section{background:#fff;border:1px solid #dfe3e8;border-radius:10px;padding:22px;margin-bottom:18px}.row{display:grid;grid-template-columns:1fr 1fr;gap:14px}.three{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}label{display:block;font-weight:700;margin:10px 0 5px}input,textarea,select{width:100%;padding:10px;border:1px solid #cfd4da;border-radius:7px}textarea{min-height:90px}.button,button{display:inline-block;border:0;border-radius:7px;background:#22272d;color:#fff;padding:10px 14px;text-decoration:none;cursor:pointer}.secondary{background:#59636e}.muted{color:#68707a}.notice{border-left:4px solid #68707a;background:#f4f6f8;padding:12px 14px}.success{border-left-color:#16794a;background:#f0faf5}.warning{border-left-color:#946200;background:#fff9e8}.danger{border-left-color:#b42318;background:#fff1f0}.actions{display:flex;gap:8px;flex-wrap:wrap}.badge{display:inline-block;border-radius:999px;background:#eef1f4;padding:4px 8px;font-size:12px}.checklist{list-style:none;padding:0}.checklist li{padding:7px 0;border-bottom:1px solid #e8eaed}.agency-nav{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:18px}.agency-nav a{display:inline-block;border:1px solid #cfd4da;border-radius:7px;background:#fff;color:#22272d;padding:8px 11px;text-decoration:none}.agency-nav a[aria-current='page']{background:#22272d;color:#fff;border-color:#22272d}table{width:100%;border-collapse:collapse}th,td{text-align:left;padding:10px;border-bottom:1px solid #e8eaed;vertical-align:top}th{font-size:12px;text-transform:uppercase;color:#68707a}@media(max-width:760px){.row,.three{grid-template-columns:1fr}}
+"""
+
+
+def _root(request: Request) -> Path | None:
+    value = getattr(request.app.state, "veridra_tenant_data_root", None)
+    return value if isinstance(value, Path) else None
+
+
+def _values(body: bytes) -> dict[str, list[str]]:
+    return parse_qs(body.decode("utf-8"), keep_blank_values=True)
+
+
+def _one(values: dict[str, list[str]], name: str) -> str:
+    return values.get(name, [""])[0].strip()
+
+
+def _lines(values: dict[str, list[str]], name: str) -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in _one(values, name).splitlines()
+        if line.strip()
+    )
+
+
+def _trusted_origin(request: Request) -> None:
+    configured = os.environ.get("VERIDRA_TRUSTED_ORIGIN", "").strip()
+    if not configured:
+        raise HTTPException(status_code=503, detail="Recurring service workflow is not configured.")
+    try:
+        TrustedSameOriginPolicy(configured).validate(request)
+    except SameOriginRequestError as exc:
+        raise HTTPException(status_code=403, detail="Recurring service request is not permitted.") from exc
+
+
+def _identity(request: Request, capability: TenantCapability = TenantCapability.view_data) -> RequestIdentity:
+    identity = require_request_identity(request)
+    try:
+        require_tenant_capability(identity, capability)
+    except IdentityBoundaryError as exc:
+        raise HTTPException(status_code=403, detail="This action is not permitted.") from exc
+    return identity
+
+
+def _project_exists(request: Request, identity: RequestIdentity, project_id: str) -> None:
+    store = TenantProjectStore(_root(request))
+    try:
+        store.load(identity, store.ref(identity, project_id))
+    except TenantProjectStoreError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+
+def _linked_customer(
+    request: Request,
+    identity: RequestIdentity,
+    project_id: str,
+) -> tuple[str, CustomerRecord]:
+    linked = [
+        item
+        for item in TenantCustomerStore(_root(request)).list(identity)
+        if project_id in item[1].project_ids
+    ]
+    if not linked:
+        raise HTTPException(status_code=409, detail="Project must be linked to a customer first.")
+    if len(linked) > 1:
+        raise HTTPException(status_code=409, detail="Recurring service requires one unambiguous linked customer.")
+    return linked[0]
+
+
+def _change_request_link(customer: CustomerRecord) -> str:
+    if customer.source_type is CustomerSourceType.prospect:
+        return f"/agency/prospects/{html.escape(customer.source_id, quote=True)}/deal/change-requests"
+    return "/agency/deals"
+
+
+def _status_label(value: str) -> str:
+    return value.replace("_", " ").title()
+
+
+def _event(record: RecurringServiceRecord, action: str, reference: str = "") -> tuple[RecurringServiceEvent, ...]:
+    return (*record.events, RecurringServiceEvent(action=action, reference=reference))
+
+
+def _save(
+    request: Request,
+    identity: RequestIdentity,
+    record: RecurringServiceRecord,
+    updates: dict[str, object],
+    *,
+    action: str,
+    reference: str = "",
+) -> None:
+    updates["events"] = _event(record, action, reference)
+    try:
+        updated = RecurringServiceRecord.model_validate(
+            {**record.model_dump(mode="json"), **updates}
+        )
+    except ValidationError as exc:
+        message = exc.errors()[0].get("msg", "Recurring service transition is invalid.")
+        raise HTTPException(status_code=400, detail=str(message)) from exc
+    TenantRecurringServiceStore(_root(request)).save(identity, updated)
+
+
+def _parse_date(value: str, field: str, *, required: bool = False) -> date | None:
+    if not value:
+        if required:
+            raise HTTPException(status_code=400, detail=f"{field} is required.")
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"{field} must be a valid date.") from exc
+
+
+def _parse_money(value: str) -> Decimal:
+    try:
+        return Decimal(value)
+    except InvalidOperation as exc:
+        raise HTTPException(status_code=400, detail="Recurring fee must be a valid amount.") from exc
+
+
+def _version_summary(record: RecurringServiceRecord) -> str:
+    version = record.active_version
+    if version is None:
+        return "<p class='muted'>No recurring plan version configured yet.</p>"
+    scope = "".join(f"<li>{html.escape(item)}</li>" for item in version.scope) or "<li>None</li>"
+    deliverables = "".join(f"<li>{html.escape(item)}</li>" for item in version.deliverables) or "<li>None</li>"
+    exclusions = "".join(f"<li>{html.escape(item)}</li>" for item in version.exclusions) or "<li>None</li>"
+    return f"""
+<div class='three'><div><h3>Scope</h3><ul>{scope}</ul></div><div><h3>Deliverables</h3><ul>{deliverables}</ul></div><div><h3>Exclusions</h3><ul>{exclusions}</ul></div></div>
+<p><strong>Version:</strong> {version.version} · <strong>Fee:</strong> {html.escape(str(version.fee))} {html.escape(version.currency)} / {html.escape(version.billing_cadence.value)} · <strong>Cadence:</strong> {html.escape(version.cadence_description or 'Not set')}</p>
+<p><strong>Response:</strong> {html.escape(version.response_time or 'Not set')} · <strong>Escalation:</strong> {html.escape(version.escalation_expectations or 'Not set')}</p>"""
+
+
+def _history(record: RecurringServiceRecord) -> str:
+    if not record.events:
+        return "<p class='muted'>No recurring lifecycle events yet.</p>"
+    return "<ul class='checklist'>" + "".join(
+        f"<li><strong>{html.escape(_status_label(item.action))}</strong> · {html.escape(item.at.isoformat())}"
+        + (f"<br><span class='muted'>{html.escape(item.reference)}</span>" if item.reference else "")
+        + "</li>"
+        for item in reversed(record.events)
+    ) + "</ul>"
+
+
+def _configure_form(record: RecurringServiceRecord, *, renewal: bool = False) -> str:
+    version = record.active_version
+    scope = "\n".join(version.scope) if version else ""
+    deliverables = "\n".join(version.deliverables) if version else ""
+    exclusions = "\n".join(version.exclusions) if version else ""
+    fee = str(version.fee) if version else "99.00"
+    currency = version.currency if version else "EUR"
+    cadence = version.billing_cadence.value if version else BillingCadence.monthly.value
+    action = "renew" if renewal else "configure"
+    heading = "Renew / change recurring plan" if renewal else "Configure recurring plan"
+    submit = "Create new plan version" if renewal else "Save recurring plan"
+    return f"""<section><h2>{heading}</h2><form method='post' action='recurring/{action}'>
+<label>Service scope — one item per line</label><textarea name='scope' required>{html.escape(scope)}</textarea>
+<div class='row'><div><label>Deliverables — one per line</label><textarea name='deliverables' required>{html.escape(deliverables)}</textarea></div><div><label>Exclusions — one per line</label><textarea name='exclusions'>{html.escape(exclusions)}</textarea></div></div>
+<div class='three'><div><label>Recurring fee</label><input name='fee' value='{html.escape(fee, quote=True)}' required></div><div><label>Currency</label><input name='currency' maxlength='3' value='{html.escape(currency, quote=True)}' required></div><div><label>Billing cadence</label><select name='billing_cadence'><option value='monthly' {'selected' if cadence == 'monthly' else ''}>Monthly</option><option value='quarterly' {'selected' if cadence == 'quarterly' else ''}>Quarterly</option><option value='annually' {'selected' if cadence == 'annually' else ''}>Annually</option></select></div></div>
+<label>Service / monitoring cadence</label><input name='cadence_description' value='{html.escape(version.cadence_description if version else '', quote=True)}' required>
+<div class='row'><div><label>Response-time expectation</label><input name='response_time' value='{html.escape(version.response_time if version else '', quote=True)}'></div><div><label>Escalation expectation</label><input name='escalation_expectations' value='{html.escape(version.escalation_expectations if version else '', quote=True)}'></div></div>
+<label>Effective from</label><input type='date' name='effective_from' value='{html.escape(str(version.effective_from) if version and version.effective_from else '', quote=True)}'>
+{"<label>Renewal / scope-price change reference</label><textarea name='renewal_reference' required></textarea>" if renewal else ''}
+<button type='submit'>{submit}</button></form></section>"""
+
+
+def _actions(record: RecurringServiceRecord, customer: CustomerRecord) -> str:
+    if record.status is RecurringServiceStatus.draft:
+        return _configure_form(record) + ("<section><form method='post' action='recurring/offer'><button type='submit'>Mark plan offered</button></form></section>" if record.active_version else "")
+    if record.status is RecurringServiceStatus.offered:
+        return """<section><h2>Activate accepted recurring service</h2><form method='post' action='recurring/accept'><label>Acceptance evidence/reference</label><textarea name='acceptance_reference' required></textarea><div class='three'><div><label>Start date</label><input type='date' name='start_date' required></div><div><label>Next billing date</label><input type='date' name='next_billing_date' required></div><div><label>Renewal date</label><input type='date' name='renewal_date'></div></div><div class='three'><div><label>Minimum term (months)</label><input type='number' min='0' max='120' name='minimum_term_months' value='0'></div><div><label>Renewal behavior</label><select name='renewal_behavior'><option value='manual'>Manual decision</option><option value='auto_renew'>Auto renew</option><option value='fixed_term'>Fixed term</option></select></div><div><label>Monitoring cadence</label><input name='monitoring_cadence' value='Monthly'></div></div><label>Report cadence</label><input name='report_cadence' value='Monthly'><button type='submit'>Record acceptance & activate</button></form></section>"""
+    if record.status is RecurringServiceStatus.cancelled:
+        return "<section><p class='notice'>Recurring service is cancelled. Historical versions and evidence remain read-only.</p></section>"
+    if record.status is RecurringServiceStatus.expired:
+        return "<section><p class='notice'>Recurring service has expired. Create a new recurring agreement rather than silently reactivating this record.</p></section>"
+    change_link = html.escape(_change_request_link(customer), quote=True)
+    common = f"""<section><h2>Recurring operations</h2><div class='row'><form method='post' action='recurring/deliverable'><label>Completed recurring deliverable</label><input name='deliverable' required><label>Evidence/reference</label><input name='reference' required><button type='submit'>Record deliverable</button></form><form method='post' action='recurring/payment'><label>Invoice reference</label><input name='invoice_reference' required><label>Payment state</label><select name='payment_state'><option value='paid'>Paid</option><option value='failed'>Failed / overdue</option></select><label>Payment/provider reference</label><input name='payment_reference' required><label>Next billing date</label><input type='date' name='next_billing_date'><button type='submit'>Record billing state</button></form></div><p><a class='button secondary' href='{change_link}'>Out-of-scope / overage Change Request</a></p></section>"""
+    if record.status is RecurringServiceStatus.active:
+        return common + f"""<section><div class='row'><form method='post' action='recurring/pause'><h2>Pause service</h2><label>Pause reason/reference</label><textarea name='reference' required></textarea><button class='secondary' type='submit'>Pause</button></form><form method='post' action='recurring/cancel-notice'><h2>Cancellation notice</h2><label>Notice date</label><input type='date' name='notice_date' required><label>Requested effective date</label><input type='date' name='effective_date'><label>Notice/reference</label><textarea name='reference' required></textarea><button class='secondary' type='submit'>Record cancellation notice</button></form></div></section>{_configure_form(record, renewal=True)}"""
+    if record.status is RecurringServiceStatus.paused:
+        return common + "<section><p class='notice warning'>Service is paused; recurring work should not be treated as active.</p><form method='post' action='recurring/resume'><label>Resume evidence/reference</label><textarea name='reference' required></textarea><button type='submit'>Resume service</button></form></section>"
+    if record.status is RecurringServiceStatus.payment_blocked:
+        return common + "<section><p class='notice danger'>Service is payment-blocked. Record a paid billing state before normal delivery resumes.</p></section>"
+    if record.status is RecurringServiceStatus.cancellation_pending:
+        return """<section><p class='notice warning'>Cancellation is pending. Complete the exit/handoff boundary before final cancellation.</p><form method='post' action='recurring/cancel-complete'><label>Effective cancellation date</label><input type='date' name='effective_date' required><label>Exit / ownership-access handoff evidence</label><textarea name='exit_handoff_reference' required></textarea><button type='submit'>Complete cancellation</button></form></section>"""
+    return common
+
+
+@router.get("/projects/{project_id}/recurring", response_class=HTMLResponse)
+def recurring_service_page(project_id: str, request: Request) -> str:
+    identity = _identity(request)
+    _project_exists(request, identity, project_id)
+    customer_id, customer = _linked_customer(request, identity, project_id)
+    record = TenantRecurringServiceStore(_root(request)).load_or_empty(identity, project_id, customer_id)
+    next_billing = str(record.next_billing_date) if record.next_billing_date else "Not scheduled"
+    renewal = str(record.renewal_date) if record.renewal_date else "Not scheduled"
+    body = f"""{agency_navigation(identity, current='projects')}<section><p><a href='/agency/projects/{html.escape(project_id, quote=True)}'>← Project overview</a></p><h1>Recurring service</h1><p><strong>Customer:</strong> {html.escape(customer.business_name)} · <span class='badge'>{html.escape(_status_label(record.status.value))}</span></p><p><strong>Next billing:</strong> {html.escape(next_billing)} · <strong>Renewal:</strong> {html.escape(renewal)} · <strong>Next action:</strong> {html.escape(record.next_action or 'Not set')}</p></section><section><h2>Current plan</h2>{_version_summary(record)}</section>{_actions(record, customer)}<section><details><summary><strong>Recurring lifecycle history</strong></summary>{_history(record)}</details></section>"""
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>Recurring service</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+@router.get("/recurring-services", response_class=HTMLResponse)
+def recurring_service_index(request: Request) -> str:
+    identity = _identity(request)
+    store = TenantRecurringServiceStore(_root(request))
+    records = store.list(identity)
+    customer_names = {customer_id: customer.business_name for customer_id, customer in TenantCustomerStore(_root(request)).list(identity)}
+    if records:
+        rows = "".join(
+            f"<tr><td><a href='/agency/projects/{html.escape(item.project_id, quote=True)}/recurring'>{html.escape(customer_names.get(item.customer_id, item.customer_id))}</a></td><td>{html.escape(_status_label(item.status.value))}</td><td>{html.escape(str(item.active_version.fee) + ' ' + item.active_version.currency if item.active_version else 'Not configured')}</td><td>{html.escape(str(item.next_billing_date) if item.next_billing_date else '—')}</td><td>{html.escape(item.next_action or '—')}</td></tr>"
+            for item in records
+        )
+    else:
+        rows = "<tr><td colspan='5' class='muted'>No recurring services configured yet.</td></tr>"
+    body = f"""{agency_navigation(identity, current='customers')}<section><h1>Recurring revenue</h1><p class='muted'>Operational view of recurring service state, billing and next action.</p><table><thead><tr><th>Customer</th><th>Status</th><th>Fee</th><th>Next billing</th><th>Next action</th></tr></thead><tbody>{rows}</tbody></table></section>"""
+    return f"<!doctype html><html lang='en'><head><meta charset='utf-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>Recurring revenue</title><style>{_STYLE}</style></head><body><main>{body}</main></body></html>"
+
+
+def _record_for_write(request: Request, project_id: str) -> tuple[RequestIdentity, str, CustomerRecord, RecurringServiceRecord]:
+    identity = _identity(request, TenantCapability.manage_projects)
+    _trusted_origin(request)
+    _project_exists(request, identity, project_id)
+    customer_id, customer = _linked_customer(request, identity, project_id)
+    record = TenantRecurringServiceStore(_root(request)).load_or_empty(identity, project_id, customer_id)
+    return identity, customer_id, customer, record
+
+
+def _redirect(project_id: str) -> RedirectResponse:
+    return RedirectResponse(f"/agency/projects/{project_id}/recurring", status_code=303)
+
+
+@router.post("/projects/{project_id}/recurring/configure")
+async def configure_recurring(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status is not RecurringServiceStatus.draft:
+        raise HTTPException(status_code=409, detail="Only a draft recurring service can be configured directly.")
+    values = _values(await request.body())
+    try:
+        cadence = BillingCadence(_one(values, "billing_cadence"))
+        version = RecurringServiceVersion(
+            version=max((item.version for item in record.versions), default=0) + 1,
+            scope=_lines(values, "scope"),
+            deliverables=_lines(values, "deliverables"),
+            exclusions=_lines(values, "exclusions"),
+            cadence_description=_one(values, "cadence_description"),
+            response_time=_one(values, "response_time"),
+            escalation_expectations=_one(values, "escalation_expectations"),
+            fee=_parse_money(_one(values, "fee")),
+            currency=_one(values, "currency").upper(),
+            billing_cadence=cadence,
+            effective_from=_parse_date(_one(values, "effective_from"), "Effective-from date"),
+        )
+    except (ValueError, ValidationError) as exc:
+        raise HTTPException(status_code=400, detail="Recurring plan configuration is invalid.") from exc
+    _save(request, identity, record, {"versions": (*record.versions, version), "current_version": version.version}, action="plan_configured", reference=f"Version {version.version}")
+    return _redirect(project_id)
+
+
+@router.post("/projects/{project_id}/recurring/offer")
+async def offer_recurring(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status is not RecurringServiceStatus.draft or record.active_version is None:
+        raise HTTPException(status_code=409, detail="A configured draft plan is required before offering recurring service.")
+    _save(request, identity, record, {"status": RecurringServiceStatus.offered, "offered_at": datetime.now(UTC), "next_action": "Await customer recurring-service decision."}, action="plan_offered")
+    return _redirect(project_id)
+
+
+@router.post("/projects/{project_id}/recurring/accept")
+async def accept_recurring(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status is not RecurringServiceStatus.offered:
+        raise HTTPException(status_code=409, detail="Only an offered recurring plan can be accepted.")
+    values = _values(await request.body())
+    reference = _one(values, "acceptance_reference")
+    try:
+        minimum = int(_one(values, "minimum_term_months") or "0")
+        renewal_behavior = RenewalBehavior(_one(values, "renewal_behavior"))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Recurring acceptance terms are invalid.") from exc
+    _save(
+        request,
+        identity,
+        record,
+        {
+            "status": RecurringServiceStatus.active,
+            "accepted_at": datetime.now(UTC),
+            "acceptance_reference": reference,
+            "start_date": _parse_date(_one(values, "start_date"), "Start date", required=True),
+            "minimum_term_months": minimum,
+            "renewal_behavior": renewal_behavior,
+            "renewal_date": _parse_date(_one(values, "renewal_date"), "Renewal date"),
+            "next_billing_date": _parse_date(_one(values, "next_billing_date"), "Next billing date", required=True),
+            "monitoring_cadence": _one(values, "monitoring_cadence"),
+            "report_cadence": _one(values, "report_cadence"),
+            "next_action": "Run the next recurring deliverable and maintain billing evidence.",
+        },
+        action="service_activated",
+        reference=reference,
+    )
+    return _redirect(project_id)
+
+
+@router.post("/projects/{project_id}/recurring/deliverable")
+async def recurring_deliverable(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status is not RecurringServiceStatus.active:
+        raise HTTPException(status_code=409, detail="Recurring deliverables can only be recorded while service is active.")
+    values = _values(await request.body())
+    deliverable = _one(values, "deliverable")
+    reference = _one(values, "reference")
+    if not deliverable or not reference:
+        raise HTTPException(status_code=400, detail="Deliverable and evidence/reference are required.")
+    _save(request, identity, record, {"completed_deliverables": (*record.completed_deliverables, deliverable), "next_action": "Review next billing date and scheduled recurring deliverable."}, action="deliverable_completed", reference=f"{deliverable}: {reference}")
+    return _redirect(project_id)
+
+
+@router.post("/projects/{project_id}/recurring/payment")
+async def recurring_payment(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status not in {RecurringServiceStatus.active, RecurringServiceStatus.payment_blocked}:
+        raise HTTPException(status_code=409, detail="Billing state can only be updated for active or payment-blocked service.")
+    values = _values(await request.body())
+    state = _one(values, "payment_state")
+    if state not in {"paid", "failed"}:
+        raise HTTPException(status_code=400, detail="Payment state is invalid.")
+    invoice_reference = _one(values, "invoice_reference")
+    payment_reference = _one(values, "payment_reference")
+    if not invoice_reference or not payment_reference:
+        raise HTTPException(status_code=400, detail="Invoice and payment/provider references are required.")
+    status = RecurringServiceStatus.active if state == "paid" else RecurringServiceStatus.payment_blocked
+    _save(request, identity, record, {"status": status, "invoice_reference": invoice_reference, "payment_reference": payment_reference, "last_payment_state": f"{state}: {invoice_reference} / {payment_reference}", "next_billing_date": _parse_date(_one(values, "next_billing_date"), "Next billing date") or record.next_billing_date, "next_action": "Continue recurring delivery." if state == "paid" else "Resolve failed/overdue recurring payment before further delivery."}, action="billing_paid" if state == "paid" else "billing_failed", reference=f"{invoice_reference} / {payment_reference}")
+    return _redirect(project_id)
+
+
+@router.post("/projects/{project_id}/recurring/pause")
+async def pause_recurring(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status is not RecurringServiceStatus.active:
+        raise HTTPException(status_code=409, detail="Only active recurring service can be paused.")
+    values = _values(await request.body())
+    reference = _one(values, "reference")
+    _save(request, identity, record, {"status": RecurringServiceStatus.paused, "pause_reference": reference, "next_action": "Resolve pause condition before recurring work resumes."}, action="service_paused", reference=reference)
+    return _redirect(project_id)
+
+
+@router.post("/projects/{project_id}/recurring/resume")
+async def resume_recurring(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status is not RecurringServiceStatus.paused:
+        raise HTTPException(status_code=409, detail="Only paused recurring service can be resumed directly.")
+    values = _values(await request.body())
+    reference = _one(values, "reference")
+    if not reference:
+        raise HTTPException(status_code=400, detail="Resume evidence/reference is required.")
+    _save(request, identity, record, {"status": RecurringServiceStatus.active, "pause_reference": "", "next_action": "Continue recurring delivery and billing cadence."}, action="service_resumed", reference=reference)
+    return _redirect(project_id)
+
+
+@router.post("/projects/{project_id}/recurring/renew")
+async def renew_recurring(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status is not RecurringServiceStatus.active:
+        raise HTTPException(status_code=409, detail="Only active recurring service can be renewed or re-scoped.")
+    values = _values(await request.body())
+    reference = _one(values, "renewal_reference")
+    if not reference:
+        raise HTTPException(status_code=400, detail="Renewal/scope-price change reference is required.")
+    try:
+        version = RecurringServiceVersion(
+            version=max((item.version for item in record.versions), default=0) + 1,
+            scope=_lines(values, "scope"),
+            deliverables=_lines(values, "deliverables"),
+            exclusions=_lines(values, "exclusions"),
+            cadence_description=_one(values, "cadence_description"),
+            response_time=_one(values, "response_time"),
+            escalation_expectations=_one(values, "escalation_expectations"),
+            fee=_parse_money(_one(values, "fee")),
+            currency=_one(values, "currency").upper(),
+            billing_cadence=BillingCadence(_one(values, "billing_cadence")),
+            effective_from=_parse_date(_one(values, "effective_from"), "Effective-from date"),
+        )
+    except (ValueError, ValidationError) as exc:
+        raise HTTPException(status_code=400, detail="Renewal version is invalid.") from exc
+    _save(request, identity, record, {"versions": (*record.versions, version), "current_version": version.version, "renewal_reference": reference, "next_action": "Operate recurring service under the new approved plan version."}, action="service_renewed", reference=f"Version {version.version}: {reference}")
+    return _redirect(project_id)
+
+
+@router.post("/projects/{project_id}/recurring/cancel-notice")
+async def cancel_notice(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status not in {RecurringServiceStatus.active, RecurringServiceStatus.paused, RecurringServiceStatus.payment_blocked}:
+        raise HTTPException(status_code=409, detail="Cancellation notice is not valid from the current recurring state.")
+    values = _values(await request.body())
+    reference = _one(values, "reference")
+    _save(request, identity, record, {"status": RecurringServiceStatus.cancellation_pending, "cancellation_notice_date": _parse_date(_one(values, "notice_date"), "Cancellation notice date", required=True), "cancellation_effective_date": _parse_date(_one(values, "effective_date"), "Cancellation effective date"), "cancellation_reference": reference, "next_action": "Complete recurring-service exit and ownership/access handoff."}, action="cancellation_notice", reference=reference)
+    return _redirect(project_id)
+
+
+@router.post("/projects/{project_id}/recurring/cancel-complete")
+async def cancel_complete(project_id: str, request: Request) -> RedirectResponse:
+    identity, _customer_id, _customer, record = _record_for_write(request, project_id)
+    if record.status is not RecurringServiceStatus.cancellation_pending:
+        raise HTTPException(status_code=409, detail="Cancellation must be pending before it can be completed.")
+    values = _values(await request.body())
+    exit_reference = _one(values, "exit_handoff_reference")
+    _save(request, identity, record, {"status": RecurringServiceStatus.cancelled, "cancellation_effective_date": _parse_date(_one(values, "effective_date"), "Cancellation effective date", required=True), "exit_handoff_reference": exit_reference, "next_action": "Recurring service closed; retain historical evidence only."}, action="service_cancelled", reference=exit_reference)
+    return _redirect(project_id)

--- a/src/veridra/recurring_service.py
+++ b/src/veridra/recurring_service.py
@@ -179,6 +179,19 @@ class RecurringServiceStore:
                 "Saved recurring service record was not found or is invalid."
             ) from exc
 
+    def list(self) -> list[RecurringServiceRecord]:
+        if not self.directory.exists():
+            return []
+        records: list[RecurringServiceRecord] = []
+        for path in sorted(self.directory.glob("*.json")):
+            try:
+                records.append(RecurringServiceRecord.model_validate_json(path.read_text(encoding="utf-8")))
+            except (OSError, ValueError) as exc:
+                raise RecurringServiceStoreError(
+                    f"Saved recurring service record {path.name!r} is invalid."
+                ) from exc
+        return records
+
     def save(self, record: RecurringServiceRecord) -> None:
         self.directory.mkdir(parents=True, exist_ok=True)
         content = json.dumps(

--- a/src/veridra/recurring_service.py
+++ b/src/veridra/recurring_service.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from enum import StrEnum
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class RecurringServiceStatus(StrEnum):
+    draft = "draft"
+    offered = "offered"
+    active = "active"
+    paused = "paused"
+    payment_blocked = "payment_blocked"
+    cancellation_pending = "cancellation_pending"
+    cancelled = "cancelled"
+    expired = "expired"
+
+
+class BillingCadence(StrEnum):
+    monthly = "monthly"
+    quarterly = "quarterly"
+    annually = "annually"
+
+
+class RenewalBehavior(StrEnum):
+    manual = "manual"
+    auto_renew = "auto_renew"
+    fixed_term = "fixed_term"
+
+
+class RecurringServiceEvent(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    action: str = Field(min_length=1, max_length=120)
+    reference: str = Field(default="", max_length=2000)
+    at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class RecurringServiceVersion(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    version: int = Field(ge=1)
+    scope: tuple[str, ...] = ()
+    exclusions: tuple[str, ...] = ()
+    deliverables: tuple[str, ...] = ()
+    cadence_description: str = Field(default="", max_length=1000)
+    response_time: str = Field(default="", max_length=500)
+    escalation_expectations: str = Field(default="", max_length=1000)
+    fee: Decimal = Field(default=Decimal("0"), ge=0)
+    currency: str = Field(default="EUR", min_length=3, max_length=3)
+    billing_cadence: BillingCadence = BillingCadence.monthly
+    effective_from: date | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @model_validator(mode="after")
+    def validate_commercial_terms(self) -> RecurringServiceVersion:
+        if self.currency.upper() != self.currency:
+            raise ValueError("Currency must use an uppercase ISO-style code.")
+        if self.fee > 0 and not self.scope:
+            raise ValueError("Paid recurring service requires a bounded service scope.")
+        return self
+
+
+class RecurringServiceRecord(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", str_strip_whitespace=True)
+
+    project_id: str = Field(min_length=24, max_length=64)
+    customer_id: str = Field(min_length=24, max_length=64)
+    status: RecurringServiceStatus = RecurringServiceStatus.draft
+    versions: tuple[RecurringServiceVersion, ...] = ()
+    current_version: int | None = None
+    offered_at: datetime | None = None
+    accepted_at: datetime | None = None
+    acceptance_reference: str = Field(default="", max_length=2000)
+    start_date: date | None = None
+    minimum_term_months: int = Field(default=0, ge=0, le=120)
+    renewal_behavior: RenewalBehavior = RenewalBehavior.manual
+    renewal_date: date | None = None
+    renewal_reference: str = Field(default="", max_length=2000)
+    next_billing_date: date | None = None
+    invoice_reference: str = Field(default="", max_length=240)
+    payment_reference: str = Field(default="", max_length=240)
+    last_payment_state: str = Field(default="", max_length=120)
+    monitoring_cadence: str = Field(default="", max_length=500)
+    report_cadence: str = Field(default="", max_length=500)
+    next_action: str = Field(default="", max_length=1000)
+    completed_deliverables: tuple[str, ...] = ()
+    overage_reference: str = Field(default="", max_length=2000)
+    pause_reference: str = Field(default="", max_length=2000)
+    cancellation_notice_date: date | None = None
+    cancellation_effective_date: date | None = None
+    cancellation_reference: str = Field(default="", max_length=2000)
+    exit_handoff_reference: str = Field(default="", max_length=2000)
+    events: tuple[RecurringServiceEvent, ...] = ()
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @property
+    def active_version(self) -> RecurringServiceVersion | None:
+        if self.current_version is None:
+            return None
+        return next(
+            (item for item in self.versions if item.version == self.current_version),
+            None,
+        )
+
+    @model_validator(mode="after")
+    def validate_state(self) -> RecurringServiceRecord:
+        version_numbers = [item.version for item in self.versions]
+        if len(version_numbers) != len(set(version_numbers)):
+            raise ValueError("Recurring service versions must be unique.")
+        if version_numbers != sorted(version_numbers):
+            raise ValueError("Recurring service versions must be stored in ascending order.")
+        if self.current_version is not None and self.active_version is None:
+            raise ValueError("Current recurring service version does not exist.")
+        if self.status is not RecurringServiceStatus.draft and self.active_version is None:
+            raise ValueError("Recurring service status requires a current service version.")
+        if self.status in {
+            RecurringServiceStatus.offered,
+            RecurringServiceStatus.active,
+            RecurringServiceStatus.paused,
+            RecurringServiceStatus.payment_blocked,
+            RecurringServiceStatus.cancellation_pending,
+            RecurringServiceStatus.cancelled,
+            RecurringServiceStatus.expired,
+        } and self.offered_at is None:
+            raise ValueError("Offered and later recurring states require an offered-at timestamp.")
+        if self.status in {
+            RecurringServiceStatus.active,
+            RecurringServiceStatus.paused,
+            RecurringServiceStatus.payment_blocked,
+            RecurringServiceStatus.cancellation_pending,
+            RecurringServiceStatus.cancelled,
+        }:
+            if self.accepted_at is None or not self.acceptance_reference:
+                raise ValueError("Active recurring service requires acceptance evidence.")
+            if self.start_date is None:
+                raise ValueError("Active recurring service requires a start date.")
+        if self.status is RecurringServiceStatus.payment_blocked and not self.last_payment_state:
+            raise ValueError("Payment-blocked service requires a payment-state reference.")
+        if self.status is RecurringServiceStatus.paused and not self.pause_reference:
+            raise ValueError("Paused service requires a pause reference.")
+        if self.status in {
+            RecurringServiceStatus.cancellation_pending,
+            RecurringServiceStatus.cancelled,
+        }:
+            if self.cancellation_notice_date is None or not self.cancellation_reference:
+                raise ValueError("Cancellation requires notice date and evidence/reference.")
+        if self.status is RecurringServiceStatus.cancelled:
+            if self.cancellation_effective_date is None:
+                raise ValueError("Cancelled service requires an effective cancellation date.")
+            if not self.exit_handoff_reference:
+                raise ValueError("Cancelled service requires exit/handoff evidence.")
+        return self
+
+
+class RecurringServiceStoreError(RuntimeError):
+    pass
+
+
+class RecurringServiceStore:
+    def __init__(self, directory: Path) -> None:
+        self.directory = directory
+
+    def _path(self, project_id: str) -> Path:
+        return self.directory / f"{project_id}.json"
+
+    def load(self, project_id: str) -> RecurringServiceRecord:
+        try:
+            text = self._path(project_id).read_text(encoding="utf-8")
+            return RecurringServiceRecord.model_validate_json(text)
+        except (OSError, ValueError) as exc:
+            raise RecurringServiceStoreError(
+                "Saved recurring service record was not found or is invalid."
+            ) from exc
+
+    def save(self, record: RecurringServiceRecord) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        content = json.dumps(
+            record.model_dump(mode="json"),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        path = self._path(record.project_id)
+        with NamedTemporaryFile(
+            mode="wb",
+            dir=self.directory,
+            prefix=f".{record.project_id}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(path)

--- a/src/veridra/runtime.py
+++ b/src/veridra/runtime.py
@@ -32,6 +32,7 @@ from .agency_prospect_discovery_evidence_web import (
 from .agency_prospect_discovery_web import router as agency_prospect_discovery_router
 from .agency_prospect_import_web import router as agency_prospect_import_router
 from .agency_prospect_web import router as agency_prospect_router
+from .agency_recurring_service_web import router as agency_recurring_service_router
 from .agency_reply_transition_web import router as agency_reply_transition_router
 from .agency_report_profile_edit_web import router as agency_report_profile_edit_router
 from .agency_report_profile_web import router as agency_report_profile_router
@@ -178,6 +179,7 @@ app.include_router(agency_customer_project_router)
 app.include_router(agency_customer_router)
 app.include_router(agency_project_index_router)
 app.include_router(agency_project_customer_router)
+app.include_router(agency_recurring_service_router)
 app.include_router(agency_conversion_router)
 app.include_router(agency_crawl_profile_router)
 app.include_router(agency_prospect_import_router)

--- a/src/veridra/tenant_recurring_service_store.py
+++ b/src/veridra/tenant_recurring_service_store.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .identity_tenancy import (
+    RequestIdentity,
+    TenantCapability,
+    require_tenant_capability,
+)
+from .recurring_service import (
+    RecurringServiceRecord,
+    RecurringServiceStore,
+    RecurringServiceStoreError,
+)
+from .tenant_project_store import default_tenant_data_directory
+
+
+class TenantRecurringServiceStoreError(RuntimeError):
+    pass
+
+
+class TenantRecurringServiceStore:
+    def __init__(self, root: Path | None = None) -> None:
+        self.root = root or default_tenant_data_directory()
+
+    def _store(self, identity: RequestIdentity) -> RecurringServiceStore:
+        return RecurringServiceStore(
+            self.root / identity.tenant_id / "recurring-services"
+        )
+
+    def load_or_empty(
+        self,
+        identity: RequestIdentity,
+        project_id: str,
+        customer_id: str,
+    ) -> RecurringServiceRecord:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        try:
+            record = self._store(identity).load(project_id)
+        except RecurringServiceStoreError:
+            return RecurringServiceRecord(
+                project_id=project_id,
+                customer_id=customer_id,
+            )
+        if record.customer_id != customer_id:
+            raise TenantRecurringServiceStoreError(
+                "Recurring service customer linkage does not match the requested customer."
+            )
+        return record
+
+    def save(
+        self,
+        identity: RequestIdentity,
+        record: RecurringServiceRecord,
+    ) -> None:
+        require_tenant_capability(identity, TenantCapability.manage_projects)
+        stamped = record.model_copy(update={"updated_at": datetime.now(UTC)})
+        try:
+            self._store(identity).save(stamped)
+        except (OSError, ValueError) as exc:
+            raise TenantRecurringServiceStoreError(
+                "Recurring service record could not be saved safely."
+            ) from exc

--- a/src/veridra/tenant_recurring_service_store.py
+++ b/src/veridra/tenant_recurring_service_store.py
@@ -49,6 +49,15 @@ class TenantRecurringServiceStore:
             )
         return record
 
+    def list(self, identity: RequestIdentity) -> list[RecurringServiceRecord]:
+        require_tenant_capability(identity, TenantCapability.view_data)
+        try:
+            return self._store(identity).list()
+        except RecurringServiceStoreError as exc:
+            raise TenantRecurringServiceStoreError(
+                "Recurring service records could not be loaded safely."
+            ) from exc
+
     def save(
         self,
         identity: RequestIdentity,

--- a/tests/test_agency_recurring_service_web.py
+++ b/tests/test_agency_recurring_service_web.py
@@ -187,7 +187,10 @@ def test_recurring_full_operator_lifecycle(
         client,
         f"{base}/renew",
         {
-            "scope": "Monthly website health review\nMonitoring review\nQuarterly conversion-path review",
+            "scope": (
+                "Monthly website health review\nMonitoring review\n"
+                "Quarterly conversion-path review"
+            ),
             "deliverables": "Monthly monitoring review\nMonthly client summary",
             "exclusions": "New page builds\nPaid media",
             "fee": "129.00",

--- a/tests/test_agency_recurring_service_web.py
+++ b/tests/test_agency_recurring_service_web.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import cast
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from fastapi.testclient import TestClient
+from httpx import Response as HTTPResponse
+
+from veridra.agency_recurring_service_web import router
+from veridra.customer_store import CustomerRecord, CustomerSourceType
+from veridra.identity_tenancy import RequestIdentity, TenantRole
+from veridra.project_store import ClientProject, ProjectStore
+from veridra.recurring_service import RecurringServiceStatus
+from veridra.request_security import bind_verified_request_identity
+from veridra.tenant_customer_store import TenantCustomerStore
+from veridra.tenant_recurring_service_store import TenantRecurringServiceStore
+
+ORIGIN = "http://testserver"
+NOW = datetime(2026, 9, 4, 10, 0, tzinfo=UTC)
+OWNER = RequestIdentity(
+    user_id="1" * 24,
+    tenant_id="a" * 24,
+    membership_role=TenantRole.owner,
+    session_id="recurring-owner-session-01",
+    authenticated_at=NOW,
+)
+
+
+def _client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TestClient, Path, str, str]:
+    root = tmp_path / "tenants"
+    app = FastAPI()
+    app.state.veridra_tenant_data_root = root
+
+    @app.middleware("http")
+    async def identity(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        bind_verified_request_identity(request, OWNER)
+        return await call_next(request)
+
+    app.include_router(router)
+    monkeypatch.setenv("VERIDRA_TRUSTED_ORIGIN", ORIGIN)
+    project_id = ProjectStore(root / OWNER.tenant_id / "projects").save(
+        ClientProject.build(
+            name="Synthetic recurring service",
+            target_url="https://example.com",
+            client_label="Synthetic client",
+        )
+    )
+    customer = CustomerRecord(
+        business_name="Synthetic recurring customer",
+        website="https://example.com",
+        source_type=CustomerSourceType.prospect,
+        source_id="b" * 24,
+        project_ids=(project_id,),
+    )
+    customer_id = TenantCustomerStore(root).upsert(OWNER, customer)
+    return TestClient(app), root, project_id, customer_id
+
+
+def _post(
+    client: TestClient,
+    path: str,
+    data: dict[str, str] | None = None,
+) -> HTTPResponse:
+    return cast(
+        HTTPResponse,
+        client.post(
+            path,
+            headers={"Origin": ORIGIN},
+            data=data or {},
+            follow_redirects=False,
+        ),
+    )
+
+
+def test_recurring_full_operator_lifecycle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, root, project_id, customer_id = _client(tmp_path, monkeypatch)
+    base = f"/agency/projects/{project_id}/recurring"
+
+    page = client.get(base)
+    assert page.status_code == 200
+    assert "Configure recurring plan" in page.text
+    assert "Synthetic recurring customer" in page.text
+
+    configured = _post(
+        client,
+        f"{base}/configure",
+        {
+            "scope": "Monthly website health review\nMonitoring review",
+            "deliverables": "Monthly monitoring review\nMonthly client summary",
+            "exclusions": "New page builds\nPaid media",
+            "fee": "99.00",
+            "currency": "EUR",
+            "billing_cadence": "monthly",
+            "cadence_description": "Monthly review and report",
+            "response_time": "Review within two business days",
+            "escalation_expectations": "Availability evidence surfaced first",
+            "effective_from": "2026-09-05",
+        },
+    )
+    assert configured.status_code == 303
+    assert _post(client, f"{base}/offer").status_code == 303
+
+    activated = _post(
+        client,
+        f"{base}/accept",
+        {
+            "acceptance_reference": "Synthetic customer accepts recurring plan v1.",
+            "start_date": "2026-09-05",
+            "next_billing_date": "2026-10-05",
+            "renewal_date": "2026-10-05",
+            "minimum_term_months": "0",
+            "renewal_behavior": "manual",
+            "monitoring_cadence": "Monthly",
+            "report_cadence": "Monthly",
+        },
+    )
+    assert activated.status_code == 303
+
+    delivered = _post(
+        client,
+        f"{base}/deliverable",
+        {
+            "deliverable": "Monthly monitoring review",
+            "reference": "Synthetic monitoring/report evidence 2026-09.",
+        },
+    )
+    assert delivered.status_code == 303
+
+    paused = _post(
+        client,
+        f"{base}/pause",
+        {"reference": "Synthetic customer-requested temporary pause."},
+    )
+    assert paused.status_code == 303
+    record = TenantRecurringServiceStore(root).load_or_empty(
+        OWNER, project_id, customer_id
+    )
+    assert record.status is RecurringServiceStatus.paused
+    assert _post(
+        client,
+        f"{base}/resume",
+        {"reference": "Synthetic customer requests service resume."},
+    ).status_code == 303
+
+    failed = _post(
+        client,
+        f"{base}/payment",
+        {
+            "invoice_reference": "INV-RECUR-002",
+            "payment_state": "failed",
+            "payment_reference": "Provider attempt failed synthetic ref",
+            "next_billing_date": "2026-10-05",
+        },
+    )
+    assert failed.status_code == 303
+    record = TenantRecurringServiceStore(root).load_or_empty(
+        OWNER, project_id, customer_id
+    )
+    assert record.status is RecurringServiceStatus.payment_blocked
+
+    recovered = _post(
+        client,
+        f"{base}/payment",
+        {
+            "invoice_reference": "INV-RECUR-002",
+            "payment_state": "paid",
+            "payment_reference": "PAY-RECUR-002",
+            "next_billing_date": "2026-11-05",
+        },
+    )
+    assert recovered.status_code == 303
+
+    renewed = _post(
+        client,
+        f"{base}/renew",
+        {
+            "scope": "Monthly website health review\nMonitoring review\nQuarterly conversion-path review",
+            "deliverables": "Monthly monitoring review\nMonthly client summary",
+            "exclusions": "New page builds\nPaid media",
+            "fee": "129.00",
+            "currency": "EUR",
+            "billing_cadence": "monthly",
+            "cadence_description": "Monthly review and quarterly conversion-path review",
+            "response_time": "Review within two business days",
+            "escalation_expectations": "Availability evidence surfaced first",
+            "effective_from": "2026-10-05",
+            "renewal_reference": "Synthetic customer approval of recurring v2.",
+        },
+    )
+    assert renewed.status_code == 303
+    record = TenantRecurringServiceStore(root).load_or_empty(
+        OWNER, project_id, customer_id
+    )
+    assert record.current_version == 2
+    assert record.active_version is not None
+    assert str(record.active_version.fee) == "129.00"
+
+    notice = _post(
+        client,
+        f"{base}/cancel-notice",
+        {
+            "notice_date": "2026-10-20",
+            "effective_date": "2026-11-05",
+            "reference": "Synthetic cancellation notice.",
+        },
+    )
+    assert notice.status_code == 303
+    cancelled = _post(
+        client,
+        f"{base}/cancel-complete",
+        {
+            "effective_date": "2026-11-05",
+            "exit_handoff_reference": (
+                "Synthetic ownership/access exit checklist completed."
+            ),
+        },
+    )
+    assert cancelled.status_code == 303
+    record = TenantRecurringServiceStore(root).load_or_empty(
+        OWNER, project_id, customer_id
+    )
+    assert record.status is RecurringServiceStatus.cancelled
+    assert record.exit_handoff_reference
+    assert record.completed_deliverables == ("Monthly monitoring review",)
+    assert [item.version for item in record.versions] == [1, 2]
+
+    final_page = client.get(base)
+    assert "Recurring service is cancelled" in final_page.text
+    index = client.get("/agency/recurring-services")
+    assert index.status_code == 200
+    assert "Recurring revenue" in index.text
+    assert "Synthetic recurring customer" in index.text
+    assert "Cancelled" in index.text
+
+
+def test_recurring_page_exposes_existing_change_request_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _root, project_id, _customer_id = _client(tmp_path, monkeypatch)
+    base = f"/agency/projects/{project_id}/recurring"
+    assert _post(
+        client,
+        f"{base}/configure",
+        {
+            "scope": "Monitoring review",
+            "deliverables": "Monthly summary",
+            "fee": "99.00",
+            "currency": "EUR",
+            "billing_cadence": "monthly",
+            "cadence_description": "Monthly",
+        },
+    ).status_code == 303
+    assert _post(client, f"{base}/offer").status_code == 303
+    assert _post(
+        client,
+        f"{base}/accept",
+        {
+            "acceptance_reference": "Synthetic acceptance.",
+            "start_date": "2026-09-05",
+            "next_billing_date": "2026-10-05",
+            "minimum_term_months": "0",
+            "renewal_behavior": "manual",
+            "monitoring_cadence": "Monthly",
+            "report_cadence": "Monthly",
+        },
+    ).status_code == 303
+    page = client.get(base)
+    assert "/agency/prospects/" + "b" * 24 + "/deal/change-requests" in page.text
+    assert "Out-of-scope / overage Change Request" in page.text

--- a/tests/test_agency_recurring_service_web.py
+++ b/tests/test_agency_recurring_service_web.py
@@ -57,7 +57,6 @@ def _client(
     )
     customer = CustomerRecord(
         business_name="Synthetic recurring customer",
-        website="https://example.com",
         source_type=CustomerSourceType.prospect,
         source_id="b" * 24,
         project_ids=(project_id,),

--- a/tests/test_recurring_service.py
+++ b/tests/test_recurring_service.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from veridra.recurring_service import (
+    BillingCadence,
+    RecurringServiceRecord,
+    RecurringServiceStatus,
+    RecurringServiceStore,
+    RecurringServiceVersion,
+    RenewalBehavior,
+)
+
+
+PROJECT_ID = "a" * 24
+CUSTOMER_ID = "b" * 24
+
+
+def _version(version: int = 1) -> RecurringServiceVersion:
+    return RecurringServiceVersion(
+        version=version,
+        scope=("Monthly website health review", "Monitoring review"),
+        exclusions=("New page builds", "Third-party paid media"),
+        deliverables=("Monthly monitoring review", "Monthly client summary"),
+        cadence_description="Monthly review and report.",
+        response_time="Operational issues reviewed within two business days.",
+        escalation_expectations="Critical availability evidence is surfaced first.",
+        fee=Decimal("99.00"),
+        currency="EUR",
+        billing_cadence=BillingCadence.monthly,
+        effective_from=date(2026, 9, 4),
+    )
+
+
+def _active() -> RecurringServiceRecord:
+    return RecurringServiceRecord(
+        project_id=PROJECT_ID,
+        customer_id=CUSTOMER_ID,
+        status=RecurringServiceStatus.active,
+        versions=(_version(),),
+        current_version=1,
+        offered_at=datetime(2026, 9, 4, 9, 0, tzinfo=UTC),
+        accepted_at=datetime(2026, 9, 4, 10, 0, tzinfo=UTC),
+        acceptance_reference="Synthetic customer approval.",
+        start_date=date(2026, 9, 5),
+        minimum_term_months=0,
+        renewal_behavior=RenewalBehavior.manual,
+        renewal_date=date(2026, 10, 5),
+        next_billing_date=date(2026, 10, 5),
+        invoice_reference="INV-RECUR-001",
+        payment_reference="PAY-RECUR-001",
+        last_payment_state="paid",
+        monitoring_cadence="Monthly",
+        report_cadence="Monthly",
+        next_action="Run next monthly monitoring review.",
+    )
+
+
+def test_active_service_requires_real_acceptance_evidence() -> None:
+    with pytest.raises(ValidationError, match="acceptance evidence"):
+        RecurringServiceRecord(
+            project_id=PROJECT_ID,
+            customer_id=CUSTOMER_ID,
+            status=RecurringServiceStatus.active,
+            versions=(_version(),),
+            current_version=1,
+            offered_at=datetime(2026, 9, 4, 9, 0, tzinfo=UTC),
+            accepted_at=datetime(2026, 9, 4, 10, 0, tzinfo=UTC),
+            start_date=date(2026, 9, 5),
+        )
+
+
+def test_paid_service_requires_bounded_scope() -> None:
+    with pytest.raises(ValidationError, match="bounded service scope"):
+        RecurringServiceVersion(
+            version=1,
+            fee=Decimal("99.00"),
+            currency="EUR",
+        )
+
+
+def test_payment_blocked_pause_and_cancellation_require_evidence() -> None:
+    active = _active()
+    blocked = RecurringServiceRecord.model_validate(
+        {
+            **active.model_dump(mode="json"),
+            "status": "payment_blocked",
+            "last_payment_state": "failed: invoice INV-RECUR-002",
+        }
+    )
+    assert blocked.status is RecurringServiceStatus.payment_blocked
+
+    paused = RecurringServiceRecord.model_validate(
+        {
+            **active.model_dump(mode="json"),
+            "status": "paused",
+            "pause_reference": "Synthetic customer-requested pause.",
+        }
+    )
+    assert paused.pause_reference
+
+    with pytest.raises(ValidationError, match="Cancellation requires"):
+        RecurringServiceRecord.model_validate(
+            {
+                **active.model_dump(mode="json"),
+                "status": "cancellation_pending",
+            }
+        )
+
+
+def test_cancelled_service_requires_exit_handoff() -> None:
+    active = _active()
+    pending = RecurringServiceRecord.model_validate(
+        {
+            **active.model_dump(mode="json"),
+            "status": "cancellation_pending",
+            "cancellation_notice_date": "2026-09-20",
+            "cancellation_reference": "Synthetic cancellation notice.",
+        }
+    )
+    with pytest.raises(ValidationError, match="exit/handoff evidence"):
+        RecurringServiceRecord.model_validate(
+            {
+                **pending.model_dump(mode="json"),
+                "status": "cancelled",
+                "cancellation_effective_date": "2026-10-05",
+            }
+        )
+
+
+def test_version_history_preserves_scope_and_price_change() -> None:
+    first = _version(1)
+    second = first.model_copy(
+        update={
+            "version": 2,
+            "fee": Decimal("129.00"),
+            "scope": (*first.scope, "Quarterly conversion-path review"),
+            "effective_from": date(2026, 10, 5),
+        }
+    )
+    record = _active().model_copy(
+        update={"versions": (first, second), "current_version": 2}
+    )
+    assert record.active_version == second
+    assert record.versions[0].fee == Decimal("99.00")
+
+
+def test_store_round_trip_is_atomic_json(tmp_path) -> None:
+    store = RecurringServiceStore(tmp_path / "recurring")
+    record = _active()
+    store.save(record)
+    loaded = store.load(PROJECT_ID)
+    assert loaded == record
+    assert (tmp_path / "recurring" / f"{PROJECT_ID}.json").exists()

--- a/tests/test_recurring_service.py
+++ b/tests/test_recurring_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, date, datetime
 from decimal import Decimal
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -148,7 +149,7 @@ def test_version_history_preserves_scope_and_price_change() -> None:
     assert record.versions[0].fee == Decimal("99.00")
 
 
-def test_store_round_trip_is_atomic_json(tmp_path) -> None:
+def test_store_round_trip_is_atomic_json(tmp_path: Path) -> None:
     store = RecurringServiceStore(tmp_path / "recurring")
     record = _active()
     store.save(record)

--- a/tests/test_recurring_service.py
+++ b/tests/test_recurring_service.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
 from veridra.recurring_service import (
     BillingCadence,
@@ -14,7 +14,6 @@ from veridra.recurring_service import (
     RecurringServiceVersion,
     RenewalBehavior,
 )
-
 
 PROJECT_ID = "a" * 24
 CUSTOMER_ID = "b" * 24

--- a/tests/test_recurring_service.py
+++ b/tests/test_recurring_service.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
-import pytest
 from pydantic import ValidationError
+import pytest
 
 from veridra.recurring_service import (
     BillingCadence,

--- a/tools/operator_recurring_visual_acceptance_entry.py
+++ b/tools/operator_recurring_visual_acceptance_entry.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import operator_e2e_acceptance as acceptance
+import operator_e2e_acceptance_entry as hardened
+import operator_visual_acceptance_entry as visual
+from playwright.sync_api import Page
+
+
+def _assert_delivery_url(page: Page, delivery_url: str) -> None:
+    page.wait_for_load_state("networkidle")
+    if page.url != delivery_url:
+        raise AssertionError(f"Delivery transition left expected route: {page.url!r}")
+
+
+def _delivery_closure_with_recurring(page: Page, project_url: str) -> None:
+    """Complete sprint delivery, then exercise the recurring lifecycle in Chromium."""
+    page.goto(f"{project_url}/delivery", wait_until="networkidle")
+    delivery_url = page.url
+    acceptance._assert_text(page, "Delivery setup")
+
+    page.locator("textarea[name='deliverables']").fill(
+        "Client report\nImplemented fixes\nVerification summary"
+    )
+    page.locator("input[name='revision_policy']").fill(
+        "One included revision against agreed scope; additional work requires an "
+        "approved Change Request."
+    )
+    page.locator("input[name='included_revisions']").fill("1")
+    page.locator("textarea[name='acceptance_criteria']").fill(
+        "Agreed deliverables are complete, verified and accepted by the customer."
+    )
+    page.locator("input[name='final_balance_required']").check()
+    page.get_by_role("button", name="Save delivery setup").click()
+    _assert_delivery_url(page, delivery_url)
+    page.get_by_role("button", name="Mark deliverables complete & request review").click()
+    _assert_delivery_url(page, delivery_url)
+
+    page.locator(
+        "form[action$='/changes-requested'] textarea[name='reference']"
+    ).fill("Customer email requests one in-scope copy revision.")
+    page.get_by_role("button", name="Record changes requested").click()
+    _assert_delivery_url(page, delivery_url)
+    page.locator(
+        "form[action$='/revision-completed'] textarea[name='reference']"
+    ).fill("Revision 1 completed and verification rerun.")
+    page.get_by_role("button", name="Complete revision & return to review").click()
+    _assert_delivery_url(page, delivery_url)
+
+    page.locator("form[action$='/unresponsive'] input[name='reference']").fill(
+        "Synthetic follow-up after review deadline; no customer reply."
+    )
+    page.get_by_role("button", name="Mark unresponsive").click()
+    _assert_delivery_url(page, delivery_url)
+    acceptance._assert_text(page, "project remains open")
+    page.get_by_role("button", name="Resume customer review").click()
+    _assert_delivery_url(page, delivery_url)
+
+    page.get_by_role("link", name="Out-of-scope change request").click()
+    hardened._assert_change_request_page(page)
+    page.locator("textarea[name='summary']").fill(
+        "Add a new landing page outside the accepted delivery scope."
+    )
+    page.locator("input[name='requested_by']").fill("customer")
+    page.locator("textarea[name='scope_impact']").fill(
+        "Additional page design, implementation and verification."
+    )
+    page.locator("input[name='price_impact']").fill("Additional fixed fee required.")
+    page.locator("input[name='timeline_impact']").fill(
+        "Adds two working days after approval."
+    )
+    page.get_by_role("button", name="Record change request").click()
+    hardened._assert_change_request_page(page)
+    change_form = page.locator("form[action$='/status']")
+    change_form.locator("select[name='status']").select_option("approved")
+    change_form.locator("input[name='decision_reference']").fill(
+        "Synthetic customer approval for out-of-scope work and price impact."
+    )
+    page.get_by_role("button", name="Update change request").click()
+    hardened._assert_change_request_page(page)
+    acceptance._assert_text(page, "approved")
+
+    page.goto(delivery_url, wait_until="networkidle")
+    page.locator("form[action$='/accept'] textarea[name='reference']").fill(
+        "Synthetic customer acceptance after revision and scope decision."
+    )
+    page.get_by_role("button", name="Record customer acceptance").click()
+    _assert_delivery_url(page, delivery_url)
+    page.get_by_role("button", name="Start handoff").click()
+    _assert_delivery_url(page, delivery_url)
+
+    handoff = page.locator("form[action$='/handoff-complete']")
+    handoff.locator("input[name='backups']").check()
+    handoff.locator("input[name='access']").check()
+    handoff.locator("input[name='documentation']").check()
+    handoff.locator("textarea[name='reference']").fill(
+        "Synthetic backup, access-transfer and documentation handoff evidence."
+    )
+    page.get_by_role("button", name="Complete handoff").click()
+    _assert_delivery_url(page, delivery_url)
+
+    page.locator("textarea[name='completion_summary']").fill(
+        "Synthetic sprint delivered, accepted, handed off and financially closed."
+    )
+    page.locator("input[name='final_balance_evidence']").fill(
+        "Synthetic final invoice balance paid: INV-E2E-FINAL-001."
+    )
+    page.locator("select[name='recurring_decision']").select_option("accepted")
+    page.get_by_role("button", name="Close project").click()
+    _assert_delivery_url(page, delivery_url)
+    acceptance._assert_text(page, "Project closed")
+    acceptance._assert_text(page, "Recurring service: Accepted")
+    visual._capture(page, "17-delivery-closed-recurring-accepted")
+
+    _recurring_lifecycle(page, project_url)
+
+
+def _recurring_lifecycle(page: Page, project_url: str) -> None:
+    recurring_url = f"{project_url}/recurring"
+    page.goto(recurring_url, wait_until="networkidle")
+    acceptance._assert_text(page, "Configure recurring plan")
+    visual._capture(page, "18-recurring-draft")
+
+    page.locator("textarea[name='scope']").fill(
+        "Monthly website health review\nMonitoring review"
+    )
+    page.locator("textarea[name='deliverables']").fill(
+        "Monthly monitoring review\nMonthly client summary"
+    )
+    page.locator("textarea[name='exclusions']").fill(
+        "New page builds\nThird-party paid media"
+    )
+    page.locator("input[name='fee']").fill("99.00")
+    page.locator("input[name='currency']").fill("EUR")
+    page.locator("select[name='billing_cadence']").select_option("monthly")
+    page.locator("input[name='cadence_description']").fill("Monthly review and report")
+    page.locator("input[name='response_time']").fill("Review within two business days")
+    page.locator("input[name='escalation_expectations']").fill(
+        "Critical availability evidence surfaced first"
+    )
+    page.locator("input[name='effective_from']").fill("2026-09-05")
+    page.get_by_role("button", name="Save recurring plan").click()
+    page.wait_for_url(recurring_url)
+    page.get_by_role("button", name="Mark plan offered").click()
+    page.wait_for_url(recurring_url)
+    acceptance._assert_text(page, "Offered")
+
+    page.locator("textarea[name='acceptance_reference']").fill(
+        "Synthetic customer accepts recurring plan v1."
+    )
+    page.locator("input[name='start_date']").fill("2026-09-05")
+    page.locator("input[name='next_billing_date']").fill("2026-10-05")
+    page.locator("input[name='renewal_date']").fill("2026-10-05")
+    page.locator("input[name='minimum_term_months']").fill("0")
+    page.locator("select[name='renewal_behavior']").select_option("manual")
+    page.locator("input[name='monitoring_cadence']").fill("Monthly")
+    page.locator("input[name='report_cadence']").fill("Monthly")
+    page.get_by_role("button", name="Record acceptance & activate").click()
+    page.wait_for_url(recurring_url)
+    acceptance._assert_text(page, "Active")
+    visual._capture(page, "19-recurring-active")
+
+    deliverable_form = page.locator("form[action$='/deliverable']")
+    deliverable_form.locator("input[name='deliverable']").fill(
+        "Monthly monitoring review"
+    )
+    deliverable_form.locator("input[name='reference']").fill(
+        "Synthetic recurring monitoring/report evidence."
+    )
+    page.get_by_role("button", name="Record deliverable").click()
+    page.wait_for_url(recurring_url)
+
+    page.locator("form[action$='/pause'] textarea[name='reference']").fill(
+        "Synthetic customer-requested pause."
+    )
+    page.get_by_role("button", name="Pause").click()
+    page.wait_for_url(recurring_url)
+    acceptance._assert_text(page, "Paused")
+    page.locator("form[action$='/resume'] textarea[name='reference']").fill(
+        "Synthetic customer requests resume."
+    )
+    page.get_by_role("button", name="Resume service").click()
+    page.wait_for_url(recurring_url)
+
+    billing = page.locator("form[action$='/payment']")
+    billing.locator("input[name='invoice_reference']").fill("INV-RECUR-E2E-002")
+    billing.locator("select[name='payment_state']").select_option("failed")
+    billing.locator("input[name='payment_reference']").fill("FAILED-E2E-002")
+    billing.locator("input[name='next_billing_date']").fill("2026-10-05")
+    page.get_by_role("button", name="Record billing state").click()
+    page.wait_for_url(recurring_url)
+    acceptance._assert_text(page, "Payment Blocked")
+    visual._capture(page, "20-recurring-payment-blocked")
+
+    billing = page.locator("form[action$='/payment']")
+    billing.locator("input[name='invoice_reference']").fill("INV-RECUR-E2E-002")
+    billing.locator("select[name='payment_state']").select_option("paid")
+    billing.locator("input[name='payment_reference']").fill("PAY-RECUR-E2E-002")
+    billing.locator("input[name='next_billing_date']").fill("2026-11-05")
+    page.get_by_role("button", name="Record billing state").click()
+    page.wait_for_url(recurring_url)
+    acceptance._assert_text(page, "Active")
+
+    renew = page.locator("form[action$='/renew']")
+    renew.locator("textarea[name='scope']").fill(
+        "Monthly website health review\nMonitoring review\nQuarterly conversion-path review"
+    )
+    renew.locator("textarea[name='deliverables']").fill(
+        "Monthly monitoring review\nMonthly client summary"
+    )
+    renew.locator("textarea[name='exclusions']").fill(
+        "New page builds\nThird-party paid media"
+    )
+    renew.locator("input[name='fee']").fill("129.00")
+    renew.locator("input[name='currency']").fill("EUR")
+    renew.locator("select[name='billing_cadence']").select_option("monthly")
+    renew.locator("input[name='cadence_description']").fill(
+        "Monthly review plus quarterly conversion-path review"
+    )
+    renew.locator("input[name='effective_from']").fill("2026-10-05")
+    renew.locator("textarea[name='renewal_reference']").fill(
+        "Synthetic customer approval for recurring plan v2 and new fee."
+    )
+    page.get_by_role("button", name="Create new plan version").click()
+    page.wait_for_url(recurring_url)
+    acceptance._assert_text(page, "129.00 EUR")
+    acceptance._assert_text(page, "Version: 2")
+    visual._capture(page, "21-recurring-renewed")
+
+    cancel = page.locator("form[action$='/cancel-notice']")
+    cancel.locator("input[name='notice_date']").fill("2026-10-20")
+    cancel.locator("input[name='effective_date']").fill("2026-11-05")
+    cancel.locator("textarea[name='reference']").fill("Synthetic cancellation notice.")
+    page.get_by_role("button", name="Record cancellation notice").click()
+    page.wait_for_url(recurring_url)
+    acceptance._assert_text(page, "Cancellation Pending")
+
+    page.locator("input[name='effective_date']").fill("2026-11-05")
+    page.locator("textarea[name='exit_handoff_reference']").fill(
+        "Synthetic recurring exit and ownership/access handoff evidence."
+    )
+    page.get_by_role("button", name="Complete cancellation").click()
+    page.wait_for_url(recurring_url)
+    acceptance._assert_text(page, "Recurring service is cancelled")
+    visual._capture(page, "22-recurring-cancelled")
+
+    page.goto(page.url.split("/projects/", 1)[0] + "/recurring-services", wait_until="networkidle")
+    acceptance._assert_text(page, "Recurring revenue")
+    acceptance._assert_text(page, "Cancelled")
+    visual._capture(page, "23-recurring-management")
+
+
+hardened._delivery_closure = _delivery_closure_with_recurring
+
+
+if __name__ == "__main__":
+    hardened._preserve_playwright_browser_cache()
+    acceptance.main()


### PR DESCRIPTION
Completes #288, the recurring-service child workstream of #284.

Implemented:
- tenant-isolated recurring service records keyed by project/customer;
- versioned bounded scope, deliverables, exclusions, response/escalation expectations and pricing;
- monthly/quarterly/annual billing cadence plus next-billing and renewal metadata;
- offer -> acceptance -> active recurring service lifecycle;
- recurring deliverable evidence;
- pause/resume;
- failed-payment blocking and paid-state recovery;
- versioned renewal / scope-price change with approval reference;
- cancellation notice -> effective cancellation -> exit/handoff evidence;
- management-facing Recurring revenue view and shared navigation entry;
- explicit handoff to the existing Change Request workflow for out-of-scope/overage work;
- domain/store/web regression coverage;
- expanded Windows Playwright first-customer path covering sprint closure into recurring service, failed payment, renewal, cancellation and management view.

CI run 3172 passed Linux verify and Windows portability/Playwright acceptance. Synthetic/internal test data only. Real outreach remains blocked by parent #284 pending final parent-gate review and Rafael approval.