### PR TITLE
#289 full business lifecycle Playwright acceptance

### DIFF
--- a/VERIDRA_OPERATOR_E2E_ACCEPTANCE.bat
+++ b/VERIDRA_OPERATOR_E2E_ACCEPTANCE.bat
@@ -5,6 +5,6 @@ if not exist ".venv\Scripts\python.exe" (
   call "%~dp0VERIDRA_SETUP.bat"
   if errorlevel 1 exit /b %ERRORLEVEL%
 )
-echo [Veridra] Running true Playwright first-customer + recurring operator acceptance...
-".venv\Scripts\python.exe" -u "%~dp0tools\operator_recurring_visual_acceptance_entry.py"
+echo [Veridra] Running full business lifecycle Playwright acceptance...
+".venv\Scripts\python.exe" -u "%~dp0tools\full_business_lifecycle_acceptance_entry.py"
 exit /b %ERRORLEVEL%

--- a/src/veridra/task_store.py
+++ b/src/veridra/task_store.py
@@ -18,6 +18,7 @@ class TaskStatus(StrEnum):
     open = "open"
     planned = "planned"
     in_progress = "in_progress"
+    blocked = "blocked"
     fixed = "fixed"
     ignored = "ignored"
     accepted_risk = "accepted_risk"

--- a/tests/test_agency_task_management_web.py
+++ b/tests/test_agency_task_management_web.py
@@ -88,6 +88,7 @@ def test_task_list_is_tenant_scoped_escaped_and_permissioned(tmp_path: Path) -> 
     assert "Fix &lt;title&gt; metadata" in owner.text
     assert f"/agency/projects/{project_id}/tasks/{task_id}" in owner.text
     assert "verification required" in owner.text
+    assert "Blocked" in owner.text
     assert "does not mean independently verified" in owner.text
 
 
@@ -118,6 +119,7 @@ def test_task_detail_keeps_source_identity_server_side(tmp_path: Path) -> None:
     assert "name='finding_id'" not in response.text
     assert "name='source_assessment_id'" not in response.text
     assert "name='status'" in response.text
+    assert "value='blocked'" in response.text
     assert "name='owner_label'" in response.text
     assert "name='due_date'" in response.text
     assert "name='notes'" in response.text
@@ -155,6 +157,45 @@ def test_task_update_changes_only_work_fields(tmp_path: Path) -> None:
     assert updated.owner_label == "Rafael"
     assert updated.due_date == "2026-08-25"
     assert updated.notes == "Work started."
+
+
+def test_task_can_be_blocked_and_resumed(tmp_path: Path) -> None:
+    client, root, project_id, task_id = _client(tmp_path)
+    store = TenantTaskStore(root)
+
+    blocked = client.post(
+        f"/agency/projects/{project_id}/tasks/{task_id}",
+        headers={"x-test-role": "owner"},
+        data={
+            "status": "blocked",
+            "owner_label": "Rafael",
+            "due_date": "2026-08-25",
+            "notes": "Waiting for external access.",
+        },
+        follow_redirects=False,
+    )
+    assert blocked.status_code == 303
+    blocked_entries = store.list(OWNER, project_id=project_id)
+    assert len(blocked_entries) == 1
+    blocked_id, blocked_task = blocked_entries[0]
+    assert blocked_task.status is TaskStatus.blocked
+    assert blocked_task.notes == "Waiting for external access."
+
+    resumed = client.post(
+        f"/agency/projects/{project_id}/tasks/{blocked_id}",
+        headers={"x-test-role": "owner"},
+        data={
+            "status": "in_progress",
+            "owner_label": "Rafael",
+            "due_date": "2026-08-25",
+            "notes": "Access received; work resumed.",
+        },
+        follow_redirects=False,
+    )
+    assert resumed.status_code == 303
+    resumed_entries = store.list(OWNER, project_id=project_id)
+    assert len(resumed_entries) == 1
+    assert resumed_entries[0][1].status is TaskStatus.in_progress
 
 
 def test_invalid_task_update_does_not_mutate(tmp_path: Path) -> None:

--- a/tools/full_business_lifecycle_acceptance_entry.py
+++ b/tools/full_business_lifecycle_acceptance_entry.py
@@ -172,6 +172,7 @@ def _remediation_with_blocked_branch(page: Page, project_url: str) -> None:
 
 # Importing the recurring entry installs the delivery->recurring lifecycle monkeypatch.
 # Replace only the earlier phases so one supported Windows run now spans reply through exit.
+acceptance._run_launcher = hardened._run_launcher
 acceptance._create_and_qualify_prospect = _sales_cycle_create_and_qualify
 acceptance._complete_onboarding = _complete_onboarding_full_cycle
 acceptance._remediation = _remediation_with_blocked_branch

--- a/tools/full_business_lifecycle_acceptance_entry.py
+++ b/tools/full_business_lifecycle_acceptance_entry.py
@@ -1,6 +1,8 @@
 # ruff: noqa: E501,I001,F401
 from __future__ import annotations
 
+from pathlib import Path
+
 import operator_e2e_acceptance as acceptance
 import operator_e2e_acceptance_entry as hardened
 import operator_recurring_visual_acceptance_entry as recurring
@@ -170,12 +172,40 @@ def _remediation_with_blocked_branch(page: Page, project_url: str) -> None:
     visual._capture(page, "12b-remediation-resumed")
 
 
-# Importing the recurring entry installs the delivery->recurring lifecycle monkeypatch.
-# Replace only the earlier phases so one supported Windows run now spans reply through exit.
+def _report_with_full_lifecycle(page: Page, project_url: str, evidence: Path) -> None:
+    """Run report delivery and prove delivery closure through recurring-service exit."""
+    visual._report(page, project_url, evidence)
+
+    required_visuals = (
+        "17-delivery-closed-recurring-accepted",
+        "18-recurring-draft",
+        "19-recurring-active",
+        "20-recurring-payment-blocked",
+        "21-recurring-renewed",
+        "22-recurring-cancelled",
+        "23-recurring-management",
+    )
+    missing = [
+        name
+        for name in required_visuals
+        if not (visual.VISUAL_ROOT / f"{name}.png").is_file()
+    ]
+    if missing:
+        raise AssertionError(
+            "Full lifecycle acceptance did not create required delivery/recurring evidence: "
+            + ", ".join(missing)
+        )
+
+
+# Importing the recurring entry replaces hardened delivery closure with the
+# delivery->recurring implementation.  Point the visual report wrapper at the
+# hardened report so report delivery necessarily invokes that closure path.
+visual._ORIGINAL_REPORT = hardened._report
 acceptance._run_launcher = hardened._run_launcher
 acceptance._create_and_qualify_prospect = _sales_cycle_create_and_qualify
 acceptance._complete_onboarding = _complete_onboarding_full_cycle
 acceptance._remediation = _remediation_with_blocked_branch
+acceptance._report = _report_with_full_lifecycle
 
 
 if __name__ == "__main__":

--- a/tools/full_business_lifecycle_acceptance_entry.py
+++ b/tools/full_business_lifecycle_acceptance_entry.py
@@ -1,0 +1,182 @@
+# ruff: noqa: E501
+from __future__ import annotations
+
+import operator_e2e_acceptance as acceptance
+import operator_e2e_acceptance_entry as hardened
+import operator_recurring_visual_acceptance_entry as recurring
+import operator_visual_acceptance_entry as visual
+import sales_contract_acceptance as sales
+from playwright.sync_api import Page
+
+
+_VISUAL_CREATE_AND_QUALIFY = acceptance._create_and_qualify_prospect
+_ORIGINAL_ONBOARDING = hardened._ORIGINAL_COMPLETE_ONBOARDING
+_VISUAL_REMEDIATION = acceptance._remediation
+
+
+def _sales_cycle_create_and_qualify(page: Page, base_url: str) -> str:
+    """Run #285 reply/discovery/proposal branches before continuing the same customer state."""
+    prospect_url = _VISUAL_CREATE_AND_QUALIFY(page, base_url)
+
+    sales._set_reply(page, prospect_url, "price_request")
+    if "before quoting" not in sales._next_action(page):
+        raise AssertionError("Price request did not produce the bounded pre-quote next action.")
+    visual._capture(page, "05a-price-request")
+
+    sales._set_reply(page, prospect_url, "call_request")
+    if "discovery call" not in sales._next_action(page):
+        raise AssertionError("Call request did not produce a discovery-call next action.")
+    visual._capture(page, "05b-call-request")
+
+    sales._set_reply(page, prospect_url, "different_scope")
+    if "assess fit" not in sales._next_action(page):
+        raise AssertionError("Different-scope request did not produce a fit assessment.")
+    visual._capture(page, "05c-different-scope-request")
+
+    sales._set_reply(page, prospect_url, "positive")
+    visual._capture(page, "05d-positive-reply")
+    sales._discovery(page, prospect_url)
+    acceptance._assert_text(page, "Discovery")
+    visual._capture(page, "05e-discovery-complete")
+
+    version1 = sales._create_proposal(
+        page,
+        prospect_url,
+        title="Website Improvement Sprint",
+        price="650.00",
+    )
+    sales._proposal_status(page, prospect_url, version1, "sent")
+    sales._proposal_status(
+        page,
+        prospect_url,
+        version1,
+        "accepted",
+        "Synthetic customer accepted proposal v1 externally.",
+    )
+    acceptance._assert_text(page, "Proposal accepted")
+    acceptance._assert_text(page, "agreement and payment evidence before work starts")
+    visual._capture(page, "05f-proposal-accepted")
+
+    page.goto(
+        f"{prospect_url}/deal/proposals/{version1}/artifact",
+        wait_until="networkidle",
+    )
+    acceptance._assert_text(page, "Webify Digital Solutions")
+    acceptance._assert_text(page, "EUR 650.00")
+    acceptance._assert_text(page, "not an accounting invoice")
+    visual._capture(page, "05g-proposal-artifact")
+
+    version2 = sales._create_proposal(
+        page,
+        prospect_url,
+        title="Alternative Scope",
+        price="500.00",
+        recurring=False,
+    )
+    sales._proposal_status(page, prospect_url, version2, "sent")
+    sales._proposal_status(page, prospect_url, version2, "declined")
+    visual._capture(page, "05h-proposal-declined")
+
+    version3 = sales._create_proposal(
+        page,
+        prospect_url,
+        title="Scope Change Revision",
+        price="800.00",
+    )
+    sales._scope_change(page, prospect_url, version3)
+    visual._capture(page, "05i-prebooking-scope-change")
+
+    page.goto(f"{base_url}/agency/deals", wait_until="networkidle")
+    acceptance._assert_text(page, "Sales / proposals")
+    acceptance._assert_text(page, acceptance.BUSINESS)
+    visual._capture(page, "05j-sales-workbench")
+    return prospect_url
+
+
+def _complete_onboarding_full_cycle(page: Page, customer_url: str) -> None:
+    """Prove accepted-but-unpaid and paid-but-access-delayed gates in the same customer."""
+    page.goto(customer_url, wait_until="networkidle")
+    acceptance._assert_text(page, "Work blocked")
+
+    page.get_by_label("Terms / agreement reference").fill("WEBIFY-MSA-E2E")
+    page.get_by_label("Terms version").fill("2026-09")
+    page.get_by_label("Accepted at").fill("2026-09-04T10:00")
+    page.get_by_label("External signature reference").fill("SIGN-E2E-001")
+    page.get_by_label("Acceptance evidence").fill(
+        "Synthetic accepted-terms evidence for #289 full-cycle acceptance."
+    )
+    page.get_by_label("Billing status").select_option("issued")
+    page.get_by_label("External invoice reference").fill(acceptance.INVOICE)
+    page.get_by_label("Invoice amount").fill("650.00")
+    page.get_by_label("Currency").fill("EUR")
+    page.get_by_label("Issued on").fill("2026-09-04")
+    page.get_by_label("Due on").fill("2026-09-18")
+    page.get_by_label("Deposit / upfront payment required before work").check()
+    page.get_by_label("Required upfront amount").fill("325.00")
+    page.get_by_role("button", name="Save customer").click()
+    page.wait_for_url(customer_url)
+    acceptance._assert_text(page, "Work blocked")
+    acceptance._assert_text(page, "Waiting for required payment evidence")
+    if page.get_by_role("button", name="Create and link project").count() != 0:
+        raise AssertionError("Project creation was exposed for accepted-but-unpaid customer.")
+    visual._capture(page, "07a-accepted-unpaid-blocked")
+
+    page.get_by_label("Billing status").select_option("partially_paid")
+    page.get_by_label("Amount paid").fill("325.00")
+    page.get_by_label("Payment evidence reference").fill("PAY-E2E-DEPOSIT-001")
+    page.get_by_label("Payment method reference").fill("bank transfer")
+    page.get_by_label("Provider transaction reference").fill("BANK-E2E-001")
+    page.get_by_role("button", name="Save customer").click()
+    page.wait_for_url(customer_url)
+    acceptance._assert_text(page, "Work may start")
+    page.get_by_role("button", name="Create and link project").wait_for(state="visible")
+
+    access = page.get_by_label("Access/domain/hosting requirements confirmed")
+    if access.is_checked():
+        raise AssertionError("Access readiness unexpectedly completed before customer access handoff.")
+    acceptance._assert_text(page, "Onboarding")
+    visual._capture(page, "07b-paid-access-delayed")
+
+    _ORIGINAL_ONBOARDING(page, customer_url)
+    acceptance._assert_text(page, "Onboarding: 5/5")
+    acceptance._assert_text(page, "Status: Active")
+    visual._capture(page, "08-customer-onboarded")
+
+
+def _remediation_with_blocked_branch(page: Page, project_url: str) -> None:
+    """Exercise remediation blocked/unavailable state before resuming delivery."""
+    _VISUAL_REMEDIATION(page, project_url)
+    page.goto(f"{project_url}/tasks", wait_until="networkidle")
+    page.get_by_role("link", name="Open task").first.click()
+    page.wait_for_load_state("networkidle")
+    status = page.get_by_label("Status")
+    status.select_option("blocked")
+    page.get_by_label("Notes").fill(
+        "Synthetic dependency unavailable; remediation temporarily blocked."
+    )
+    page.get_by_role("button", name="Save task").click()
+    page.wait_for_url("**/tasks")
+    acceptance._assert_text(page, "blocked")
+    visual._capture(page, "12a-remediation-blocked")
+
+    page.get_by_role("link", name="Open task").first.click()
+    page.wait_for_load_state("networkidle")
+    page.get_by_label("Status").select_option("in_progress")
+    page.get_by_label("Notes").fill(
+        "Synthetic dependency restored; remediation resumed for acceptance."
+    )
+    page.get_by_role("button", name="Save task").click()
+    page.wait_for_url("**/tasks")
+    visual._capture(page, "12b-remediation-resumed")
+
+
+# Importing the recurring entry installs the delivery->recurring lifecycle monkeypatch.
+# Replace only the earlier phases so one supported Windows run now spans reply through exit.
+acceptance._create_and_qualify_prospect = _sales_cycle_create_and_qualify
+acceptance._complete_onboarding = _complete_onboarding_full_cycle
+acceptance._remediation = _remediation_with_blocked_branch
+
+
+if __name__ == "__main__":
+    hardened._preserve_playwright_browser_cache()
+    acceptance.main()

--- a/tools/full_business_lifecycle_acceptance_entry.py
+++ b/tools/full_business_lifecycle_acceptance_entry.py
@@ -1,4 +1,4 @@
-# ruff: noqa: E501
+# ruff: noqa: E501,I001,F401
 from __future__ import annotations
 
 import operator_e2e_acceptance as acceptance

--- a/tools/operator_e2e_acceptance_entry.py
+++ b/tools/operator_e2e_acceptance_entry.py
@@ -297,12 +297,12 @@ def _delivery_closure(page: Page, project_url: str) -> None:
     )
     page.get_by_role("button", name="Record change request").click()
     _assert_change_request_page(page)
-    change_status_form = page.locator("form[action$='/status']")
+    change_status_form = page.locator("form[action$='/status']").first
     change_status_form.locator("select[name='status']").select_option("approved")
     change_status_form.locator("input[name='decision_reference']").fill(
         "Synthetic customer approval for out-of-scope change and price impact."
     )
-    page.get_by_role("button", name="Update change request").click()
+    change_status_form.get_by_role("button", name="Update change request").click()
     _assert_change_request_page(page)
     acceptance._assert_text(page, "approved")
 
@@ -418,18 +418,18 @@ def _preserve_playwright_browser_cache() -> None:
         return
     browser_cache = Path(localapp) / "ms-playwright"
     if browser_cache.exists():
-        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browser_cache.resolve())
+        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = str(browser_cache)
         print(f"[E2E] Reusing Playwright browser cache: {browser_cache}", flush=True)
 
 
+_ORIGINAL_CREATE_AND_QUALIFY = acceptance._create_and_qualify_prospect
 _ORIGINAL_COMPLETE_ONBOARDING = acceptance._complete_onboarding
 _ORIGINAL_MANUAL_ASSESSMENT = acceptance._manual_assessment
 _ORIGINAL_WAIT_AUTONOMOUS_MONITORING = acceptance._wait_autonomous_monitoring
-acceptance._run_launcher = _run_launcher
+
 acceptance._create_and_qualify_prospect = _create_and_qualify_prospect
 acceptance._complete_onboarding = _complete_onboarding_with_booking_gate
 acceptance._manual_assessment = _manual_assessment
-acceptance._report = _report
 acceptance._wait_autonomous_monitoring = _wait_autonomous_monitoring
 
 

--- a/tools/operator_recurring_visual_acceptance_entry.py
+++ b/tools/operator_recurring_visual_acceptance_entry.py
@@ -70,12 +70,24 @@ def _delivery_closure_with_recurring(page: Page, project_url: str) -> None:
     )
     page.get_by_role("button", name="Record change request").click()
     hardened._assert_change_request_page(page)
-    change_form = page.locator("form[action$='/status']")
+
+    change_forms = page.locator("form[action$='/status']")
+    requested_forms = []
+    for index in range(change_forms.count()):
+        candidate = change_forms.nth(index)
+        if candidate.locator("select[name='status']").input_value() == "requested":
+            requested_forms.append(candidate)
+    if len(requested_forms) != 1:
+        raise AssertionError(
+            "Expected exactly one requested change awaiting approval, found "
+            f"{len(requested_forms)}."
+        )
+    change_form = requested_forms[0]
     change_form.locator("select[name='status']").select_option("approved")
     change_form.locator("input[name='decision_reference']").fill(
         "Synthetic customer approval for out-of-scope work and price impact."
     )
-    page.get_by_role("button", name="Update change request").click()
+    change_form.get_by_role("button", name="Update change request").click()
     hardened._assert_change_request_page(page)
     acceptance._assert_text(page, "approved")
 


### PR DESCRIPTION
Implements the final child acceptance gate of #284.

This PR unifies the previously separate sales-to-contract and delivery/recurring acceptance paths into one supported Windows Playwright lifecycle using the same synthetic prospect/customer/project state from reply through recurring exit.

Added coverage in the unified run:
- price-only reply;
- call request;
- different-scope request;
- positive reply;
- discovery/requirements;
- versioned proposal sent/accepted plus visible proposal artifact;
- declined alternate proposal;
- pre-booking scope change;
- accepted-but-unpaid work-start block;
- payment evidence opening the commercial gate;
- paid-but-access-delayed onboarding state;
- linked project, assessment, AI exchange, remediation;
- remediation blocked/unavailable then resumed;
- report delivery;
- revision/unresponsive/change-request/customer acceptance/handoff/closure;
- recurring plan, deliverable, pause/resume, failed payment/recovery, renewal, cancellation/exit;
- existing persistence and backup/restore acceptance.

Synthetic/internal test data only. Real outreach remains 0 and blocked by parent #284 pending final approval.